### PR TITLE
Polish music skills page and SEO

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,72 +3,114 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Suede Creator Passport Skills | Codex and Claude Skills for Rights and Releases</title>
+    <title>Suede Creator Skills | Music Rights Passport for Agents</title>
     <meta
       name="description"
-      content="Install Suede Creator Passport Skills for Codex and Claude. Audit music releases, prepare rights passports, stamp Suede locations, and create a careful creator participation trail."
+      content="Free Codex and Claude skills that audit music releases, package creator rights, document provenance, splits, licensing readiness, and Suede intake workflows."
     >
     <meta
       name="keywords"
-      content="Suede AI, Suede Labs, Codex skills, Claude skills, SKILL.md, music release metadata linter, rights passport, creator ownership, programmable IP, provenance, royalty routing, licensing, agent commerce"
+      content="music skills, Codex skills, Claude skills, SKILL.md, music release metadata linter, Suede Rights Passport, creator rights, music metadata, release readiness, provenance, royalty splits, licensing readiness, programmable IP, agent commerce, Suede AI"
     >
     <meta name="author" content="Jason Colapietro">
     <meta name="publisher" content="Suede Labs AI">
     <meta name="creator" content="Jason Colapietro">
+    <meta name="application-name" content="Suede Creator Skills">
+    <meta name="theme-color" content="#35100d">
     <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/">
     <link rel="icon" href="./assets/suede-skill-icon.png" type="image/png">
+    <link rel="apple-touch-icon" href="./assets/suede-skill-icon.png">
     <link rel="preload" as="image" href="./assets/passport-hero.png">
+    <link rel="image_src" href="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Suede Creator Passport Skills">
-    <meta property="og:description" content="Codex and Claude-ready skills for release linting, rights passporting, Suede stamps, and careful creator workflows.">
+    <meta property="og:title" content="Suede Creator Skills | Music Rights Passport for Agents">
+    <meta property="og:description" content="Install free Codex and Claude skills for music release linting, creator rights passporting, provenance, royalty splits, and Suede intake prep.">
     <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/">
-    <meta property="og:site_name" content="Suede Creator Passport Skills">
+    <meta property="og:site_name" content="Suede Creator Skills">
     <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
+    <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
-    <meta property="og:image:alt" content="Suede Creator Passport Skills — Codex and Claude skills for music rights, release metadata linting, and programmable IP.">
+    <meta property="og:image:alt" content="Suede Creator Skills - Codex and Claude skills for music rights, release metadata linting, and programmable IP.">
     <meta property="og:locale" content="en_US">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@AISUEDE">
     <meta name="twitter:creator" content="@JasonColapietro">
-    <meta name="twitter:title" content="Suede Creator Passport Skills">
-    <meta name="twitter:description" content="Install the Suede Rights Passport and Release Metadata Linter for Codex and Claude.">
+    <meta name="twitter:title" content="Suede Creator Skills">
+    <meta name="twitter:description" content="Free Codex and Claude music skills for release linting, rights passporting, provenance, splits, and Suede intake prep.">
     <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
-    <meta name="twitter:image:alt" content="Suede Creator Passport Skills — Codex and Claude skills for music rights, release metadata linting, and programmable IP.">
+    <meta name="twitter:image:alt" content="Suede Creator Skills - Codex and Claude skills for music rights, release metadata linting, and programmable IP.">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@graph": [
           {
+            "@type": "Organization",
+            "@id": "https://suedeai.ai/#org",
+            "name": "Suede Labs AI",
+            "url": "https://suedeai.ai",
+            "logo": "https://jasoncolapietro.github.io/suede-creator-skills/assets/suede-ai-logo-transparent.png",
+            "sameAs": [
+              "https://twitter.com/aisuede",
+              "https://github.com/Suede-AI",
+              "https://discord.gg/suedeai"
+            ]
+          },
+          {
             "@type": "WebSite",
             "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website",
             "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
-            "name": "Suede Creator Passport Skills",
-            "description": "Install Suede Creator Passport Skills for Codex and Claude. Audit music releases, prepare rights passports, stamp Suede locations, and create a careful creator participation trail.",
+            "name": "Suede Creator Skills",
+            "description": "Free Codex and Claude skills that audit music releases, package creator rights, document provenance, splits, licensing readiness, and Suede intake workflows.",
             "publisher": {
-              "@type": "Organization",
-              "@id": "https://suedeai.ai/#org",
-              "name": "Suede Labs AI",
-              "url": "https://suedeai.ai",
-              "sameAs": [
-                "https://twitter.com/aisuede",
-                "https://github.com/Suede-AI",
-                "https://discord.gg/suedeai"
-              ]
+              "@id": "https://suedeai.ai/#org"
+            },
+            "inLanguage": "en-US"
+          },
+          {
+            "@type": "WebPage",
+            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#webpage",
+            "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+            "name": "Suede Creator Skills | Music Rights Passport for Agents",
+            "description": "Free Codex and Claude skills that audit music releases, package creator rights, document provenance, splits, licensing readiness, and Suede intake workflows.",
+            "isPartOf": {
+              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website"
+            },
+            "primaryImageOfPage": {
+              "@type": "ImageObject",
+              "url": "https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png",
+              "width": 1200,
+              "height": 630
+            },
+            "about": [
+              "music release metadata",
+              "creator rights passport",
+              "programmable IP",
+              "provenance",
+              "royalty splits",
+              "agent commerce"
+            ],
+            "breadcrumb": {
+              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#breadcrumb"
+            },
+            "mainEntity": {
+              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#faq"
             },
             "inLanguage": "en-US"
           },
           {
             "@type": "SoftwareSourceCode",
             "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#skills",
-            "name": "Suede Creator Passport Skills",
+            "name": "Suede Creator Skills",
             "description": "Public Codex and Claude skills for music release metadata linting, rights passport transfer packages, provenance, royalty routing, licensing readiness, and agent commerce.",
             "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
             "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
             "programmingLanguage": "Python",
             "applicationCategory": "DeveloperTool",
             "license": "https://github.com/JasonColapietro/suede-creator-skills/blob/main/LICENSE",
+            "isAccessibleForFree": true,
+            "softwareRequirements": ["Codex", "Claude Code", "Python 3"],
             "creator": {
               "@type": "Person",
               "@id": "https://github.com/JasonColapietro",
@@ -80,17 +122,67 @@
               "@id": "https://suedeai.ai/#org"
             },
             "keywords": [
+              "music skills",
               "Codex skills",
               "Claude skills",
               "SKILL.md",
-              "creator ownership",
+              "creator rights",
               "rights passport",
               "music metadata linter",
+              "release readiness",
               "provenance",
-              "royalty routing",
+              "royalty splits",
+              "licensing readiness",
               "agent commerce",
-              "programmable IP",
-              "music licensing"
+              "programmable IP"
+            ]
+          },
+          {
+            "@type": "FAQPage",
+            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#faq",
+            "mainEntity": [
+              {
+                "@type": "Question",
+                "name": "What are Suede Creator Skills?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "Suede Creator Skills are free Codex and Claude skill folders for music and media creators. They audit release metadata, organize rights evidence, and prepare Suede-ready transfer packages without uploading private files."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Which music workflows do the skills support?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "The skills support song, album, catalog, stem pack, artwork, lyrics, credits, split, sample-status, provenance, licensing-readiness, and agent-commerce preparation workflows."
+                }
+              },
+              {
+                "@type": "Question",
+                "name": "Do the skills clear music rights or guarantee distribution?",
+                "acceptedAnswer": {
+                  "@type": "Answer",
+                  "text": "No. The public skills organize evidence and flag missing information. They do not provide legal clearance, write to a registry, distribute music, or promise payouts."
+                }
+              }
+            ]
+          },
+          {
+            "@type": "BreadcrumbList",
+            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#breadcrumb",
+            "itemListElement": [
+              {
+                "@type": "ListItem",
+                "position": 1,
+                "name": "GitHub",
+                "item": "https://github.com/JasonColapietro"
+              },
+              {
+                "@type": "ListItem",
+                "position": 2,
+                "name": "Suede Creator Skills",
+                "item": "https://jasoncolapietro.github.io/suede-creator-skills/"
+              }
             ]
           }
         ]
@@ -143,6 +235,37 @@
         color: inherit;
       }
 
+      a:focus-visible,
+      button:focus-visible,
+      summary:focus-visible {
+        outline: 3px solid var(--cyan);
+        outline-offset: 4px;
+      }
+
+      ::selection {
+        background: oklch(0.78 0.12 78 / 0.32);
+        color: var(--cream);
+      }
+
+      .skip-link {
+        position: fixed;
+        top: 10px;
+        left: 10px;
+        z-index: 40;
+        transform: translateY(-160%);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--cream);
+        color: var(--ink);
+        padding: 10px 12px;
+        font-weight: 900;
+        text-decoration: none;
+      }
+
+      .skip-link:focus {
+        transform: translateY(0);
+      }
+
       .shell {
         width: min(1180px, calc(100% - 32px));
         margin: 0 auto;
@@ -190,12 +313,15 @@
       }
 
       .hero {
-        padding: 30px 0 64px;
+        border-top: 0;
+        padding: clamp(28px, 6vw, 72px) 0 64px;
       }
 
       .hero-grid {
         display: grid;
-        gap: 26px;
+        grid-template-columns: minmax(0, 0.9fr) minmax(360px, 0.64fr);
+        gap: clamp(22px, 4vw, 48px);
+        align-items: center;
       }
 
       .eyebrow {
@@ -220,9 +346,9 @@
 
       h1 {
         margin: 18px 0;
-        max-width: 780px;
+        max-width: 720px;
         color: var(--cream);
-        font-size: clamp(38px, 5vw, 70px);
+        font-size: clamp(40px, 6vw, 76px);
         line-height: 0.98;
         letter-spacing: 0;
       }
@@ -235,6 +361,7 @@
 
       .hero-media {
         position: relative;
+        align-self: stretch;
       }
 
       .hero-media img {
@@ -247,16 +374,61 @@
       }
 
       .hero-copy {
+        min-width: 0;
+      }
+
+      .hero-panel {
+        border: 1px solid oklch(0.96 0.018 62 / 0.18);
+        border-radius: 8px;
+        background:
+          linear-gradient(150deg, oklch(0.74 0.12 205 / 0.13), transparent 42%),
+          repeating-linear-gradient(90deg, oklch(0.96 0.018 62 / 0.045) 0 1px, transparent 1px 18px),
+          oklch(0.13 0.03 28 / 0.9);
+        margin-top: 24px;
+        padding: 18px;
+      }
+
+      .panel-kicker {
+        display: block;
+        color: var(--cyan);
+        font-size: 12px;
+        font-weight: 950;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .panel-list {
         display: grid;
-        grid-template-columns: minmax(0, 1fr) max-content;
-        gap: 24px;
-        align-items: end;
+        gap: 10px;
+        margin: 14px 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .panel-list li {
+        display: grid;
+        grid-template-columns: 18px minmax(0, 1fr);
+        gap: 10px;
+        color: var(--muted);
+      }
+
+      .panel-list li::before {
+        content: "";
+        width: 9px;
+        height: 9px;
+        margin-top: 8px;
+        border: 1px solid var(--gold);
+        border-radius: 999px;
+        background: var(--red);
       }
 
       .actions,
+      .metric-grid,
       .link-grid,
       .install-grid,
       .skill-grid,
+      .use-grid,
+      .faq-grid,
       .stamp-grid {
         display: grid;
         gap: 14px;
@@ -285,6 +457,40 @@
         background: oklch(0.96 0.018 62 / 0.08);
       }
 
+      .button:hover {
+        border-color: oklch(0.78 0.12 78 / 0.62);
+        transform: translateY(-1px);
+      }
+
+      .metric-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-top: 30px;
+      }
+
+      .metric {
+        min-width: 0;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: oklch(0.96 0.018 62 / 0.07);
+        padding: 16px;
+      }
+
+      .metric b {
+        display: block;
+        color: var(--gold);
+        font-size: 24px;
+        line-height: 1;
+      }
+
+      .metric span {
+        display: block;
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 13px;
+        font-weight: 800;
+        text-transform: uppercase;
+      }
+
       section {
         padding: 78px 0;
         border-top: 1px solid var(--line);
@@ -303,6 +509,16 @@
         margin: 0;
         color: var(--muted);
         font-size: 18px;
+      }
+
+      .section-kicker {
+        display: block;
+        margin-bottom: 12px;
+        color: var(--cyan);
+        font-size: 12px;
+        font-weight: 950;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
       }
 
       .skill-grid {
@@ -399,6 +615,33 @@
         background: oklch(0.22 0.065 52 / 0.68);
         padding: 18px;
         color: var(--cream);
+      }
+
+      .use-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        margin-top: 30px;
+      }
+
+      .use-card {
+        min-width: 0;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background:
+          linear-gradient(180deg, oklch(0.96 0.018 62 / 0.08), transparent),
+          oklch(0.15 0.03 28 / 0.92);
+        padding: 20px;
+      }
+
+      .use-card b {
+        display: block;
+        color: var(--cream);
+        font-size: 18px;
+      }
+
+      .use-card span {
+        display: block;
+        margin-top: 9px;
+        color: var(--muted);
       }
 
       .link-grid {
@@ -509,6 +752,31 @@
         color: var(--muted);
       }
 
+      .faq-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        margin-top: 30px;
+      }
+
+      .faq-card {
+        min-width: 0;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: oklch(0.14 0.028 28 / 0.9);
+        padding: 20px;
+      }
+
+      .faq-card h3 {
+        margin: 0 0 10px;
+        color: var(--cream);
+        font-size: 20px;
+        line-height: 1.2;
+      }
+
+      .faq-card p {
+        margin: 0;
+        color: var(--muted);
+      }
+
       footer {
         border-top: 1px solid var(--line);
         padding: 34px 0;
@@ -517,15 +785,15 @@
       }
 
       @media (max-width: 920px) {
+        .hero-grid,
+        .metric-grid,
         .skill-grid,
+        .use-grid,
         .install-grid,
         .link-grid,
+        .faq-grid,
         .flow,
         .stamp-grid {
-          grid-template-columns: 1fr;
-        }
-
-        .hero-copy {
           grid-template-columns: 1fr;
         }
 
@@ -542,44 +810,60 @@
     </style>
   </head>
   <body>
+    <a class="skip-link" href="#main">Skip to content</a>
     <header>
       <div class="shell nav">
-        <div class="brand"><img class="brand-logo" src="./assets/suede-ai-logo-transparent.png" alt="Suede Labs AI logo"><span>Suede Creator Passport</span></div>
+        <div class="brand"><img class="brand-logo" src="./assets/suede-ai-logo-transparent.png" alt="Suede Labs AI logo"><span>Suede Creator Skills</span></div>
         <nav class="nav-links" aria-label="Primary">
           <a href="#skills">Skills</a>
+          <a href="#use-cases">Use cases</a>
           <a href="#stamps">Stamps</a>
           <a href="#install">Install</a>
+          <a href="#faq">FAQ</a>
           <a href="#links">Links</a>
         </nav>
       </div>
     </header>
 
-    <main>
+    <main id="main">
       <section class="hero">
         <div class="shell hero-grid">
-          <div class="hero-media">
-            <img src="./assets/passport-hero.png" alt="A premium Suede Creator Passport with the Suede emblem, Suede signing workflow, website, app, Discord, X, Telegram, GitHub, Codex, Claude, and Suede Holder passport stamps.">
-          </div>
           <div class="hero-copy">
-            <div>
-            <div class="eyebrow">Codex and Claude skills for Suede creators</div>
-            <h1>Stamp every creator journey into a rights-aware passport.</h1>
+            <div class="eyebrow">Free Codex and Claude skills for music creators</div>
+            <h1>Turn music folders into rights-ready creator passports.</h1>
             <p class="lead">
-              Install the Suede Rights Passport and Release Metadata Linter to audit music
-              projects, prepare transfer packages, document Suede locations visited, and build
-              a careful participation trail for future engagement signals.
+              Install the Suede Rights Passport and Music Release Metadata Linter to audit
+              releases, organize credits and splits, document provenance, and prepare a
+              Suede-ready transfer package before licensing, registry review, or agent commerce.
             </p>
-            </div>
             <div class="actions">
               <a class="button" href="https://github.com/jasoncolapietro/suede-creator-skills">View GitHub Repo</a>
               <a class="button secondary" href="#install">Install Skills</a>
             </div>
+            <div class="hero-panel" aria-label="What the skill pack prepares">
+              <span class="panel-kicker">Release evidence, not hype</span>
+              <ul class="panel-list">
+                <li>Music metadata linting for songs, albums, catalogs, stem packs, lyrics, artwork, and release folders.</li>
+                <li>Rights passport packaging for provenance notes, royalty splits, license status, missing-info reports, and Suede intake prep.</li>
+                <li>Careful public language: no legal-clearance claims, no payout promises, no private Suede service calls.</li>
+              </ul>
+            </div>
+            <div class="metric-grid" aria-label="Suede Creator Skills summary">
+              <div class="metric"><b>2</b><span>public skills</span></div>
+              <div class="metric"><b>0</b><span>uploads by default</span></div>
+              <div class="metric"><b>3</b><span>agent targets</span></div>
+              <div class="metric"><b>MIT</b><span>license</span></div>
+            </div>
+          </div>
+          <div class="hero-media">
+            <img src="./assets/passport-hero.png" alt="A premium Suede Creator Passport with the Suede emblem, Suede signing workflow, website, app, Discord, X, Telegram, GitHub, Codex, Claude, and Suede Holder passport stamps.">
           </div>
         </div>
       </section>
 
       <section id="skills">
         <div class="shell">
+          <span class="section-kicker">What installs</span>
           <h2>Two skills, one passport system.</h2>
           <p class="section-lead">
             The linter checks whether a music project can travel. The Rights Passport packages
@@ -617,8 +901,38 @@
         </div>
       </section>
 
+      <section id="use-cases">
+        <div class="shell">
+          <span class="section-kicker">High-intent music workflows</span>
+          <h2>Use it before the work leaves your machine.</h2>
+          <p class="section-lead">
+            Suede Creator Skills are built for the quiet pre-release work that search engines,
+            platforms, agents, and rights teams rarely see but every serious music project needs.
+          </p>
+          <div class="use-grid">
+            <article class="use-card">
+              <b>Before release</b>
+              <span>Check titles, artist names, masters, artwork, lyrics, stems, contributors, sample status, and platform-delivery blockers.</span>
+            </article>
+            <article class="use-card">
+              <b>Before licensing</b>
+              <span>Collect provenance, split details, license notes, missing confirmations, and the evidence needed for a cleaner rights review.</span>
+            </article>
+            <article class="use-card">
+              <b>Before Suede intake</b>
+              <span>Generate a structured transfer package with <code>RIGHTS_PASSPORT.md</code>, <code>suede-intake.json</code>, and optimization notes.</span>
+            </article>
+            <article class="use-card">
+              <b>Before agent commerce</b>
+              <span>Make a creative work understandable to payable agents without exposing secrets, uploading files, or overclaiming clearance.</span>
+            </article>
+          </div>
+        </div>
+      </section>
+
       <section id="stamps">
         <div class="shell">
+          <span class="section-kicker">Participation trail</span>
           <h2>Passport stamps for Suede locations.</h2>
           <p class="section-lead">
             Every creator action can become a stamp: website visit, Discord join, X follow,
@@ -655,6 +969,7 @@
 
       <section id="flow">
         <div class="shell">
+          <span class="section-kicker">How it works</span>
           <h2>Creator flow.</h2>
           <p class="section-lead">Start from a folder. End with a passported, Suede-ready evidence package.</p>
           <div class="flow">
@@ -668,6 +983,7 @@
 
       <section id="install">
         <div class="shell">
+          <span class="section-kicker">Agent install paths</span>
           <h2>Install for Codex and Claude.</h2>
           <p class="section-lead">
             These are standard <code>SKILL.md</code> folders with bundled references, templates, and Python
@@ -696,8 +1012,33 @@ cp -R ../suede-creator-skills/skills/music-release-metadata-linter .claude/skill
         </div>
       </section>
 
+      <section id="faq">
+        <div class="shell">
+          <span class="section-kicker">Search-ready answers</span>
+          <h2>Music skills FAQ.</h2>
+          <p class="section-lead">
+            Short answers for creators, labels, managers, developers, and agents deciding whether the public Suede skill pack fits their workflow.
+          </p>
+          <div class="faq-grid">
+            <article class="faq-card">
+              <h3>What are Suede Creator Skills?</h3>
+              <p>Suede Creator Skills are free Codex and Claude skill folders for music and media creators. They audit release metadata, organize rights evidence, and prepare Suede-ready transfer packages without uploading private files.</p>
+            </article>
+            <article class="faq-card">
+              <h3>Which music workflows do the skills support?</h3>
+              <p>The skills support song, album, catalog, stem pack, artwork, lyrics, credits, split, sample-status, provenance, licensing-readiness, and agent-commerce preparation workflows.</p>
+            </article>
+            <article class="faq-card">
+              <h3>Do the skills clear music rights or guarantee distribution?</h3>
+              <p>No. The public skills organize evidence and flag missing information. They do not provide legal clearance, write to a registry, distribute music, or promise payouts.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
       <section id="links">
         <div class="shell">
+          <span class="section-kicker">Public surfaces</span>
           <h2>Stampable linkset.</h2>
           <p class="section-lead">Each public destination is a passport stamp: visit the site, open the app, join Discord, follow on X, enter Telegram, install the repo, or read the agent install docs.</p>
           <div class="link-grid">

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/</loc>
-    <lastmod>2026-06-11</lastmod>
+    <lastmod>2026-06-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Tighten the GitHub Pages title, description, Open Graph/Twitter metadata, and JSON-LD for music-skill search intent.
- Upgrade the page layout with a stronger hero, visible use-case cards, FAQ content, focus states, and mobile-safe responsive grids.
- Refresh the sitemap lastmod date for the Pages URL.

## Verification
- html/jsonld parser check: one JSON-LD block, one H1, all images have alt text.
- SEO length check: title 55 chars, meta description 157 chars.
- sitemap XML parse passed.
- python3 -m compileall -q skills passed.
- git diff --check clean.
- Playwright via system Chrome: desktop 1440px and mobile 390px rendered with no console errors, no failed requests, all images loaded, no horizontal overflow, 4 use-case cards, and 3 FAQ cards.
- Public link sweep returned 200 or expected redirects for repo, Suede surfaces, X, Discord, Telegram, OpenAI Skills, and Claude Skills docs.

## Repo metadata
- Updated GitHub description and topics for music-skills, music-release, music-rights, music-metadata, rights-passport, release-readiness, royalty-splits, and related discovery terms.