### PR TITLE
Reposition as general-purpose agent-skills pack + one-command plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,36 @@
+{
+  "name": "suede",
+  "description": "Agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship gates, AI evals, and design/copy/SEO lanes. 21 MIT-licensed skills.",
+  "owner": {
+    "name": "Jason Colapietro",
+    "url": "https://github.com/JasonColapietro"
+  },
+  "plugins": [
+    {
+      "name": "suede-skills",
+      "source": "./",
+      "description": "Agent skills for Claude Code and Codex. Orchestrate multi-agent build lanes with quality gates and a signed handoff (suede-agent-teams), run end-to-end workflows (suede-workflow-skills), get code review plus a blunt A-F ship grade (suede-code, suede-code-review, suede-code-grader, suede-ship-gate), design measurable AI evals (suede-ai-eval), and ship public-facing work with the design, copy, SEO, and visibility lanes. Installs all 21 skills. Also includes a creator toolkit for music rights and release prep."
+    },
+    {
+      "name": "suede-agent-workflows",
+      "source": "./",
+      "skills": [
+        "./skills/suede-agent-teams",
+        "./skills/suede-workflow-skills",
+        "./skills/suede-ai-eval"
+      ],
+      "description": "Multi-agent orchestration subset: coordinate build lanes with quality gates and a signed handoff (suede-agent-teams), route cross-surface work end to end (suede-workflow-skills), and turn AI features into eval specs and acceptance gates (suede-ai-eval)."
+    },
+    {
+      "name": "suede-code",
+      "source": "./",
+      "skills": [
+        "./skills/suede-code",
+        "./skills/suede-code-review",
+        "./skills/suede-code-grader",
+        "./skills/suede-ship-gate"
+      ],
+      "description": "Code quality subset: one-pass review plus an A-F ship verdict (suede-code), deep findings with TypeScript, React, Next.js, OWASP, and database checklists (suede-code-review), a grade-only verdict with instant-F triggers and grade caps (suede-code-grader), and CI branch protection that gates the merge (suede-ship-gate)."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "suede-skills",
+  "description": "Agent skills for Claude Code and Codex. Orchestrate multi-agent build lanes with quality gates and a signed handoff, run code review with an A-F ship grade, design AI evals, and ship public-facing work with the design, copy, SEO, and visibility lanes. Installs all 21 skills. Also includes a creator toolkit for music rights and release prep.",
+  "author": {
+    "name": "Jason Colapietro",
+    "url": "https://github.com/JasonColapietro"
+  },
+  "homepage": "https://jasoncolapietro.github.io/suede-creator-skills/",
+  "repository": "https://github.com/JasonColapietro/suede-creator-skills",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "codex",
+    "agent-skills",
+    "multi-agent",
+    "agent-orchestration",
+    "code-review",
+    "ship-gate",
+    "ci",
+    "ai-eval",
+    "llm-evaluation",
+    "developer-tools",
+    "seo",
+    "mcp"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,586 +1,191 @@
 # Suede Creator Skills
 
-![Suede Creator Skills preview](docs/assets/og-image.png)
+Agent skills for Claude Code and Codex: orchestrate multi-agent teams, run code review with an A-F ship grade, and design AI evals.
+
+![License: MIT](https://img.shields.io/badge/License-MIT-blue) ![Skills: 21](https://img.shields.io/badge/Skills-21-black)
 
 > **By [Jason Colapietro](https://suedeai.ai/founder) / [Suede Labs AI](https://suedeai.ai)**
 
-**Suede Creator Skills** is an open-source, MIT-licensed 21-skill workflow pack
-for Codex, Claude Code, and other agent-assisted product and creator workflows.
-It is broadly reusable tooling, not a closed Suede product funnel.
-Install it when an agent needs portable context, linked guidance, reference-site
-restyling, sharper copy, SEO/AEO/AI EO, GitHub Pages polish, visibility grades,
-A-F code review, coordinated agent teams, AI evals, iOS/product checks, launch
-evidence, and creator music/IP utilities without rebuilding the prompt stack.
+## What it is
 
-The pack gives an agent a reusable product workflow: page structure, copy
-standards, reference-site analysis, visual QA, review gates, install paths,
-MCP scaffolds, a claim-safety boundary, and feedback loops that follow the
-work. It keeps context linked and inspectable instead of stuffing every
-preference into one giant prompt. In this pack, SEO includes AEO and AI EO:
-search snippets, answer engines, AI summaries, schema, sourceable claims, and
-citation-ready proof. When the agent does something that works, tell it what to
-keep. When it misses, tell it exactly what to change. You can also say
-`Cue Suede` mid-workflow or at the end to bring up choices: change something,
-preserve what worked so the agent can mimic it later, or keep as-is by saying
-nothing.
+A free, MIT-licensed pack of 21 agent skills for Claude Code and OpenAI Codex. Each skill is a `skills/<name>/SKILL.md` file the agent loads on demand.
 
-The components are reusable outside the Suede brand:
+- **Agent orchestration**: wire complex changes into coordinated agent lanes with WIP collision detection, RFC mode, feature-flag strategy, rollback trees, and a handoff checklist that won't close without evidence (`suede-agent-teams`).
+- **Code review + A-F ship grade**: deep findings plus a blunt letter verdict across 7 evidence-backed lanes, with instant-F triggers and grade caps for auth and payment surfaces (`suede-code`, `suede-code-review`, `suede-code-grader`, `suede-ship-gate`).
+- **AI evaluation**: turn LLM, RAG, classifier, and agent surfaces into AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates (`suede-ai-eval`).
+- **Design, copy, and SEO**: design systems and visual QA, conversion copy with an anti-slop gate, SEO/AEO/AI-EO audits, and A-F page visibility grades (`johnny-suede-design`, `johnny-suede-write`, `suede-design`, `suede-copy`, `suede-seo-audit`, `suede-visibility-grader`, `suede-site-alchemy`).
+- **Workflow umbrella**: load the whole pack with one skill (`suede-workflow-skills`).
 
-- Evolving context: the skill links to preferences and project guidance instead
-  of trapping the agent in one bloated memory page.
-- Suedify: give it a reference URL and a target URL, then push the target
-  toward that aesthetic with your own assets, copy, SEO/AEO/GEO/AI EO, and QA.
-- iOS/product packaging: turn a site or product into iOS-ready copy, App Store
-  metadata, screenshot direction, native-contract checks, and release QA.
-- Communicating agent teams: scout, build, review, verifier, and release lanes
-  share evidence so subagents do not disappear into disconnected silos.
-- Visibility scoring: grade findability, CTA pull, proof, AI readability,
-  schema depth, Google and Gemini result-surface readiness, and brand clarity.
-- Code and project grading: run A-F review across correctness, security, data,
-  UX, deploy readiness, public-claim truth, missing gates, and next fixes.
-- Music/IP suite: package campaigns, metadata, sync prep, rights packages,
-  release lints, provenance, credits, split notes, and review reports.
-- MCP: use structured skill discovery, install options, SEO/AEO/GEO/AI EO audit
-  scaffolds, QA checklists, and MCP validation only when structure helps.
-- Johnny Suede shortcuts: invoke Write, Design/Create, or Code to load the
-  whole workflow; a supplied company brief overrides the default Suede voice.
+## Install in one command
 
-Public GitHub users can bring their own company, repo, page, campaign, release,
-or product. Use the umbrella modes with a company brief, voice, audience, proof,
-allowed claims, forbidden claims, CTA, assets, and reference URLs; the workflow
-keeps the quality gates while using the user's brand voice and domain language.
-
-Suedify is the marketable site workflow: give the agent a reference URL and a
-target URL, then have it study layout, hierarchy, spacing, type, color, motion,
-proof structure, and content rhythm before pushing the target toward the
-reference with brand-safe design, matched screenshots, token distillation,
-copy, SEO, and QA.
-
-Even the GitHub Pages site is part of the pitch. It is not a README that got
-published by accident. The public site ships a polished landing page, docs
-guide, copy bank, skill catalog, MCP page, sitemap, schema, Open Graph assets,
-mobile-tested pages, and visible Jason Colapietro attribution from the same
-repo as the skills.
-
-`johnny-suede-write` is the one-name writing mode: public copy, company voice,
-product and mobile conversion copy, SEO/AEO/AI EO discoverability, CTAs,
-launch copy, social/email variants, and anti-generic line editing with
-Directness, Rhythm, Trust, Specificity, Authenticity, Density, and
-Search/AI readability scoring. `johnny-suede-design` is the one-name design
-mode: Suedify, mobile and product surfaces, product screenshots, UI polish,
-design-system QA, responsive checks, visual QA, visibility grading,
-implementation handoff, company voice, and the full writing mode included.
-
-Suede Visibility Grader turns a public page into an A-F visibility and CTA
-brief. It checks whether a site can be found, understood, trusted, cited by AI
-systems, acted on, and promoted with rendered design evidence. Suede Code
-Grader gives code an A-F ship-risk grade with
-the reason why across correctness, security, state, UX, tests, deploy readiness,
-and public-claim truth. Suede Code Review keeps the deeper findings and fix
-brief workflow. Suede Agent Teams adds grouping loops for major work: scout,
-constraints mapping, safe parallel build, shared context, adversarial review,
-consensus review, design visibility review, A-F code grading, WIP protection,
-quality/eval gates, release lock, recovery replay, and evidence handoff without
-lanes stepping on the same files or acting like siloed subagents. Suede AI Eval
-turns AI-powered surfaces into measurable AI-SPECs, failure-mode rubrics, eval
-cases, acceptance gates, and coverage audits.
-
-The artist lane turns a song, catalog moment, show, or drop into campaign
-material: era systems, song worlds, hook maps, release stunts, fan rituals,
-visualizer directions, merch objects, setlist theater, catalog resurrections,
-identity guides, collab angles, campaign-in-a-box plans, and sync-style review
-packages. Sync packaging stops at clean review prep: no placement promises,
-clearance claims, outreach claims, or Suede promo funnel.
-
-Creator utility skills for release metadata, provenance, rights packages, and
-royalty notes include evidence tables and severity models for projects that
-need them, but they are support tools, not the headline.
-
-The public site sells the workflow directly: install the umbrella skill, browse
-the 21 skill folders, use MCP only when structured discovery or QA helps, and
-keep legal, payout, registry, and distribution claims outside the public tools.
-
-Suede is one downstream review workflow for creator ownership infrastructure,
-programmable IP, registry-backed media, royalty routing, licensing readiness,
-and agent commerce. The pack is useful without Suede: it inspects current files,
-pages, repos, and local folders, but it does not upload files, write to a
-registry, call private services, request secrets, or claim legal clearance.
-
-## Public Page
-
-- [GitHub Pages site](https://jasoncolapietro.github.io/suede-creator-skills/) - public documentation generated from this GitHub repository, not a separate marketing site; the page itself is proof of the design/copy/SEO bar.
-- [GitHub repository](https://github.com/JasonColapietro/suede-creator-skills)
-- [Public explainer pack](PROMO.md) - long-form public guide for founders, builders, agencies, creators, AI power users, Suedify, MCP, skills, social posts, emails, SEO/AEO/AI EO metadata, FAQ, and claim boundaries.
-- [Suede Creator Skills copy bank](COPY.md) - public copy for GitHub descriptions, docs pages, CTAs, SEO/AEO/AI EO snippets, FAQs, social posts, and safety language.
-- [Copy bank page](https://jasoncolapietro.github.io/suede-creator-skills/copy.html) - live copy bank for sharing, explaining, and documentation work.
-- [Public installs and MCP page](https://jasoncolapietro.github.io/suede-creator-skills/plugins.html) - GitHub skill install commands plus the Suede Skills MCP server for skill discovery, SEO/AEO/AI EO copy audits, install guidance, and QA checklists.
-- [Skill docs catalog](https://jasoncolapietro.github.io/suede-creator-skills/skills/) - public catalog with primary skill pages, install links, manifests, scripts, folders, and resource maps.
-- [Suede Agent Teams docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html) - controlled max-agent loops for scout, safe parallel build, adversarial review, visibility grading, code grading, release lock, recovery, and evidence handoff.
-- [Suede AI Eval docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html) - public eval workflow for AI-SPECs, failure-mode rubrics, prompt and retrieval test cases, acceptance gates, and coverage audits.
-- [Creator rights package docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html) - full documentation for transfer package generation, provenance, credits, splits, licenses, intake JSON, templates, safety defaults, and install prompts.
-- [Release linter docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html) - full documentation for music release linting, metadata checks, missing-file detection, rights blockers, report outputs, templates, and downstream next steps.
-
-## Quick Start
-
-Install the umbrella workflow first and call it for Suedify, design, copy,
-SEO/AEO/AI EO, visibility grading, code grading, agent teams, AI evals, launch
-packaging, or creator utility work:
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/suede-workflow-skills
-```
-
-Example prompts:
+In Claude Code, add the marketplace and install the pack:
 
 ```text
-Use $suedify. Study https://apple.com and push https://example.com toward that design language with brand-safe design, copy, SEO/AEO/AI EO, and QA.
+/plugin marketplace add JasonColapietro/suede-creator-skills
+/plugin install suede-skills@suede
 ```
 
-```text
-Use $suede-workflow-skills to rewrite this page, audit SEO/AEO/AI EO, check design quality, and run final QA.
-```
+`suede-skills` installs all 21 skills. Two focused subsets are available if you want less: `/plugin install suede-agent-workflows@suede` (orchestration, workflows, evals) and `/plugin install suede-code@suede` (review, grade, ship-gate).
 
-```text
-Use $johnny-suede-write for my company with our brand voice.
-Company: Acme Robotics.
-Audience: operations leaders at mid-market manufacturers.
-Voice: precise, practical, slightly bold, never hype.
-Proof: customer quotes, uptime reports, factory screenshots, install docs.
-Forbidden claims: no guaranteed savings, no unverified rankings, no fake logos.
-Primary CTA: book a plant-floor workflow review.
-```
-
-```text
-Use $johnny-suede-design for my company. Redesign this landing page with our
-voice, proof, CTA, assets, and reference URLs while keeping the full design,
-copy, SEO/AEO/AI EO, visual QA, and ship-gate workflow.
-```
-
-Utility scripts are available when the project needs local creator reports:
-
-```bash
-git clone https://github.com/jasoncolapietro/suede-creator-skills.git
-cd suede-creator-skills
-
-python3 skills/suede-release-linter/scripts/lint_release.py \
-  /path/to/music-project \
-  --output /path/to/release-lint-output
-
-python3 skills/suede-rights-passport/scripts/create_transfer_package.py \
-  /path/to/creator-project \
-  --output /path/to/transfer-package \
-  --metadata /path/to/creator-project/metadata.json \
-  --project-title "Project Title" \
-  --artist "Artist Name"
-```
-
-Both scripts skip hidden files, secret-like files, dependency folders, build
-outputs, and unrecognized file types by default.
-
-## Public Explainer Pack
-
-Use [`PROMO.md`](PROMO.md) when explaining the full workflow publicly. It
-includes founder, designer, developer, agency, creator, and AI power-user
-positioning plus reusable copy for Suedify, Suede Workflow Skills, the optional
-MCP, install listings, social posts, DMs, email, SEO/AEO/AI EO metadata, FAQ
-answers, objection handling, and safe claim boundaries.
-
-The public-explainer rule: explain the outcome first. The pack gives agents a repeatable
-workflow for Suedify, design, copywriting, SEO/AEO/AI EO, visibility and CTA
-grading, code review with A-F Suede grades, QA, agent-team coordination, AI
-evals, launch packaging, creator campaign tools, and optional MCP-assisted
-discovery. Keep local install details such as `@personal` inside technical
-setup sections.
-
-Founder context for public explanations: the workflow was built from live pressure, not
-theory, turning repeated agent failures into reusable rules. The core
-conviction is that public work is not done until it is findable across Google,
-Gemini, and AI result surfaces, readable to AI systems, backed by proof, and
-clear enough for a real visitor to act.
-
-Safety-oriented CLI flags:
-
-- `--include-hidden`: include hidden files and folders, while still skipping
-  secret-like files.
-- `--include-other`: include unrecognized file types in inventories.
-- `--include-absolute-paths`: write absolute local paths into reports for
-  private operator workflows. Reports use share-safer paths by default.
-- `--force`: replace existing generated report/package files.
-
-## Install Public Skills Or Use MCP
-
-Suede skills can be installed from this public GitHub repo as plain Codex
-skills. Use the Suede Skills MCP when structured discovery, install guidance,
-SEO/AEO/AI EO copy audit scaffolds, or QA checklists would help the agent.
-
-Public Codex skill installs:
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/suede-workflow-skills
-```
-
-Install individual workflow and operations skills when you want direct triggers:
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/johnny-suede-design \
-  skills/johnny-suede-write \
-  skills/suede-code \
-  skills/suede-code-review \
-  skills/suede-code-grader \
-  skills/suede-copy \
-  skills/suede-design \
-  skills/suede-agent-teams \
-  skills/suede-ai-eval \
-  skills/suede-ship-gate \
-  skills/suede-seo-audit \
-  skills/suede-visibility-grader \
-  skills/suede-site-alchemy \
-  skills/suede-launch-packaging \
-  skills/suede-mcp-qa
-```
-
-Install creator skills:
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/suede-campaign-in-a-box \
-  skills/suede-sync-packaging \
-  skills/suede-release-linter \
-  skills/suede-rights-passport \
-  skills/suede-rights-audit
-```
-
-Restart Codex after installing new skills.
-
-Local personal marketplace plugin installs:
-
-```bash
-codex plugin add suede-workflow-skills@personal
-codex plugin add suede-creator-skills@personal
-```
-
-These commands are for a local Codex personal marketplace where the Suede plugin
-sources are registered. They are not the public install route.
-
-Optional MCP server names:
-
-- `suede_workflow_mcp`
-- `suede_creator_mcp`
-
-The public repo also includes the dependency-free stdio MCP server:
-
-```bash
-node mcp/suede-skills-mcp.mjs --profile all
-```
-
-MCP tools:
-
-- `list_suede_skills`
-- `get_suede_skill`
-- `suede_install_options`
-- `suede_copy_seo_audit`
-- `suede_visibility_grade`
-- `suede_code_grade`
-- `suede_qa_checklist`
-
-## Skills Included
-
-### Suede Workflow Skills
-
-Folder: [`skills/suede-workflow-skills`](skills/suede-workflow-skills)
-
-Install the public umbrella workflow when you want one skill to load the Suede
-design, anti-slop copy, SEO/AEO/AI EO, site polish, visibility and CTA grading,
-code review with A-F Suede grades, visual QA, launch, install support, MCP QA,
-public explanation, agent-commerce, Suedify, progressive feedback,
-two-level final explanations, Cue Suede choices, max-agent grouping loops,
-artist campaign, and creator utility workflow. The repository now ships **21
-public skill folders**.
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/suede-workflow-skills
-```
-
-Individual workflow and operations skills (15):
-
-- [`skills/johnny-suede-design`](skills/johnny-suede-design)
-- [`skills/johnny-suede-write`](skills/johnny-suede-write)
-- [`skills/suede-agent-teams`](skills/suede-agent-teams)
-- [`skills/suede-code`](skills/suede-code)
-- [`skills/suede-code-grader`](skills/suede-code-grader)
-- [`skills/suede-code-review`](skills/suede-code-review)
-- [`skills/suede-copy`](skills/suede-copy)
-- [`skills/suede-design`](skills/suede-design)
-- [`skills/suede-ai-eval`](skills/suede-ai-eval)
-- [`skills/suede-ship-gate`](skills/suede-ship-gate)
-- [`skills/suede-seo-audit`](skills/suede-seo-audit)
-- [`skills/suede-visibility-grader`](skills/suede-visibility-grader)
-- [`skills/suede-site-alchemy`](skills/suede-site-alchemy)
-- [`skills/suede-launch-packaging`](skills/suede-launch-packaging)
-- [`skills/suede-mcp-qa`](skills/suede-mcp-qa)
-
-Creator skills (5):
-
-- [`skills/suede-campaign-in-a-box`](skills/suede-campaign-in-a-box)
-- [`skills/suede-sync-packaging`](skills/suede-sync-packaging)
-- [`skills/suede-release-linter`](skills/suede-release-linter)
-- [`skills/suede-rights-passport`](skills/suede-rights-passport)
-- [`skills/suede-rights-audit`](skills/suede-rights-audit)
-
-### Creator Rights Package Builder
-
-![Suede Rights Passport preview](docs/assets/rights-passport-preview.png)
-
-Folder: [`skills/suede-rights-passport`](skills/suede-rights-passport)
-
-Turn a messy creator folder into a local rights and provenance transfer
-package. The skill inventories media, documents, lyrics, artwork, stems,
-credits, splits, licenses, provenance notes, missing rights information, and
-optimization blockers. Suede can be one downstream review workflow, but the
-package is broadly useful for creators, labels, managers, collaborators,
-registries, marketplaces, advisors, and agent-readable media workflows.
-
-Outputs include:
-
-- `RIGHTS_PASSPORT.md`
-- `suede-intake.json`
-- `provenance.md`
-- `credits-and-splits.md`
-- `license-notes.md`
-- `optimization-brief.md`
-- `missing-info-report.md`
-
-Run it locally:
-
-```bash
-python3 skills/suede-rights-passport/scripts/create_transfer_package.py \
-  /path/to/creator-project \
-  --output /path/to/transfer-package \
-  --project-title "Project Title" \
-  --artist "Artist Name" \
-  --copy-assets
-```
-
-The script refuses to write the package into or under the source folder and
-requires `--force` before replacing existing generated package files.
-
-To prefill the package with known rights facts, pass `--metadata` with a
-public-safe JSON, YAML, or key=value text metadata file. Do not point metadata
-at real `.env`, credential, wallet, or deployment config files. Metadata can
-provide project title, artist, owner claim, ownership status, contributor
-confirmations, splits status, sample status, clearance notes, wallet/payment
-destination, release history, public URLs, and provenance notes. Unknown or
-unconfirmed facts remain flagged in the generated reports.
-
-### Suede Release Linter
-
-![Suede Release Linter preview](docs/assets/release-linter-preview.png)
-
-Folder: [`skills/suede-release-linter`](skills/suede-release-linter)
-
-Audit a song, album, catalog, stem pack, or media project before release,
-licensing, registry preparation, agent commerce, or downstream review. The
-linter checks for missing title, artist, metadata, final masters, artwork,
-lyrics, stems, contributors, split totals, sample status, release history,
-provenance notes, and readiness blockers.
-
-Outputs include:
-
-- `release-lint-report.md`
-- `release-lint-report.json`
-
-Run it locally:
-
-```bash
-python3 skills/suede-release-linter/scripts/lint_release.py \
-  /path/to/music-project \
-  --output /path/to/release-lint-output
-```
-
-With metadata:
-
-```bash
-python3 skills/suede-release-linter/scripts/lint_release.py \
-  /path/to/music-project \
-  --metadata /path/to/music-project/metadata.json \
-  --output /path/to/release-lint-output
-```
-
-## Install For Codex
-
-Codex skills live in `$CODEX_HOME/skills`, falling back to `~/.codex/skills`
-when `CODEX_HOME` is not set.
-
-```bash
-git clone https://github.com/jasoncolapietro/suede-creator-skills.git
-cd suede-creator-skills
-
-mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
-cp -R skills/suede-rights-passport "${CODEX_HOME:-$HOME/.codex}/skills/"
-cp -R skills/suede-release-linter "${CODEX_HOME:-$HOME/.codex}/skills/"
-```
-
-Example Codex prompts:
-
-```text
-Use $suede-release-linter to audit this album folder for release readiness.
-```
-
-```text
-Use $suede-rights-passport to organize this creator project into a rights and provenance package.
-```
-
-## Install For Claude Code
-
-Quick install (all 21 skills):
+Prefer a clone? `install.sh` copies all 21 skills into `~/.claude/skills/` and prints the installed count:
 
 ```bash
 git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
 ```
 
-Claude Code skills use `SKILL.md` files in `.claude/skills/` directories. For a
-project-level install:
+You can also copy individual skill folders into `.claude/skills/` (project) or `~/.claude/skills/` (user).
+
+<details>
+<summary>Other install routes (Codex installer, project-level copy, MCP)</summary>
+
+**Codex — install one skill from GitHub:**
 
 ```bash
-git clone https://github.com/jasoncolapietro/suede-creator-skills.git /tmp/suede-creator-skills
-cd /path/to/your-project
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo JasonColapietro/suede-creator-skills \
+  --path skills/suede-agent-teams
+```
 
+Swap `skills/<skill>` for any skill folder, or pass extra `skills/<name>` paths to install several at once. Restart Codex after installing.
+
+**Claude Code — project-level copy of a single skill:**
+
+```bash
+git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
-cp -R /tmp/suede-creator-skills/skills/suede-rights-passport .claude/skills/
-cp -R /tmp/suede-creator-skills/skills/suede-release-linter .claude/skills/
+cp -R /tmp/suede-creator-skills/skills/suede-agent-teams .claude/skills/
 ```
 
-For a user-level install:
+**MCP — dependency-free stdio server:**
 
 ```bash
-mkdir -p ~/.claude/skills
-cp -R skills/suede-rights-passport ~/.claude/skills/
-cp -R skills/suede-release-linter ~/.claude/skills/
+node mcp/suede-skills-mcp.mjs --profile all
 ```
 
-Example Claude Code prompts:
+Exposes 7 tools (`list_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist`), 5 resources, and 5 prompts over JSON-RPC.
+
+</details>
+
+## Try it in 30 seconds
+
+Install the pack, then ask for a code review with a ship grade on your current changes:
 
 ```text
-Use the suede-release-linter skill to check this release folder.
+Use suede-code to review my staged diff and give it an A-F ship grade.
 ```
 
-```text
-Use the suede-rights-passport skill to organize this catalog into a local rights package.
+The skill runs its findings pass (TypeScript, React, Next.js, OWASP, and database checklists), then returns a grade card scoring Correctness, Security and permissions, Data and state, domain truth, UX and release behavior, Tests and verification, and Deploy readiness, plus an overall A-F grade. If it hits an instant-F trigger — a hardcoded secret, a missing auth check on a paid route — the grade locks to F with the exact file and line, and no other lane can raise it.
+
+## The skills
+
+### Agent orchestration & workflows
+
+| Skill | What it does |
+|---|---|
+| [`suede-agent-teams`](skills/suede-agent-teams) | Coordinate agent lanes with WIP collision detection, RFC mode, rollback trees, and a signed handoff |
+| [`suede-ai-eval`](skills/suede-ai-eval) | AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for AI surfaces |
+| [`suede-workflow-skills`](skills/suede-workflow-skills) | Umbrella skill that loads the full pack |
+
+### Code quality & shipping
+
+| Skill | What it does |
+|---|---|
+| [`suede-code`](skills/suede-code) | Review + A-F grade in one pass |
+| [`suede-code-review`](skills/suede-code-review) | Deep findings with Accessibility and SEO lanes, no letter grade |
+| [`suede-code-grader`](skills/suede-code-grader) | A-F ship verdict only, 7 lanes, instant-F triggers |
+| [`suede-ship-gate`](skills/suede-ship-gate) | Write CI that gates the merge — stack/lockfile detection, one required check, branch protection |
+
+### Design, copy & SEO
+
+| Skill | What it does |
+|---|---|
+| [`johnny-suede-design`](skills/johnny-suede-design) | Full design lane: brand and product surfaces, tokens, visual QA |
+| [`johnny-suede-write`](skills/johnny-suede-write) | Full writing lane: structure, persuasion frameworks, anti-slop gate, copy score |
+| [`suede-design`](skills/suede-design) | Design laws, dark-mode tokens, fluid type, component rules |
+| [`suede-copy`](skills/suede-copy) | Conversion copy: headline formulas, A/B variants, anti-slop gate |
+| [`suede-seo-audit`](skills/suede-seo-audit) | SEO/AEO/AI-EO, metadata, schema, internal-link, and intent audit |
+| [`suede-visibility-grader`](skills/suede-visibility-grader) | A-F page grades for findability, clarity, CTA pull, proof, and AI citation readiness |
+| [`suede-site-alchemy`](skills/suede-site-alchemy) | Funnel analysis, friction audit, conversion math, ranked quick-wins |
+| [`suede-launch-packaging`](skills/suede-launch-packaging) | Package work as a launch: docs, install commands, proof links, QA |
+| [`suede-mcp-qa`](skills/suede-mcp-qa) | QA the Suede Skills MCP before it ships |
+
+Plus a creator toolkit (rights, release prep) — see [docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/): `suede-campaign-in-a-box`, `suede-sync-packaging`, `suede-release-linter`, `suede-rights-passport`, `suede-rights-audit`.
+
+## Public pages
+
+- [GitHub repository](https://github.com/JasonColapietro/suede-creator-skills)
+- [GitHub Pages site](https://jasoncolapietro.github.io/suede-creator-skills/) — public documentation generated from this repo
+- [Skill docs catalog](https://jasoncolapietro.github.io/suede-creator-skills/skills/) — every skill with install and resource links
+- [Installs and MCP page](https://jasoncolapietro.github.io/suede-creator-skills/plugins.html) — install commands plus the Suede Skills MCP
+- [Copy bank](https://jasoncolapietro.github.io/suede-creator-skills/copy.html) ([source](COPY.md)) and [public explainer pack](PROMO.md)
+
+## MCP server
+
+The repo ships a dependency-free stdio MCP server at [`mcp/`](mcp/). It implements `initialize`, `tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, and `prompts/get`.
+
+```bash
+node mcp/suede-skills-mcp.mjs --profile all
 ```
 
-Claude.ai and organization-managed Claude Skills may use upload or admin-managed
-skill flows instead of direct filesystem copy. Review the skill contents before
-enabling code execution.
+| Tools (7) | Resources (5) | Prompts (5) |
+|---|---|---|
+| `list_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist` | catalog, plugins, copy-seo-audit, visibility-grade, code-grade | discovery and audit prompts |
 
-## How The Workflow Fits Together
+## Install for Codex
 
-```text
-creator folder
-  -> release metadata lint
-  -> missing info and rights fixes
-  -> rights and provenance transfer package
-  -> optional release, licensing, registry, collaborator, marketplace, or review workflow
+Codex skills live in `$CODEX_HOME/skills`, falling back to `~/.codex/skills` when `CODEX_HOME` is unset. Install one or more skills from GitHub:
+
+```bash
+python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
+  --repo JasonColapietro/suede-creator-skills \
+  --path skills/suede-workflow-skills
 ```
 
-Use the linter first when you want a fast audit. Use the rights package builder
-when you are ready to create a durable transfer package with hashes,
-provenance, credits, splits, license notes, and unresolved questions.
+To install several at once, pass extra `skills/<name>` paths after `--path`. Restart Codex after installing.
 
-## Project And Platform References
+## Install for Claude Code
 
-Use these links to inspect the open-source repo, install paths, docs pages, and
-skill resources.
+All 21 skills:
 
-- GitHub repository: <https://github.com/JasonColapietro/suede-creator-skills>
-- GitHub Pages site: <https://jasoncolapietro.github.io/suede-creator-skills/>
-- Skill docs catalog: <https://jasoncolapietro.github.io/suede-creator-skills/skills/> - public index for every Suede Creator Skill and its install/resource links.
-- Public explainer source: [PROMO.md](PROMO.md) - full public explanation kit for Suede skills, MCP, Suedify, SEO/AEO/AI EO audits, QA, social posts, emails, FAQ, and claim boundaries.
-- Copy bank page: <https://jasoncolapietro.github.io/suede-creator-skills/copy.html> - live GitHub, docs, CTA, SEO/AEO/AI EO, FAQ, social, and safety copy for Suede Creator Skills.
-- Copy bank source: [COPY.md](COPY.md) - reusable public copy for repo metadata, skill pages, install surfaces, launch posts, and claim boundaries.
-- Public installs and MCP page: <https://jasoncolapietro.github.io/suede-creator-skills/plugins.html> - GitHub skill install commands and Suede Skills MCP docs for skill discovery, SEO/AEO/AI EO copy audits, install guidance, and QA checklists.
-- MCP source: [mcp/](mcp/) - dependency-free stdio MCP server, catalog, and MCP README.
-- Creator rights package docs: <https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html> - transfer package docs for creator rights, provenance, splits, license notes, intake JSON, and optimization briefs.
-- Release linter docs: <https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html> - release-readiness docs for metadata, artwork, masters, lyrics, stems, credits, samples, reports, and downstream blockers.
-- Rights Passport skill: [skills/suede-rights-passport/SKILL.md](skills/suede-rights-passport/SKILL.md)
-- Rights Passport script: [skills/suede-rights-passport/scripts/create_transfer_package.py](skills/suede-rights-passport/scripts/create_transfer_package.py)
-- Rights Passport OpenAI metadata: [skills/suede-rights-passport/agents/openai.yaml](skills/suede-rights-passport/agents/openai.yaml)
-- Rights Passport references: [skills/suede-rights-passport/references/](skills/suede-rights-passport/references/)
-- Rights Passport templates: [skills/suede-rights-passport/assets/](skills/suede-rights-passport/assets/)
-- Release Linter skill: [skills/suede-release-linter/SKILL.md](skills/suede-release-linter/SKILL.md)
-- Release Linter script: [skills/suede-release-linter/scripts/lint_release.py](skills/suede-release-linter/scripts/lint_release.py)
-- Release Linter OpenAI metadata: [skills/suede-release-linter/agents/openai.yaml](skills/suede-release-linter/agents/openai.yaml)
-- Release Linter references: [skills/suede-release-linter/references/](skills/suede-release-linter/references/)
-- Release Linter templates: [skills/suede-release-linter/assets/](skills/suede-release-linter/assets/)
-- Page source: [docs/index.html](docs/index.html)
-- Skill docs source: [docs/skills/](docs/skills/)
+```bash
+git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
+```
 
-Platform references:
+Claude Code skills use `SKILL.md` files in `.claude/skills/`. For a project-level install, copy individual folders:
 
-- OpenAI Skills examples: <https://github.com/openai/skills>
-- Claude Code skills documentation: <https://docs.claude.com/en/docs/claude-code/skills>
-- Claude Skills help center: <https://support.claude.com/en/articles/12512180-using-skills-in-claude>
+```bash
+git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
+mkdir -p .claude/skills
+cp -R /tmp/suede-creator-skills/skills/suede-agent-teams .claude/skills/
+```
 
-## About the Creator
+For a user-level install, copy into `~/.claude/skills/` instead. Claude.ai and organization-managed Claude Skills may use upload or admin-managed flows instead of filesystem copy. Review skill contents before enabling code execution.
 
-**Jason Colapietro** is the founder and CEO of [Suede Labs AI](https://suedeai.ai), a published author, and a Forbes contributor. He builds programmable IP and creator ownership infrastructure for AI-native media.
+## Safety
 
-> "The gap in the creator economy isn't talent. It's the gap between the moment you make something and the moment you own it in a form that can be licensed, monetized, and defended."
+These skills inspect current files, pages, repos, and local folders. They do not upload files, write to a registry, call private services, request secrets, or claim legal clearance.
 
-> "Rights metadata is the dark matter of the creative economy. It governs everything. Almost nobody can see it."
+The creator skills generate private drafts by default — reports and packages can contain names, payment notes, file names, hashes, rights claims, and provenance notes. Review and redact before publishing or sending outside the intended workflow. A clean report is not a legal opinion, registry write, rights clearance, or payment guarantee.
 
-> "Every piece of music that enters the world has a signal chain. The IP chain is just the part most musicians never mapped until now."
-
-> "Build what doesn't exist yet. Register that you built it. That sequence is the whole game."
-
-### Books by Jason Colapietro
-
-- **[The Signal Chain](https://guitar.solutions)**: Illustrated electric-guitar tone history, memoir, method, and workbook editions. From pickup to speaker, from gear to IP. (guitar.solutions)
-- **[The Guitar Without a Number](https://www.amazon.com/stores/author/B0GD5FX6N6)**: Memoir-driven guitar instruction for the self-taught player. Theory, tone, artist songbooks, and a music IP rights chapter. (Amazon author store)
-- **[Suede Labs: The Human Authenticity Layer](https://www.amazon.com/dp/B0GD5FX6N6)**: How ownership, origin, and AI redraw the creative map. (Kindle)
-- **[Proof as Infrastructure](https://www.amazon.com/dp/B0GMB2VLXQ)**: Designing durable systems without trust assumptions. (Kindle)
-- **[Stake Your Claim](https://www.amazon.com/dp/B0GRG8LGQQ)**: Hard truths on turning the AI era into a real asset. (Kindle)
-
-Follow: [X / @johnnysuede](https://x.com/johnnysuede) · [suedeai.ai](https://suedeai.ai) · [suedeai.ai/founder](https://suedeai.ai/founder)
-
-
-## Public Safety
-
-A clean lint report or completed transfer package is not a legal opinion,
-distributor approval, registry write, rights clearance, payment guarantee, or
-platform approval. These skills prepare materials so creators, reviewers, and
-advisors can inspect the work with better structure.
-
-Generated reports and transfer packages are private drafts by default. They can
-contain creator names, wallet/payment notes, file names, hashes, rights claims,
-contributor details, restrictions, and provenance notes. Review and redact them
-before publishing, committing, or sending outside the intended workflow.
+CLI flags on the creator scripts: `--include-hidden`, `--include-other`, `--include-absolute-paths`, and `--force`. Scripts skip hidden files, secret-like files, dependency folders, and build outputs by default, and refuse to write a package into or under its source folder.
 
 ## Status
 
-The scripts are dependency-light Python and run with the standard library.
-Optional enhancements use installed packages when available, such as Pillow for
-artwork dimension checks or PyYAML for YAML metadata parsing.
-
-YAML metadata support requires PyYAML:
+The creator scripts are dependency-light Python and run on the standard library. Optional enhancements use installed packages when available — Pillow for artwork dimension checks, PyYAML for YAML metadata:
 
 ```bash
 python3 -m pip install PyYAML
 ```
 
-## License And Contributions
+## About the creator
+
+**Jason Colapietro** is the founder and CEO of [Suede Labs AI](https://suedeai.ai). He builds programmable IP and creator-ownership infrastructure for AI-native media.
+
+Follow: [X / @johnnysuede](https://x.com/johnnysuede) · [suedeai.ai](https://suedeai.ai) · [suedeai.ai/founder](https://suedeai.ai/founder)
+
+## License and contributions
 
 Released under the [MIT License](LICENSE).
 
-Contributions are welcome for docs fixes, install-path corrections, lint rules,
-template improvements, and public-safe workflow improvements. Do not submit
-private catalogs, unreleased media, credentials, seed phrases, private Suede API
-details, payment secrets, or third-party copyrighted files.
+Contributions are welcome for docs fixes, install-path corrections, lint rules, template improvements, and public-safe workflow improvements. Do not submit private catalogs, unreleased media, credentials, seed phrases, private Suede API details, payment secrets, or third-party copyrighted files.
+


### PR DESCRIPTION
## Why

GitHub traffic showed almost no organic human reach (≈14 unique viewers in 14 days; the large clone count is bots/mirrors). The repo also led with a music-creator framing and a ~600-line README, while the actual high-value content is general-purpose: agent-team orchestration, code review + A-F ship grade, AI evals, and design/copy/SEO. This repositions for the much larger developer/AI-builder audience and removes install friction.

## What changed

**One-command install (new `.claude-plugin/`)**
- `marketplace.json` + `plugin.json` so users can run:
  ```
  /plugin marketplace add JasonColapietro/suede-creator-skills
  /plugin install suede-skills@suede
  ```
- `suede-skills` installs all 21; `suede-agent-workflows` and `suede-code` are focused subsets.
- Passes `claude plugin validate --strict`.

**README rewrite (~600 → ~190 lines)**
- Hero one-liner: "Agent skills for Claude Code and Codex: orchestrate multi-agent teams, run code review with an A-F ship grade, and design AI evals."
- One-command install above the fold; a 30-second try-it example; a scannable grouped skill table.
- Creator/rights skills compressed to a single footnote line. No claims that aren't backed by the repo.

Produced and adversarially verified (claim-truth, anti-slop, positioning) before commit.