### PR TITLE
Clarify private companion routes

### DIFF
--- a/skills/johnny-suede-design/SKILL.md
+++ b/skills/johnny-suede-design/SKILL.md
@@ -110,7 +110,7 @@ Choose the smallest path that fits the request.
 - **Ambiguous or net-new design:** gather context, propose 2–3 approaches with tradeoffs, recommend one, get approval before implementation.
 - **Large redesign:** write a compact shape brief first — audience, page job, register, scene, color strategy, typography, layout, signature moment, constraints, QA plan.
 - **Visual system work:** scan current CSS, tokens, components, spacing, shadows, breakpoints, icon usage, and repeated UI patterns before proposing changes.
-- **Source-to-implementation QA:** if there is a mock, screenshot, Figma frame, or image target plus a rendered implementation, compare both visually before handoff and save `suede-visual-qa.md` in the project root.
+- **Source-to-implementation QA:** if there is a mock, screenshot, Figma frame, or image target plus a rendered implementation, compare both visually before handoff and save `visual-qa-report.md` in the project root.
 - **Long polish loop:** iterate through a visible checklist. If the same failure repeats, freeze the loop, reduce scope to the failing unit, and rerun with explicit acceptance criteria.
 
 ## Delivery Discipline
@@ -176,7 +176,7 @@ Below 70/100 the system is failing: fix the two lowest dimensions before styling
 
 ## Visual QA Report (Lane A)
 
-When comparing a source visual target against an implementation, save `suede-visual-qa.md` with:
+When comparing a source visual target against an implementation, save `visual-qa-report.md` with:
 - source visual truth path or URL
 - implementation path, URL, or screenshot
 - viewport and state

--- a/skills/suede-ai-eval/SKILL.md
+++ b/skills/suede-ai-eval/SKILL.md
@@ -281,5 +281,5 @@ Ship gate is mechanical: **hold** = any severity-5 failure mode uncovered, or no
 
 - The AI surface's implementation needs review or a ship grade → **suede-code**
 - Eval cases written and passing → **suede-ship-gate** to wire them into CI as a required check
-- Built feature needs UAT beyond the eval suite → (use suede-verify — private)
+- Built feature needs UAT beyond the eval suite → (private Suede Labs companion, not in this pack: suede-verify)
 - The eval work is one lane of a bigger coordinated build → **suede-agent-teams**

--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -379,7 +379,7 @@ Verify that threat mitigations declared in a threat model (ADR threat table, PLA
 
 **Trigger:** pass `--threat-verify` or say "verify threat mitigations" / "check threat model compliance"
 
-**Input:** threat model source — file path or pasted content. Accepted formats: ADR threat table (e.g. from suede-arch — private), PLAN.md risk section, free-form "Threat: X / Mitigation: Y" pairs.
+**Input:** threat model source — file path or pasted content. Accepted formats: ADR threat table (private Suede Labs companion, not in this pack: suede-arch), PLAN.md risk section, free-form "Threat: X / Mitigation: Y" pairs.
 
 **Process:**
 1. Parse the threat model into: { threat_id, description, declared_mitigation, expected_location }

--- a/skills/suede-copy/SKILL.md
+++ b/skills/suede-copy/SKILL.md
@@ -8,8 +8,8 @@ description: "Write copy that earns the click. 12 headline formulas, 5 persuasio
 ## When to use this skill instead of related skills
 - **suede-copy** (this skill): standalone conversion email, landing page copy, CTAs, microcopy, button labels
 - **johnny-suede-write**: full writing stack (copy + SEO + AI Engine Optimization)
-- Multi-email campaign sequences and campaign performance reporting: (use suede-growth — private)
-- Post-production pass to strip AI writing patterns from already-written copy: (use suede-deslop — private)
+- Multi-email campaign sequences and campaign performance reporting: (private Suede Labs companion, not in this pack: suede-growth)
+- Post-production pass to strip AI writing patterns from already-written copy: (private Suede Labs companion, not in this pack: suede-deslop)
 
 Write conversion copy, page copy, GitHub docs, email, and social posts that are specific, proof-backed, and free of AI boilerplate. Default voice: Suede. Supply a company brief to override everything.
 

--- a/skills/suede-design/SKILL.md
+++ b/skills/suede-design/SKILL.md
@@ -7,8 +7,8 @@ description: "Evolve any Suede interface from generic to intentional. Design law
 
 ## When to use this skill instead of related skills
 - **suede-design** (this skill): design system tokens, color ramps, type scale, component-level polish, brand identity decisions
-- Visual iteration with the local script harness (craft, shape, audit sub-commands): (use suede-visual-qa — private)
-- UX critique, accessibility audit, information architecture, design handoff docs: (use suede-ui — private)
+- Visual iteration with the local script harness (craft, shape, audit sub-commands): (private Suede Labs companion, not in this pack: suede-visual-qa)
+- UX critique, accessibility audit, information architecture, design handoff docs: (private Suede Labs companion, not in this pack: suede-ui)
 - **johnny-suede-design**: full-stack build combining design + copy + visual QA for a launch or redesign
 
 Use this skill to make Suede interfaces feel intentional, premium, legible, and
@@ -73,7 +73,7 @@ Choose the smallest path that fits the request.
   changes.
 - **Source-to-implementation QA:** if there is a mock, screenshot, Figma frame,
   or image target plus a rendered implementation, compare both visually before
-  handoff and save `suede-visual-qa.md` in the project root.
+  handoff and save `visual-qa-report.md` in the project root.
 - **Long polish loop:** iterate through a visible checklist. If the same failure
   repeats, freeze the loop, reduce scope to the failing unit, and rerun with
   explicit acceptance criteria.
@@ -501,7 +501,7 @@ non-critical, and acceptable for the launch stage.
 ## Visual QA Report
 
 When comparing a source visual target against an implementation, save
-`suede-visual-qa.md` with:
+`visual-qa-report.md` with:
 
 - source visual truth path or URL
 - implementation path, URL, or screenshot

--- a/skills/suede-mcp-qa/SKILL.md
+++ b/skills/suede-mcp-qa/SKILL.md
@@ -197,5 +197,5 @@ Ship gate: ship | ship-with-caveats | hold
 After QA:
 - MCP source needs fixes → return to the MCP source file and fix, then re-run this skill
 - Catalog JSON needs updates → edit `mcp/catalog.json` and re-run steps 2 and 7
-- Docs/README language mismatch → update the docs surface to match live MCP output (use suede-docs — private), then re-run check 7
+- Docs/README language mismatch → update the docs surface to match live MCP output (private Suede Labs companion, not in this pack: suede-docs), then re-run check 7
 - Install command broken → **suede-launch-packaging** to fix and test the install path

--- a/skills/suede-workflow-skills/references/no-missed-quality-gates.md
+++ b/skills/suede-workflow-skills/references/no-missed-quality-gates.md
@@ -162,7 +162,7 @@ one from memory.
   improvised SVGs, or text approximations as a blocking defect unless the user
   explicitly asked for that substitution.
 - Save the QA artifact named by the relevant skill, usually
-  `suede-visual-qa.md` or `suedify-visual-qa.md`, with source truth,
+  `visual-qa-report.md` or `suedify-visual-qa.md`, with source truth,
   implementation evidence, viewport/state, findings, patches, caveats, and
   `final result: passed` or `final result: blocked`.
 


### PR DESCRIPTION
## Summary
- Replace bare routes to private-only Suede companion skills with explicit private-companion phrasing.
- Rename visual QA report artifact examples so they do not look like missing runnable public skills.

## Verification
- grep -rE "suede-(growth|deslop|visual-qa|ui|docs|verify|arch)" skills/
- rg -n "use suede-(growth|deslop|visual-qa|ui|docs|verify|arch)|use \$?suede-(growth|deslop|visual-qa|ui|docs|verify|arch)" skills
- git diff --check
- node scripts/validate-skill-pack.mjs