### PR TITLE
Reposition GitHub Pages landing page to general-purpose agent skills

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,12 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Suede Creator Skills | Open-Source Agent Skill Pack</title>
-  <meta name="description" content="Install 21 public open-source skills for Codex and Claude Code: portable agent context, reference-site restyling, agent teams, SEO/AEO/GEO/AI EO, code review, iOS, music, IP, and creator workflows.">
+  <meta name="description" content="Install 21 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO. One-command install.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills | Open-Source Agent Skill Pack">
-  <meta property="og:description" content="Install 21 public MIT-licensed skills for portable agent context, reference-site restyling, coordinated agent teams, SEO/AEO/GEO/AI EO, code review, iOS, music, IP, and creator workflows.">
+  <meta property="og:description" content="Install 21 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO.">
   <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
   <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/">
   <meta property="og:site_name" content="Suede Creator Skills">
@@ -17,7 +17,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills | Open-Source Agent Skill Pack">
-  <meta name="twitter:description" content="Install 21 public MIT-licensed skills for portable agent context, reference-site restyling, coordinated agent teams, SEO/AEO/GEO/AI EO, code review, iOS, music, IP, and creator workflows.">
+  <meta name="twitter:description" content="Install 21 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO.">
   <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
 
   <!-- Canonical -->
@@ -59,7 +59,7 @@
       {
         "@type": "SoftwareSourceCode",
         "name": "Suede Creator Skills",
-        "description": "Public, open-source (MIT) pack of 21 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server. One install gives an AI coding agent portable context and a reusable product workflow: preference-aware writing, linked preferences, reference-site restyling, coordinated agent teams, SEO/AEO/GEO/AI EO audits, schema-level visibility grading, A-F code and project grading, iOS and product surface checks, launch packaging, music/IP workflows, creator rights utilities, MCP QA, and feedback loops. Users can bring their own company, repo, page, campaign, release, or product.",
+        "description": "Public, open-source (MIT) pack of 21 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server. One install gives an AI coding agent a reusable engineering workflow: coordinated multi-agent build lanes with quality gates and a signed handoff, code review with a blunt A-F ship grade, CI ship-gates, AI evaluation specs and acceptance gates, and design, copy, SEO, and visibility lanes for shipping public work. Also includes a small creator toolkit for music rights and release prep. Users can bring their own company, repo, page, or product.",
         "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
         "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
         "programmingLanguage": ["TypeScript", "Swift", "Python", "Markdown"],
@@ -67,7 +67,7 @@
         "author": { "@id": "https://suedeai.ai/#org" },
         "creator": { "@id": "https://suedeai.ai/founder#person" },
         "license": "https://opensource.org/licenses/MIT",
-        "keywords": ["Claude Code skills", "Codex skills", "Agent Skills", "MCP server", "SEO AEO GEO AI EO audit", "AI code review", "project grader", "design system", "Suedify", "iOS app packaging", "creator economy", "music rights", "royalty splits", "agent commerce"]
+        "keywords": ["Claude Code skills", "Codex skills", "Agent Skills", "MCP server", "multi-agent orchestration", "AI code review", "A-F ship grade", "CI ship gate", "AI eval", "design system", "Suedify", "iOS app packaging", "SEO AEO GEO AI EO audit", "developer tools"]
       },
       {
         "@type": "ItemList",
@@ -1966,13 +1966,13 @@
 
     <img id="hero-logo" class="hero-anim" src="./assets/suede-ai-logo-transparent.png" alt="Suede AI" onerror="this.style.display='none'">
 
-    <h1 id="hero-headline" class="hero-anim">Install reusable agent skills for product, creator, and code workflows.</h1>
+    <h1 id="hero-headline" class="hero-anim">Install reusable agent skills for orchestration, code review, and AI evals.</h1>
 
-    <p id="hero-subline" class="hero-anim">Suede Creator Skills is a 21-skill MIT-licensed toolkit for portable context, linked guidance, reference-site restyling, agent teams, SEO/AEO/GEO/AI EO, code and project grading, schema-level visibility, creator music/IP utilities, and iOS-ready product work. Bring your own company, repo, page, campaign, release, or product.</p>
+    <p id="hero-subline" class="hero-anim">Suede Creator Skills is a 21-skill MIT-licensed pack for Claude Code and Codex: coordinate multi-agent build lanes with quality gates, run code review with a blunt A-F ship grade, design measurable AI evals, and ship public work with the design, copy, and SEO lanes. Bring your own company, repo, page, or product.</p>
 
     <div id="hero-proof" class="hero-anim">
       <span class="hero-proof-line">Public install commands, MIT license, and inspectable SKILL.md folders</span>
-      <span class="hero-proof-line">Reusable with any company brief, product surface, source repo, or creator project</span>
+      <span class="hero-proof-line">Reusable with any company brief, product surface, source repo, or landing page</span>
       <span class="hero-proof-line">Local-first by default: no uploads, registry writes, payouts, or legal clearance claims</span>
     </div>
 
@@ -2082,8 +2082,8 @@
       </div>
       <div class="feature-card">
         <span class="feature-num">08</span>
-        <span class="feature-label">Music + IP suite</span>
-        <p class="feature-copy">Builds campaign systems, release lint reports, rights packages, metadata checks, sync prep, provenance, credits, split notes, and review reports</p>
+        <span class="feature-label">AI eval</span>
+        <p class="feature-copy">Turns LLM, RAG, classifier, and agent surfaces into measurable AI-SPECs with failure-mode rubrics, eval cases, and acceptance gates you can fail a release on</p>
       </div>
       <div class="feature-card">
         <span class="feature-num">09</span>
@@ -2183,7 +2183,7 @@
       </div>
 
       <div class="proof-col proof-col--right">
-        <p class="col-label">For builders and creators</p>
+        <p class="col-label">For builders and AI engineers</p>
 
         <div class="waveform-wrap" aria-hidden="true">
           <div class="waveform-bar" style="--d:.55s;--s:5;height:12px;"></div>
@@ -2208,8 +2208,8 @@
           <div class="waveform-bar" style="--d:.57s;--s:7;height:16px;"></div>
         </div>
 
-        <h3 class="musicians-headline">Website, app, music, IP,<br>and release work get a full QA spine.</h3>
-        <p class="musicians-sub">Design, copy, visibility, code, campaign, metadata, music rights, royalty split notes, GitHub Pages polish, MCP, and iOS-ready product checks live in the same pack.</p>
+        <h3 class="musicians-headline">Design, code, and AI work<br>get a full QA spine.</h3>
+        <p class="musicians-sub">Agent orchestration, code review and A-F grading, AI evals, design, copy, visibility, SEO, MCP, and CI ship-gates live in the same pack.</p>
 
         <ul class="musicians-list">
           <li class="musicians-item">
@@ -2218,7 +2218,7 @@
           </li>
           <li class="musicians-item">
             <div class="musicians-tick"></div>
-            <span class="musicians-text">Creator tools package campaigns, sync notes, release lints, rights packages, split status, metadata checks, online search, and rights audits.</span>
+            <span class="musicians-text">A small <strong>creator toolkit</strong> also ships for music rights and release prep, kept separate from the core developer workflow.</span>
           </li>
           <li class="musicians-item">
             <div class="musicians-tick"></div>
@@ -2244,19 +2244,20 @@
 
   <div class="install-inner">
     <h2 class="install-headline reveal">Install the open-source pack.</h2>
-    <p class="install-sub reveal reveal-d1">Clone the public repo, install the skills, and give the agent portable context, reference-site restyling, grading, code review, SEO/AEO/GEO/AI EO, MCP, iOS, music, IP, and QA rails it can reuse across your own work.</p>
+    <p class="install-sub reveal reveal-d1">Add the marketplace in Claude Code and install all 21 skills in one command, or clone the repo. Either way the agent gets orchestration, code review and A-F grading, AI evals, design, copy, SEO, and CI rails it can reuse across your own work.</p>
 
     <div class="install-terminal reveal reveal-d1">
       <div class="install-terminal-bar" aria-hidden="true">
         <span class="tdot"></span>
         <span class="tdot"></span>
         <span class="tdot"></span>
-        <span class="install-terminal-title">install.sh</span>
+        <span class="install-terminal-title">claude code</span>
       </div>
       <div class="install-code-block">
-        <code id="install-cmd">git clone https://github.com/JasonColapietro/suede-creator-skills.git &amp;&amp; bash suede-creator-skills/install.sh</code>
+        <code id="install-cmd" style="white-space:pre-line">/plugin marketplace add JasonColapietro/suede-creator-skills
+/plugin install suede-skills@suede</code>
         <button class="copy-btn" id="copy-btn" onclick="
-          var cmd='git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh';
+          var cmd='/plugin marketplace add JasonColapietro/suede-creator-skills\n/plugin install suede-skills@suede';
           navigator.clipboard.writeText(cmd).then(function(){
             var b=document.getElementById('copy-btn');
             b.textContent='Copied';


### PR DESCRIPTION
Follow-up to #3. The README + repo metadata were repositioned, but the GitHub Pages site (`docs/index.html`, hand-built — not generated from the README) still led with creator/music framing. This brings the public landing page in line.

- Meta description, OG, Twitter, and JSON-LD: drop music/creator-led copy; lead with orchestration, code review + A-F grade, CI ship-gates, AI evals, design/copy/SEO.
- Hero: `Install reusable agent skills for orchestration, code review, and AI evals.`
- Feature grid: swap 'Music + IP suite' card for an 'AI eval' card.
- Proof section reframed to design/code/AI; creator compressed to one footnote line.
- Install: hero is now the one-command `/plugin marketplace add` route (clone as fallback).

Verified rendered locally: no console errors, two-line install command renders, and the word 'musician' no longer appears on the page.