### PR TITLE
Clarify private git hygiene routes

### DIFF
--- a/skills/suede-agent-teams/SKILL.md
+++ b/skills/suede-agent-teams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suede-agent-teams
-description: "Wire complex changes into coordinated agent lanes with quality gates and a signed handoff. WIP collision detection, RFC mode, feature flag strategy, rollback trees, 5 scenario templates, and a handoff checklist that won't close without evidence. Use when work needs parallel agents or multiple coordinated lanes — an auth rewrite, payment integration, data migration, performance audit, or public launch review — or when parallel edits could collide with dirty WIP. NOT FOR: single-lane code review or grading (use suede-code); wiring CI and branch protection (use suede-ship-gate)."
+description: "Wire complex changes into coordinated agent lanes with quality gates and a signed handoff. WIP collision detection, RFC mode, feature flag strategy, rollback trees, 5 scenario templates, and a handoff checklist that won't close without evidence. Use when work needs parallel agents or multiple coordinated lanes, such as an auth rewrite, payment integration, data migration, performance audit, public launch review, or parallel edits that could collide with dirty WIP. NOT FOR: single-lane code review or grading (use suede-code); wiring CI and branch protection (use suede-ship-gate); Jason's private branch/worktree lifecycle and finish/cleanup discipline (private Suede Labs companion, not in this pack: suede-git-hygiene)."
 ---
 
 # Agent Team Orchestrator
@@ -493,5 +493,6 @@ Cue Suede:
 
 - A code lane needs review or a ship grade → **suede-code** (combined), **suede-code-review** (findings only), or **suede-code-grader** (grade only)
 - The repo's merge gate is weak or missing → **suede-ship-gate**
+- The work needs branch ownership, stale-mirror worktree setup, finish options, or cleanup discipline → **suede-git-hygiene** (private Suede Labs companion, not in this pack)
 - A lane ships AI behavior → **suede-ai-eval** before that lane's quality gate closes
 - The public launch lane needs a page verdict → **suede-visibility-grader**, then **suede-launch-packaging**

--- a/skills/suede-ship-gate/SKILL.md
+++ b/skills/suede-ship-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suede-ship-gate
-description: "Wire any repo so CI actually gates the merge — path-aware builds, one required check that can't deadlock, and branch protection that holds. Runs in any folder. Detects the stack, package managers, lockfiles, existing workflows, and deploy platform, then writes GitHub Actions that build only what changed. Use when adding CI, protecting main, fixing a duplicate or hanging pipeline, or auditing why a required check never passes. NOT FOR: reviewing or grading the code the pipeline runs on (use suede-code); designing AI eval cases (use suede-ai-eval, then wire them in here)."
+description: "Wire any repo so CI actually gates the merge: path-aware builds, one required check that can't deadlock, and branch protection that holds. Runs in any folder. Detects the stack, package managers, lockfiles, existing workflows, and deploy platform, then writes GitHub Actions that build only what changed. Use when adding CI, protecting main, fixing a duplicate or hanging pipeline, or auditing why a required check never passes. NOT FOR: reviewing or grading the code the pipeline runs on (use suede-code); designing AI eval cases (use suede-ai-eval, then wire them in here); Jason's private branch/worktree lifecycle, stale-mirror base selection, or finish/cleanup discipline (private Suede Labs companion, not in this pack: suede-git-hygiene)."
 ---
 
 # Suede Ship Gate
@@ -207,4 +207,5 @@ Generate; don't enforce. This skill writes workflow files and tells you the prot
 - The gate is failing on real defects → **suede-code** to review and grade the change
 - AI features need eval jobs in the pipeline → **suede-ai-eval** to design the cases, then wire them in here
 - Rollout needs flags, staged lanes, or a rollback tree → **suede-agent-teams**
+- Branch/worktree setup, stale local state, PR finish options, or cleanup discipline → **suede-git-hygiene** (private Suede Labs companion, not in this pack)
 - Gate holds and the release goes public → **suede-launch-packaging**


### PR DESCRIPTION
## Summary
- mark suede-git-hygiene as a private Suede Labs companion from agent-teams and ship-gate routes
- keep public users on shipped alternatives for orchestration and CI gates

## Verification
- node scripts/validate-skill-pack.mjs .