### PR TITLE
Route verification law companion

### DIFF
--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -406,3 +406,5 @@ Verify that threat mitigations declared in a threat model (ADR threat table, PLA
 - Verdict delivered; make CI enforce it on every merge → **suede-ship-gate**
 - The diff ships AI behavior with no eval coverage → **suede-ai-eval**
 - Fixes span multiple coordinated lanes → **suede-agent-teams**
+- Completion-claim law for saying a fix is done, live, merged, or ready →
+  private Suede Labs companion, not in this pack: suede-verification-law


### PR DESCRIPTION
## Summary
- add a private-companion route from suede-code to suede-verification-law

## Verification
- python3 /Users/jasoncolapietro/code/suede-personal-skills/suede-skill-forge/scripts/lint_skill_estate.py /Users/jasoncolapietro/code/suede-creator-skills
- node scripts/validate-skill-pack.mjs