### PR TITLE
Code-review parity + catalog sync to 21

### DIFF
--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -155,7 +155,7 @@
     <main class="shell">
       <div class="eyebrow">Skill catalog</div>
       <h1>Public Suede skills for design, copy, visibility, code review, Suede SEO, artist campaigns, rights, and QA.</h1>
-      <p class="lead">The public repo ships 16 installable <code>SKILL.md</code> folders. This catalog is the GitHub Pages surface generated from the public repo, not a separate marketing site. The links below help ambassadors, builders, creators, agents, agencies, and developers install or inspect the workflow before using it.</p>
+      <p class="lead">The public repo ships 21 installable <code>SKILL.md</code> folders. This catalog is the GitHub Pages surface generated from the public repo, not a separate marketing site. The links below help ambassadors, builders, creators, agents, agencies, and developers install or inspect the workflow before using it.</p>
 
       <div class="grid">
         <article class="card">
@@ -204,12 +204,17 @@
       </div>
 
       <section class="panel">
-                <h2>All 16 skill folders</h2>
+                <h2>All 21 skill folders</h2>
         <div class="links">
           <a class="link-row" href="suede-workflow-skills.html"><b>suede-workflow-skills</b><span>Umbrella workflow for the full public Suede stack.</span></a>
           <a class="link-row" href="johnny-suede-write.html"><b>johnny-suede-write</b><span>Full writing mode for Suede or a supplied company: copy, company voice, Apple and iOS copy, SEO/AEO/AI EO, CTAs, launch copy, claim checks, and anti-slop line editing.</span></a>
           <a class="link-row" href="johnny-suede-design.html"><b>johnny-suede-design</b><span>Full design mode for Suede or a supplied company: Suedify, Apple and iOS surfaces, App Store screenshots, UI polish, design-system QA, visual QA, visibility grading, implementation handoff, company voice, and copy.</span></a>
+          <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-design"><b>suede-design</b><span>Design laws, component rules, dark-mode tokens, fluid type, motion sequencing, and visual QA for any Suede surface.</span></a>
+          <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-copy"><b>suede-copy</b><span>Conversion copy with headline formulas, persuasion frameworks, A/B variants, an anti-slop gate, and a copy score.</span></a>
           <a class="link-row" href="suede-code.html"><b>suede-code</b><span>Unified code review and A-F grading for correctness, security, data/state, deploy readiness, and ship risk.</span></a>
+          <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-code-review"><b>suede-code-review</b><span>Deep diff review with TypeScript, React, Next.js, Swift/iOS, OWASP, and database checklists plus fix briefs and a grade.</span></a>
+          <a class="link-row" href="suede-code-grader.html"><b>suede-code-grader</b><span>A blunt A-F ship verdict across seven evidence-backed lanes, with instant-F triggers and surface grade caps.</span></a>
+          <a class="link-row" href="suede-agent-teams.html"><b>suede-agent-teams</b><span>Coordinate complex changes across agent lanes with collision detection, quality gates, and a signed handoff.</span></a>
           <a class="link-row" href="suede-ship-gate.html"><b>suede-ship-gate</b><span>Any-repo CI gate that blocks a merge when required checks fail — prompted only, plugs into any CI or workflow system.</span></a>
           <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-seo-audit"><b>suede-seo-audit</b><span>Search intent, answer intent, metadata, schema, links, and trust checks.</span></a>
           <a class="link-row" href="suede-visibility-grader.html"><b>suede-visibility-grader</b><span>A-F grading for findability, first-screen clarity, CTA pull, proof, AI readability, rendered design signal, evidence, grade caps, and Google and Gemini result surfaces.</span></a>

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Suede Agent Teams | Coordinated Agent Lanes with Quality Gates</title>
+    <meta name="description" content="Install Suede Agent Teams to wire complex changes into coordinated agent lanes with WIP collision detection, RFC mode, feature-flag strategy, rollback trees, scenario templates, and a handoff that won't close without evidence.">
+    <meta name="author" content="Jason Colapietro">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
+    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html">
+    <link rel="icon" href="../assets/suede-skill-icon.png" type="image/png">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Suede Agent Teams">
+    <meta property="og:description" content="Coordinate complex changes across agent lanes with quality gates, collision detection, rollback trees, and a signed evidence handoff.">
+    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html">
+    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Suede Agent Teams">
+    <meta name="twitter:description" content="Wire complex changes into coordinated agent lanes with quality gates and a handoff that won't close without evidence.">
+    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html#article",
+        "headline": "Suede Agent Teams",
+        "description": "Public Codex skill for coordinating complex changes across agent lanes with quality gates, collision detection, rollback trees, and a signed evidence handoff.",
+        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html",
+        "author": {
+          "@type": "Person",
+          "name": "Jason Colapietro",
+          "url": "https://github.com/JasonColapietro"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Suede Labs AI",
+          "url": "https://suedeai.ai"
+        },
+        "about": ["agent orchestration", "multi-agent", "quality gates", "rollback", "feature flags", "code review", "Codex skills"],
+        "mainEntity": {
+          "@type": "SoftwareSourceCode",
+          "name": "suede-agent-teams",
+          "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-agent-teams",
+          "programmingLanguage": "Markdown",
+          "applicationCategory": "DeveloperTool",
+          "license": "https://github.com/JasonColapietro/suede-creator-skills/blob/main/LICENSE"
+        }
+      }
+    </script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: oklch(0.12 0.028 28);
+        --panel: oklch(0.17 0.035 28 / 0.92);
+        --cream: oklch(0.96 0.018 62);
+        --muted: oklch(0.76 0.035 58);
+        --line: oklch(0.96 0.018 62 / 0.16);
+        --red: oklch(0.50 0.21 28);
+        --gold: oklch(0.78 0.12 78);
+        --cyan: oklch(0.74 0.12 205);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--cream);
+        background:
+          linear-gradient(115deg, oklch(0.22 0.12 28 / 0.7), transparent 38%),
+          linear-gradient(245deg, oklch(0.30 0.09 205 / 0.24), transparent 34%),
+          var(--bg);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      a { color: inherit; }
+      a:focus-visible { outline: 3px solid var(--cyan); outline-offset: 4px; }
+      .shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+      header { border-bottom: 1px solid var(--line); background: oklch(0.12 0.028 28 / 0.9); }
+      nav { display: flex; min-height: 72px; align-items: center; justify-content: space-between; gap: 18px; }
+      .brand { font-weight: 950; }
+      .nav-links { display: flex; flex-wrap: wrap; gap: 16px; color: var(--muted); font-size: 14px; font-weight: 800; }
+      .nav-links a { min-height: 44px; display: inline-flex; align-items: center; }
+      main { padding: 58px 0 80px; }
+      .eyebrow { color: var(--gold); font-size: 13px; font-weight: 950; text-transform: uppercase; }
+      h1 { max-width: 920px; margin: 14px 0 18px; font-size: clamp(42px, 6vw, 76px); line-height: 0.98; }
+      h2 { margin: 0 0 12px; font-size: clamp(30px, 4vw, 48px); line-height: 1; }
+      h3 { margin: 0 0 10px; font-size: 24px; }
+      p, li { color: var(--muted); }
+      .lead { max-width: 880px; font-size: 19px; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; margin-top: 28px; }
+      .card, .panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 24px;
+      }
+      .button {
+        display: inline-flex;
+        min-height: 44px;
+        align-items: center;
+        border: 1px solid oklch(0.78 0.12 78 / 0.42);
+        border-radius: 8px;
+        background: var(--red);
+        padding: 0 14px;
+        font-weight: 900;
+        text-decoration: none;
+      }
+      .button.secondary { background: oklch(0.96 0.018 62 / 0.08); }
+      pre {
+        overflow: auto;
+        border: 1px solid oklch(0.96 0.018 62 / 0.12);
+        border-radius: 8px;
+        background: oklch(0.08 0.02 28);
+        padding: 16px;
+        color: oklch(0.93 0.04 72);
+        font: 13px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        white-space: pre-wrap;
+      }
+      .links { display: grid; gap: 12px; }
+      .link-row {
+        display: grid;
+        grid-template-columns: minmax(210px, 0.4fr) minmax(0, 1fr);
+        gap: 14px;
+        border-top: 1px solid var(--line);
+        padding-top: 12px;
+      }
+      .link-row b { color: var(--cream); }
+      .link-row span { color: var(--muted); overflow-wrap: anywhere; }
+      section { margin-top: 52px; }
+      footer { border-top: 1px solid var(--line); color: var(--muted); padding: 28px 0; }
+      @media (max-width: 820px) {
+        nav, .grid, .link-row { grid-template-columns: 1fr; display: grid; }
+        .nav-links { gap: 10px; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <nav class="shell" aria-label="Primary">
+        <a class="brand" href="../">Suede Creator Skills</a>
+        <div class="nav-links">
+          <a href="../">Home</a>
+          <a href="./">Skill Docs</a>
+          <a href="../plugins.html">Public Installs + MCP</a>
+          <a href="../copy.html">Copy Bank</a>
+          <a href="suede-workflow-skills.html">Workflow</a>
+          <a href="https://github.com/JasonColapietro/suede-creator-skills">GitHub</a>
+        </div>
+      </nav>
+    </header>
+    <main class="shell">
+      <div class="eyebrow">Agent orchestration</div>
+      <h1>Wire complex changes into coordinated lanes with a signed handoff.</h1>
+      <p class="lead">Suede Agent Teams assigns lanes, not conversations. It detects work-in-progress collisions before any builder opens a file, runs an RFC before high-blast-radius changes, gates the work through quality and adversarial review, and closes with a handoff that will not sign off until every required field is present and truthful.</p>
+      <p><a class="button" href="../plugins.html">Install the skill</a> <a class="button secondary" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-agent-teams">View skill folder</a></p>
+
+      <section class="panel">
+        <h2>Public install command</h2>
+        <p>This is the public route. It installs from GitHub as a standard Codex skill folder.</p>
+        <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo JasonColapietro/suede-creator-skills \
+  --path skills/suede-agent-teams</code></pre>
+        <p>Restart Codex after installing the skill.</p>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>The default roster</h2>
+          <p>Start with Scout, Builder, and Handoff Writer. Add a role only when a gate needs it.</p>
+          <ul>
+            <li>Scout maps the repo, current state, dirty files, live routes, and likely blast radius.</li>
+            <li>Planner turns requirements into verifiable tasks with acceptance criteria and dependencies.</li>
+            <li>Builder makes narrow changes inside the existing system, in assigned files only.</li>
+            <li>Design reviewer, code grader, and code reviewer attach when design or code risk is present.</li>
+            <li>Release verifier owns build, deploy, live and API truth, and public-claim accuracy.</li>
+            <li>Handoff writer produces a signed delivery record, held if any required field is missing.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Where it fits</h2>
+          <p>Reach for it when a change is too broad, too risky, or too release-bound for one lane: shared interface changes, auth and payment paths, data migrations, and public launches. For high-risk work it keeps the builder and the reviewer separate so the implementation gets a second, adversarial set of eyes.</p>
+          <p>Use the smallest loop that can finish the work, and escalate deliberately when the task is broad, risky, release-bound, or you ask for max agent teams.</p>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Collision detection and quality gates</h2>
+        <p>Before any parallel lanes open, the orchestrator collects every dirty and untracked file, maps each lane's scope, and flags a collision when two lanes, or a lane and existing work, would touch the same path. No builder opens a file outside its assigned lane map.</p>
+        <div class="links">
+          <div class="link-row"><b>RFC mode</b><span>Shared interfaces, schema, auth, payment, and public API changes require an accepted RFC before a builder opens.</span></div>
+          <div class="link-row"><b>Feature flags</b><span>Risky or non-revertible changes ship behind a flag with a removal date set at creation and a staged ramp.</span></div>
+          <div class="link-row"><b>Rollback tree</b><span>Pre-agreed decisions: roll back immediately on data loss or security exposure; hold and investigate on degraded performance.</span></div>
+          <div class="link-row"><b>Adversarial review</b><span>One lens asks whether it works; another asks how it fails in production, release, abuse, accessibility, and handoff.</span></div>
+          <div class="link-row"><b>Escalation protocol</b><span>Repeated fix cycles, unknown-severity security findings, and cost spikes stop the loop and surface for sign-off.</span></div>
+          <div class="link-row"><b>Status vocabulary</b><span>"Changed locally" is not "verified locally"; "deployed" is not "verified live." States do not skip.</span></div>
+        </div>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Scenario templates</h2>
+          <p>Pre-built rosters for common high-risk deployments. Adjust only the named target.</p>
+          <ul>
+            <li>Auth rewrite: RFC and flag required; builder touches auth files only; release verifier confirms in production.</li>
+            <li>Payment integration: idempotency, webhook signatures, and decline and replay paths tested before ramp.</li>
+            <li>Public launch review: review-only roster across design, visibility, links, secrets, and claim truth.</li>
+            <li>Data migration: rollback script defined and tested in staging before production promotion.</li>
+            <li>Performance audit: rank fixes by impact, implement only the ranked set, confirm no regression.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Handoff that won't fake done</h2>
+          <p>The delivery record is held until every field is present and truthful: exact target, every changed file, every command with output, observable verification, a real status, the single next step, and every caveat.</p>
+          <pre><code>Target:
+Changed:
+Verification:
+Caveats:
+Status:
+Next:</code></pre>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Best prompts</h2>
+        <pre><code>Use $suede-agent-teams to plan lanes for this multi-file change. Run WIP collision detection first and give me the lane map.</code></pre>
+        <pre><code>Use $suede-agent-teams with the auth-rewrite template. Require an RFC and a feature flag before any builder opens.</code></pre>
+        <pre><code>Use $suede-agent-teams to coordinate this public launch review and hold the handoff until every field has evidence.</code></pre>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Safety boundary</h2>
+          <p>No lane may override an escalation threshold by re-scoping the task or declaring a condition resolved without sign-off. Release truth, meaning build, deploy, live and API behavior, and public claims, is owned by the release verifier before any completion claim.</p>
+          <p>The orchestrator organizes the work; it does not invent verification, deploy status, or approved claims.</p>
+        </article>
+        <article class="card">
+          <h2>Cue Suede</h2>
+          <p>Feedback can happen mid-workflow or at the end. Say <code>Cue Suede</code> to ask for choices: change something, preserve what worked so the agent can mimic it later, or keep as-is by saying nothing.</p>
+        </article>
+      </section>
+    </main>
+    <footer>
+      <div class="shell">Suede Agent Teams: coordinated agent lanes with collision detection, RFC mode, rollback trees, scenario templates, and a signed evidence handoff.</div>
+    </footer>
+  </body>
+</html>

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Suede Code Grader | Blunt A-F Ship Verdict on Any Code Change</title>
+    <meta name="description" content="Install Suede Code Grader for a blunt A-F ship verdict: 7 evidence-backed lanes, instant-F triggers, grade caps for auth and payment surfaces, and a required upgrade for every grade below A.">
+    <meta name="author" content="Jason Colapietro">
+    <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
+    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html">
+    <link rel="icon" href="../assets/suede-skill-icon.png" type="image/png">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Suede Code Grader">
+    <meta property="og:description" content="A blunt A-F ship verdict on any code change, with evidence-backed lanes, instant-F triggers, and grade caps for auth and payment surfaces.">
+    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html">
+    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Suede Code Grader">
+    <meta name="twitter:description" content="Get a direct A-F ship/no-ship grade on a diff, PR, file, or release. Evidence, not a lint score.">
+    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "TechArticle",
+        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html#article",
+        "headline": "Suede Code Grader",
+        "description": "Public Codex skill for a blunt A-F ship verdict on any code change, with evidence-backed lanes, instant-F triggers, and grade caps for auth and payment surfaces.",
+        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html",
+        "author": {
+          "@type": "Person",
+          "name": "Jason Colapietro",
+          "url": "https://github.com/JasonColapietro"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Suede Labs AI",
+          "url": "https://suedeai.ai"
+        },
+        "about": ["code review", "ship verdict", "code grading", "security review", "deploy readiness", "Codex skills"],
+        "mainEntity": {
+          "@type": "SoftwareSourceCode",
+          "name": "suede-code-grader",
+          "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-code-grader",
+          "programmingLanguage": "Markdown",
+          "applicationCategory": "DeveloperTool",
+          "license": "https://github.com/JasonColapietro/suede-creator-skills/blob/main/LICENSE"
+        }
+      }
+    </script>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: oklch(0.12 0.028 28);
+        --panel: oklch(0.17 0.035 28 / 0.92);
+        --cream: oklch(0.96 0.018 62);
+        --muted: oklch(0.76 0.035 58);
+        --line: oklch(0.96 0.018 62 / 0.16);
+        --red: oklch(0.50 0.21 28);
+        --gold: oklch(0.78 0.12 78);
+        --cyan: oklch(0.74 0.12 205);
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        color: var(--cream);
+        background:
+          linear-gradient(115deg, oklch(0.22 0.12 28 / 0.7), transparent 38%),
+          linear-gradient(245deg, oklch(0.30 0.09 205 / 0.24), transparent 34%),
+          var(--bg);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      a { color: inherit; }
+      a:focus-visible { outline: 3px solid var(--cyan); outline-offset: 4px; }
+      .shell { width: min(1120px, calc(100% - 32px)); margin: 0 auto; }
+      header { border-bottom: 1px solid var(--line); background: oklch(0.12 0.028 28 / 0.9); }
+      nav { display: flex; min-height: 72px; align-items: center; justify-content: space-between; gap: 18px; }
+      .brand { font-weight: 950; }
+      .nav-links { display: flex; flex-wrap: wrap; gap: 16px; color: var(--muted); font-size: 14px; font-weight: 800; }
+      .nav-links a { min-height: 44px; display: inline-flex; align-items: center; }
+      main { padding: 58px 0 80px; }
+      .eyebrow { color: var(--gold); font-size: 13px; font-weight: 950; text-transform: uppercase; }
+      h1 { max-width: 920px; margin: 14px 0 18px; font-size: clamp(42px, 6vw, 76px); line-height: 0.98; }
+      h2 { margin: 0 0 12px; font-size: clamp(30px, 4vw, 48px); line-height: 1; }
+      h3 { margin: 0 0 10px; font-size: 24px; }
+      p, li { color: var(--muted); }
+      .lead { max-width: 880px; font-size: 19px; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 18px; margin-top: 28px; }
+      .card, .panel {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 24px;
+      }
+      .button {
+        display: inline-flex;
+        min-height: 44px;
+        align-items: center;
+        border: 1px solid oklch(0.78 0.12 78 / 0.42);
+        border-radius: 8px;
+        background: var(--red);
+        padding: 0 14px;
+        font-weight: 900;
+        text-decoration: none;
+      }
+      .button.secondary { background: oklch(0.96 0.018 62 / 0.08); }
+      pre {
+        overflow: auto;
+        border: 1px solid oklch(0.96 0.018 62 / 0.12);
+        border-radius: 8px;
+        background: oklch(0.08 0.02 28);
+        padding: 16px;
+        color: oklch(0.93 0.04 72);
+        font: 13px/1.6 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        white-space: pre-wrap;
+      }
+      .links { display: grid; gap: 12px; }
+      .link-row {
+        display: grid;
+        grid-template-columns: minmax(210px, 0.4fr) minmax(0, 1fr);
+        gap: 14px;
+        border-top: 1px solid var(--line);
+        padding-top: 12px;
+      }
+      .link-row b { color: var(--cream); }
+      .link-row span { color: var(--muted); overflow-wrap: anywhere; }
+      section { margin-top: 52px; }
+      footer { border-top: 1px solid var(--line); color: var(--muted); padding: 28px 0; }
+      @media (max-width: 820px) {
+        nav, .grid, .link-row { grid-template-columns: 1fr; display: grid; }
+        .nav-links { gap: 10px; }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <nav class="shell" aria-label="Primary">
+        <a class="brand" href="../">Suede Creator Skills</a>
+        <div class="nav-links">
+          <a href="../">Home</a>
+          <a href="./">Skill Docs</a>
+          <a href="../plugins.html">Public Installs + MCP</a>
+          <a href="../copy.html">Copy Bank</a>
+          <a href="suede-workflow-skills.html">Workflow</a>
+          <a href="https://github.com/JasonColapietro/suede-creator-skills">GitHub</a>
+        </div>
+      </nav>
+    </header>
+    <main class="shell">
+      <div class="eyebrow">A-F code grading</div>
+      <h1>A blunt verdict on whether code is ready to ship.</h1>
+      <p class="lead">Suede Code Grader gives any diff, PR, file, or release a direct A-F grade across seven evidence-backed lanes. The output is a grade with evidence and a required upgrade, not a lint score and not a pile of style notes. Use it when you need the ship decision, not the full line-by-line review.</p>
+      <p><a class="button" href="../plugins.html">Install the skill</a> <a class="button secondary" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-code-grader">View skill folder</a></p>
+
+      <section class="panel">
+        <h2>Public install command</h2>
+        <p>This is the public route. It installs from GitHub as a standard Codex skill folder.</p>
+        <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo JasonColapietro/suede-creator-skills \
+  --path skills/suede-code-grader</code></pre>
+        <p>Restart Codex after installing the skill.</p>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>The seven lanes</h2>
+          <ul>
+            <li>Correctness: behavior, edge cases, error paths, async, routing, data flow, and regression risk.</li>
+            <li>Security and permissions: auth, secrets, payment, injection, path, SSRF, and data exposure fail closed.</li>
+            <li>Data and state: schemas, migrations, caches, jobs, queues, webhooks, retries, and idempotency stay consistent.</li>
+            <li>Domain truth: public claims, rights, provenance, royalty routing, and product claims match the implementation.</li>
+            <li>UX and release behavior: loading, empty, error, success, mobile, screenshot, and route states hold together.</li>
+            <li>Tests and verification: changed behavior has meaningful tests, builds, runs, readbacks, or named caveats.</li>
+            <li>Deploy readiness: env vars, flags, configs, migrations, rollback notes, and release sequencing are clear.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Where it fits</h2>
+          <p>Run it as the gate between "done" and "shipped." It reads the actual source and the evidence that exercises the change, not the PR description, then returns one overall grade with the single biggest reason and the upgrade that would move it.</p>
+          <p>Pair it with the full code review when you want findings and fix briefs too. The grader answers one question fast: does this ship, and if not, what is the smallest thing that changes the answer.</p>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Instant-F triggers</h2>
+        <p>Any single match is an automatic F. The grade stops there and names the file and line. No other lane can raise it.</p>
+        <div class="links">
+          <div class="link-row"><b>Secrets in source</b><span>A hardcoded API key, token, password, private key, or signing secret committed to a real file.</span></div>
+          <div class="link-row"><b>Injection</b><span>SQL built by string concatenation with user input, a shell command from user input, or unescaped user input rendered where XSS is reachable.</span></div>
+          <div class="link-row"><b>Auth bypass</b><span>A path that skips the auth check, a permission check bypassable by a request param, or a token accepted with no real verification.</span></div>
+          <div class="link-row"><b>Payment and wallet</b><span>A handler that swallows errors silently, a webhook with no signature check, or an amount or recipient taken from untrusted input.</span></div>
+          <div class="link-row"><b>Data destruction</b><span>A destructive migration with no rollback, a bulk delete with no guard, or a cache wipe with no restore path.</span></div>
+          <div class="link-row"><b>Plaintext sensitive data</b><span>A password stored or logged in plaintext, or PII and payment or health data in an unencrypted field or log.</span></div>
+        </div>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Grade caps by surface</h2>
+          <p>Certain surfaces cannot earn an A or B on a passing build alone. The cap is stated in the output when it applies.</p>
+          <ul>
+            <li>Auth changes need the bypass and escalation path tested, not just the happy path, or the grade caps at C.</li>
+            <li>Payment and wallet flows need error paths tested and server-side amount and recipient validation, or they cap at C.</li>
+            <li>Data migrations need a documented, tested rollback; no rollback plan caps at D.</li>
+            <li>Breaking public API changes need verified backward compatibility or a versioned migration path, or they cap at C.</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h2>Output format</h2>
+          <p>It opens with a plain-language summary a non-coder can follow, then the seven lane grades, the overall grade, any cap, the evidence-backed why, and the ranked required upgrades.</p>
+          <pre><code>Correctness: A-F
+Security and permissions: A-F
+Data and state: A-F
+Domain truth: A-F
+UX and release behavior: A-F
+Tests and verification: A-F
+Deploy readiness: A-F
+Overall: A-F</code></pre>
+        </article>
+      </section>
+
+      <section class="panel">
+        <h2>Best prompts</h2>
+        <pre><code>Use $suede-code-grader to give this PR a blunt A-F ship verdict with evidence and the one required upgrade.</code></pre>
+        <pre><code>Use $suede-code-grader on this auth change. Apply the surface grade cap and tell me what evidence would lift it.</code></pre>
+        <pre><code>Use $suede-code-grader on this release build. I want the ship decision, not a full review.</code></pre>
+      </section>
+
+      <section class="grid">
+        <article class="card">
+          <h2>Safety boundary</h2>
+          <p>The grade is a working review, not an audited guarantee. The skill does not invent tests, screenshots, live checks, or deploy status, and it does not raise a grade because the work was hard or because CI passed without exercising the change.</p>
+          <p>It never ships a C, D, or F without naming the upgrade that would move it.</p>
+        </article>
+        <article class="card">
+          <h2>Cue Suede</h2>
+          <p>Feedback can happen mid-workflow or at the end. Say <code>Cue Suede</code> to ask for choices: change something, preserve what worked so the agent can mimic it later, or keep as-is by saying nothing.</p>
+        </article>
+      </section>
+    </main>
+    <footer>
+      <div class="shell">Suede Code Grader: a blunt A-F ship verdict with evidence-backed lanes, instant-F triggers, and grade caps for auth and payment surfaces.</div>
+    </footer>
+  </body>
+</html>

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -1,7 +1,7 @@
 {
   "name": "Suede Skills MCP",
   "version": "0.1.0",
-  "updated": "2026-06-20",
+  "updated": "2026-06-21",
   "homepage": "https://jasoncolapietro.github.io/suede-creator-skills/",
   "repository": "https://github.com/JasonColapietro/suede-creator-skills",
   "summary": "Local MCP access to the Suede skill pack: Johnny Suede design+copy and writing enchiladas, Suedify site mimicry, Suede SEO/AEO/AI EO, visibility grading, one-pass code review+grade, any-repo CI ship-gate, agent-team orchestration, install and launch packaging, MCP QA, public claim checks, artist campaign tools, and creator rights utilities.",
@@ -99,6 +99,36 @@
       "area": "workflow",
       "description": "Review and grade code in one pass — deep findings plus a blunt A-F ship verdict by default, with TypeScript, React, Next.js, OWASP, and database checklists, three depth levels, 10+ instant-F triggers, grade caps for auth and payment surfaces, a deploy-safety gate, and fix briefs. Prompted-only; never auto-fires.",
       "useWhen": "Use when explicitly asked to review, grade, audit, security-check, or ship-gate a diff, PR, file, or release."
+    },
+    {
+      "name": "suede-code-review",
+      "area": "workflow",
+      "description": "Deep-dive any diff with TypeScript, React, Next.js, Swift/iOS, OWASP, and database checklists — run the repo's own gates, honor project rules, trace whole-repo and git history, then return findings, fix briefs, and a signed grade across three depth levels.",
+      "useWhen": "Use when explicitly asked to review, deep-dive, or security-check a diff, PR, file, or release and you want full findings, not just a grade."
+    },
+    {
+      "name": "suede-code-grader",
+      "area": "workflow",
+      "description": "Get a blunt A-F ship verdict on any code change — 7 evidence-backed lanes, 10+ instant-F triggers, grade caps for auth and payment surfaces, and a worked example for every grade level.",
+      "useWhen": "Use when you need a direct ship/no-ship grade with evidence, not a full line-by-line review."
+    },
+    {
+      "name": "suede-copy",
+      "area": "workflow",
+      "description": "Write copy that earns the click — 12 headline formulas, 5 persuasion frameworks, A/B variant generation, a word-substitution list, email and social templates, an anti-slop gate, and a copy score before anything ships.",
+      "useWhen": "Use to write or rewrite headlines, CTAs, landing, email, or social copy with a conversion and anti-slop pass."
+    },
+    {
+      "name": "suede-design",
+      "area": "workflow",
+      "description": "Evolve any Suede interface from generic to intentional — design laws, component-specific rules, dark-mode tokens, fluid typography, animation sequencing, and visual QA for every surface from landing page to app shell.",
+      "useWhen": "Use to polish UI, set up design tokens, fix visual hierarchy, or run a focused design pass on a single surface."
+    },
+    {
+      "name": "suede-agent-teams",
+      "area": "workflow",
+      "description": "Wire complex changes into coordinated agent lanes with quality gates and a signed handoff — WIP collision detection, RFC mode, feature-flag strategy, rollback trees, 5 scenario templates, and a handoff checklist that won't close without evidence.",
+      "useWhen": "Use when a change is big enough to split across multiple agents or lanes and you need collision-safe coordination and a verified handoff."
     },
     {
       "name": "suede-ship-gate",

--- a/skills/suede-code-review/SKILL.md
+++ b/skills/suede-code-review/SKILL.md
@@ -45,6 +45,50 @@ Build a lightweight graph before judging the diff:
 Flag beyond-the-diff risks when related files, defaults, docs, env, or deploy
 requirements no longer agree.
 
+## Run the Repo's Own Gates
+
+Do not hand-review for what a tool already decides. Before manual analysis, run the
+gates the repo already ships and fold the output into findings. Detect what exists
+from `package.json` scripts, config files, and lockfiles — run only those. Never
+introduce a tool the repo does not use, and never fabricate a result you did not run.
+
+- **Type check:** the repo's `typecheck` script, or the type checker directly. An error
+  on a changed line is at least P2; on a changed critical path, P1.
+- **Lint:** the repo's configured linter on changed files only. Report violations the
+  change introduces; ignore pre-existing noise outside the diff.
+- **Tests:** run the suite, or the changed-file subset. A failing test on changed
+  behavior is P1; a test that silently stopped running is P2.
+- **Dependency CVEs:** the repo's dependency auditor — the package manager's audit
+  command, or a vulnerability scanner — when dependencies changed. A known-exploitable
+  CVE reachable in a production path is P0/P1.
+- **Secret scan:** a real entropy-based secret scanner over the diff when the repo
+  provides one — it catches keys the Commit Dirt Score patterns miss. A verified live
+  secret is P0.
+- **Build:** for release reviews, the production build must pass. A broken build is P0.
+
+Cite the command, its exit status, and the file:line it implicates. If a gate cannot
+run (no script, missing deps, sandboxed), say so in Verification — never report a gate
+as passed that you did not execute.
+
+## Project Rules and Learnings
+
+A review that fights the house style produces noise, not signal. Honor what the repo
+already encodes.
+
+- **Read the rules first:** before judging, read `CLAUDE.md`, `AGENTS.md`,
+  `CONTRIBUTING.md`, `.editorconfig`, formatter/linter config, and any review-config
+  file at the repo root or in the changed directories. A documented convention is
+  binding — do not flag what a rule permits; do flag what it forbids.
+- **Most-specific rule wins:** a rule in a subdirectory config or a nearest-ancestor
+  `AGENTS.md` overrides a repo-root rule for files under that path.
+- **Record learnings:** when the user dismisses a finding as a false positive or a
+  deliberate house pattern, capture it in one line — pattern, why it is allowed, path
+  scope — and do not re-raise that pattern this review or in later ones. Repeat nitpicks
+  erode trust faster than a missed P3.
+- **No rule from silence:** the absence of a convention is not license to impose a
+  personal preference. A style choice not governed by a rule, a formatter, or a real
+  cost is not a finding.
+
 ## Review Modes
 
 - **Fast diff review:** small change, narrow blast radius, focused findings.
@@ -159,6 +203,17 @@ For `--deep` reviews on auth changes, payment flows, data migrations, or public 
 - **Test critic:** maps claims to tests, screenshots, simulator runs, builds, and live/API checks.
 
 Collect consensus first. If high-severity concerns persist after a fix cycle, keep status at `hold` and name the smallest next check or patch.
+
+## Whole-Repo and History Pass (--deep)
+
+The changed-file import graph is the floor. The bugs that ship hide outside the diff. On `--deep`, widen past the immediate callers:
+
+- **Reverse-dependency sweep:** find every caller of a changed function, type, route, or constant across the whole repo (search the symbol repo-wide, not just the changed file's imports). A signature, return-shape, or nullability change is safe only if every call site agrees — name the sites you checked.
+- **Shared-assumption check:** for a changed schema, env var, default, or invariant, find the other places that assume the old value — config read in two services, a default mirrored in a client, a magic value duplicated in a test. These drift silently.
+- **History of the touched lines:** `git log -L` or `git blame` the changed region. If this area was fixed before, a change that reintroduces the old shape is a regression — cite the prior commit. If it churns repeatedly, flag it as fragile.
+- **Sibling-pattern consistency:** find the nearest existing analog — the other route handlers, the other migrations — and confirm the change follows the established pattern. A lone handler that skips the shared auth wrapper the other four use is P1 even if it "works."
+
+State what you traced. A whole-repo claim with no symbols named is not evidence.
 
 ## Observability Delta
 
@@ -359,6 +414,20 @@ Always check these when relevant:
 - multi-repo or multi-surface contracts do not drift across web, backend,
   mobile, public sites, and docs.
 
+## Swift / iOS Traps
+
+Check on every Swift file in the diff. iOS ships on a release cycle with no hot-fix — a crash here is live for days.
+
+- **Force operations (`!`, `try!`, `as!`):** each crashes when the optional is nil or the cast fails. Flag unless the failure case is provably eliminated immediately above. `try!` on anything that throws at runtime (decoding, file I/O) is P1.
+- **Retain cycles in closures:** an escaping closure that strongly captures `self` inside a stored property, `Task`, Combine sink, or callback leaks the owner. Require `[weak self]` (or `[unowned self]` only when lifetime is provably bound).
+- **UI work off the main thread:** mutating `@State`, `@Published`, or UIKit views from a background context is undefined behavior. Flag observable or UI mutation inside `Task.detached`, a URLSession callback, or a background queue with no hop to `@MainActor` / `DispatchQueue.main`.
+- **Actor and concurrency misuse:** actor-isolated state mutated across a suspension point without re-checking invariants (reentrancy); `nonisolated` used to silence a warning rather than because access is truly isolation-free; `@MainActor` work awaited from a path that should already be on main.
+- **Codable fragility:** a non-optional property decoding a field the server may omit or send null fails the whole decode and drops the response. Match optionality to the real API contract; flag `decode` on fields the backend does not guarantee.
+- **SwiftUI identity and lifecycle:** `ForEach` over a non-stable `id` (index, or a value that changes) loses state and breaks animations; `onAppear` used for one-time work re-fires on re-insertion; `@StateObject` vs `@ObservedObject` confusion (owning vs observing) re-creates or prematurely releases models.
+- **Leaked resources:** unbounded image/data caches; URLSession tasks not cancelled on disappearance; observers or timers added with no matching removal.
+
+Pair with iOS / Native Contract Drift below: crash risk here, contract break there.
+
 ## iOS / Native Contract Drift
 
 Check on any API route, response shape, auth header, or shared type that iOS or other native consumers depend on:
@@ -375,6 +444,32 @@ Blast radius note: identify which iOS version is currently in production. If the
 ## Technical Debt
 
 Flag tech debt patterns as P3, group by file, don't block ship. Do not block a ship on P3 tech debt unless it directly obscures a P0/P1 bug. File as follow-up.
+
+## Intent Compliance and Scope
+
+Code that works but does not do what it claimed is still a defect.
+
+- **Claim vs diff:** restate what the change says it does — PR title, description, linked issue, commit subject — and confirm the diff delivers it. Map every acceptance criterion to a code path or a test. Claimed behavior with no corresponding change is a P1 truth gap.
+- **Scope creep:** flag changes that do more than they claim — an unrelated refactor riding inside a bugfix, a dependency bump bundled with a feature, a formatting sweep that buries the real diff. Name the unrelated clusters and recommend splitting.
+- **Review-effort signal:** state diff size (files / net lines) and an effort read — trivial / moderate / heavy / too-large-to-review-safely. A single PR mixing auth, payments, and a migration should be split before it is safe to judge.
+
+## Change Walkthrough (multi-file PRs)
+
+For a PR summary or any review spanning four or more files, lead with a walkthrough so the reader sees the shape before the findings:
+
+- **Per-file table:** file → one-line what-changed → risk lane. Collapse generated or trivial files into one row.
+- **Flow diagram when warranted:** emit a mermaid `sequenceDiagram` (request → handler → service → data) or `flowchart` when the change moves data across three or more boundaries or alters an async, auth, or payment path. Skip it for a localized edit — a diagram of a one-file change is noise.
+
+The walkthrough orients; it never replaces findings, and stays above the Findings block.
+
+## Precision Pass (before output)
+
+False positives are why reviewers get muted. Self-check the draft findings before emitting:
+
+- **Evidence test:** every finding ties to a file:line, a reproduction or trace, and a concrete fix. Drop what cannot.
+- **Already-handled test:** drop what a formatter, the type checker, a configured linter, or a documented project rule already covers — do not re-report a gate's job as a manual finding.
+- **Confidence gate:** mark each finding high / medium / low. Collapse low-confidence style observations into a single "nitpicks" line; never let them outrank a real P-level finding.
+- **Net-signal test:** if a finding would not change the ship decision and would not be worth a human reviewer's comment, cut it. Volume is not the product.
 
 ## Output Shape
 

--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -37,6 +37,10 @@ Build a lightweight graph before judging the diff:
 
 Flag beyond-the-diff risks when related files, defaults, docs, env, or deploy requirements no longer agree.
 
+## Run Gates and Honor Project Rules
+
+Before manual analysis, run the gates the repo already ships and fold results in — typecheck, the configured linter on changed files, the test suite, the dependency auditor when deps changed, and a real secret scanner over the diff. Detect what exists; run only that; never fabricate a result you did not run, and note in Verification when a gate could not run. Then read the repo's own conventions — `CLAUDE.md`, `AGENTS.md`, linter/formatter config, nearest-ancestor rules — and treat them as binding: do not flag what a rule permits, do flag what it forbids, and do not re-raise a pattern the user already accepted.
+
 ## Review Modes
 
 - **Fast diff review:** small change, narrow blast radius, focused findings.
@@ -79,6 +83,10 @@ Any single match is an automatic **F**. Stop, report the file and line, and do n
 **Database (Drizzle/Prisma)** — N+1 queries in loops; missing index on filtered/sorted/join columns; multi-table writes without a transaction; missing unique constraints on logically-unique fields; unbounded selects with no `LIMIT` on growable tables.
 
 **Performance** — new >20 KB minzipped imports (flag with size, prefer tree-shaken); render-blocking `<script>` without `async`/`defer`; non-critical routes not lazy-loaded (`next/dynamic`); raw `<img>` instead of `next/image` for non-SVG assets.
+
+**Swift / iOS** — force `!`/`try!`/`as!` without a proving guard (P1 on runtime-throwing `try!`); escaping closures capturing `self` strongly (need `[weak self]`); UI/`@Published`/`@State` mutation off the main thread; actor reentrancy across suspension points; non-optional `Codable` fields the server may omit; `ForEach` over non-stable `id`; URLSession tasks/observers not cancelled.
+
+**Whole-repo (`--deep`)** — past the changed-file import graph, sweep every caller of a changed symbol across the repo, check shared assumptions (config/defaults/env mirrored elsewhere), `git log -L`/`blame` the touched lines for reintroduced regressions, and confirm the change matches its sibling pattern. Name what you traced.
 
 ## Step 3 — OWASP Top 10 (auto-runs on auth/api/middleware/routes or crypto/session/payment imports)
 
@@ -131,6 +139,10 @@ Auto-apply local P2/P3 fixes (single file, no contract change), each as its own 
 ## Suede-Specific Checks
 
 Auth/session behavior across app, API, native shells, and server · creator rights/provenance/registry/licensing/royalty/agent-commerce claims match implemented behavior · payment/wallet/x402/checkout/credit flows fail closed · public pages invent no metrics, pricing, partners, testimonials, or release promises · Vercel/account/deploy assumptions match local guidance before prod claims · App Store/iOS screenshots, metadata, privacy answers, and build behavior match the app · migrations, env, flags, cron/jobs, queues, webhooks, secrets are documented and deployable · multi-surface contracts don't drift across web, backend, mobile, sites, docs.
+
+## Intent, Scope, and Precision
+
+Confirm the diff delivers what it claims — map each acceptance criterion to code or a test; unbacked claims are a P1 truth gap — and flag scope creep (unrelated refactors, bundled dep bumps, formatting sweeps that bury the change); recommend splitting an over-large PR. Before emitting, self-check: every finding has a file:line + fix, nothing duplicates a gate's job, low-confidence style notes collapse into one "nitpicks" line, and anything that would not move the ship decision is cut.
 
 ## Output Shape
 


### PR DESCRIPTION
## What
Brings the code-review skills to capability parity with best-in-class reviewers and finishes the 21-skill sync.

- **suede-code-review**: 7 new sections. Run the repo's own gates (typecheck, lint, tests, dependency audit, secret scan); honor project rules and learnings; whole-repo and git-history pass on `--deep`; Swift/iOS traps; intent/scope and review-effort signal; change walkthrough with flow diagram; precision (false-positive) pass.
- **suede-code**: condensed mirror of the above.
- **mcp/catalog.json**: synced 16 to 21 (adds suede-code-review, suede-code-grader, suede-copy, suede-design, suede-agent-teams).
- **docs/skills**: new flagship pages for suede-agent-teams and suede-code-grader; index lists all 21.

## Why
The 5 newer skills were in `skills/` and on the landing site but missing from the catalog and `docs/skills`, so the MCP under-reported and the validator was red. This closes that gap.

## Verification
`node scripts/validate-skill-pack.mjs` passes: 21 skills, 21 catalog entries. It was red (7 failures) before this branch; 6 remaining were pre-existing docs gaps, now resolved.