### PR TITLE
Sweep stale 21/22 skill-count copy to 23

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "suede-skills",
-  "description": "Agent skills for Claude Code and Codex. Orchestrate multi-agent build lanes with quality gates and a signed handoff, spawn reviewed OpenAI Codex CLI worker fleets, run code review with an A-F ship grade, design AI evals, and ship public-facing work with the design, copy, SEO, and visibility lanes. Installs all 22 skills. Also includes a creator toolkit for music rights and release prep.",
+  "description": "Agent skills for Claude Code and Codex. Orchestrate multi-agent build lanes with quality gates and a signed handoff, spawn reviewed OpenAI Codex CLI worker fleets, run code review with an A-F ship grade, design AI evals, and ship public-facing work with the design, copy, SEO, and visibility lanes. Installs all 23 skills. Also includes a creator toolkit for music rights and release prep.",
   "author": {
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"

--- a/COPY.md
+++ b/COPY.md
@@ -77,7 +77,7 @@ Stop prompting your agent like it has amnesia.
 
 ### Subhead
 
-Install the 22-skill Suede pack that gives agents portable context: linked
+Install the 23-skill Suede pack that gives agents portable context: linked
 preferences, reference-site Suedify, GitHub Pages polish, sharper copy,
 SEO/AEO/AI EO, AI evals, visibility and CTA grades, A-F code review,
 coordinated agent teams, install-path checks, iOS/product checks, artist

--- a/PROMO.md
+++ b/PROMO.md
@@ -70,7 +70,7 @@ skill discovery, install guidance, SEO/AEO/AI EO copy audits, or QA checklists.
 - Use MCP only when the workflow benefits from a catalog, audit, or checklist.
 - A public skill pack for people who want AI agents to ship better work with fewer resets.
 - Agent workflows for people who care about public pages, repo quality, and claim boundaries.
-- Twenty-one public Suede skills, led by one design-forward umbrella workflow.
+- Twenty-two public Suede skills, led by one design-forward umbrella workflow.
 - Even the GitHub Pages site sells: polished docs, live catalog, install paths, copy bank, schema, sitemap, OG metadata, and mobile QA.
 - Grade a website's visibility, CTA, trust, AI readability, and design signal before calling it done.
 - Get A-F Suede code grades for correctness, security, state, tests, deployment risk, and docs.
@@ -279,7 +279,7 @@ Suede Creator Skills: public Codex and Claude Code skills plus MCP tools for Sue
 ## GitHub README Intro
 
 ```text
-Suede Creator Skills is a public 22-skill agent workflow pack for builders, designers, agencies, creators, and operators. It includes Johnny Suede Write, Johnny Suede Design, mobile and product surface support, Suedify reference-site restyling, design direction, copywriting, supplied-company voice support, SEO/AEO/AI EO audits, AI eval design, visibility and CTA grading, A-F code grading, agent teams, Codex CLI worker fleets, launch packaging, MCP QA, artist campaign tools, and creator utilities.
+Suede Creator Skills is a public 23-skill agent workflow pack for builders, designers, agencies, creators, and operators. It includes Johnny Suede Write, Johnny Suede Design, mobile and product surface support, Suedify reference-site restyling, design direction, copywriting, supplied-company voice support, SEO/AEO/AI EO audits, AI eval design, visibility and CTA grading, A-F code grading, agent teams, Codex CLI worker fleets, launch packaging, MCP QA, artist campaign tools, and creator utilities.
 
 Use the skills directly for normal work. Use MCP only when the task benefits from structured lookup, audit scaffolding, install guidance, grading scaffolds, or repeatable QA.
 ```

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="./assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Suede Creator Skills Copy Bank">
-  <meta property="og:description" content="Use this copy when explaining Suede Creator Skills: 22 agent skills for Claude Code and Codex covering Suedify, agent teams, code review, AEO/GEO/AI EO, and creator workflows.">
+  <meta property="og:description" content="Use this copy when explaining Suede Creator Skills: 23 agent skills for Claude Code and Codex covering Suedify, agent teams, code review, AEO/GEO/AI EO, and creator workflows.">
   <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/copy.html">
   <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
   <meta name="twitter:card" content="summary_large_image">
@@ -211,7 +211,7 @@
         <h3>Repo copy</h3>
         <div class="copy-block">
           <b>One-line description</b>
-          <p>A 22-skill, MIT-licensed pack for Claude Code and Codex: orchestrate multi-agent build lanes with quality gates, run code review with a blunt A-F ship grade, wire CI ship-gates, design measurable AI evals, Suedify a site from a reference URL, and ship public work with the design, copy, and SEO lanes.</p>
+          <p>A 23-skill, MIT-licensed pack for Claude Code and Codex: orchestrate multi-agent build lanes with quality gates, run code review with a blunt A-F ship grade, wire CI ship-gates, design measurable AI evals, Suedify a site from a reference URL, and ship public work with the design, copy, and SEO lanes.</p>
         </div>
         <div class="copy-block">
           <b>Full description</b>
@@ -234,7 +234,7 @@
         </div>
         <div class="copy-block">
           <b>Subhead</b>
-          <p>Twenty-two public skills your agent loads as one portable workflow: linked preferences, Suedify a target page from a reference URL, rewrite the offer, audit SEO/AEO/AI EO, polish GitHub Pages, grade visibility and code, design AI evals, run coordinated agent-team QA, or package creator campaign and rights evidence.</p>
+          <p>Twenty-three public skills your agent loads as one portable workflow: linked preferences, Suedify a target page from a reference URL, rewrite the offer, audit SEO/AEO/AI EO, polish GitHub Pages, grade visibility and code, design AI evals, run coordinated agent-team QA, or package creator campaign and rights evidence.</p>
         </div>
         <div class="copy-block">
           <b>Proof line</b>

--- a/docs/dav/index.html
+++ b/docs/dav/index.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex, nofollow">
   <title>Suede Creator Skills | DAV Michelangelo</title>
-  <meta name="description" content="Install 22 public Codex and Claude skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
+  <meta name="description" content="Install 23 public Codex and Claude skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills | DAV Michelangelo">
-  <meta property="og:description" content="22 public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
+  <meta property="og:description" content="23 public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
   <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
   <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/dav/">
   <meta property="og:site_name" content="Suede Creator Skills">
@@ -18,7 +18,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills | DAV Michelangelo">
-  <meta name="twitter:description" content="22 public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
+  <meta name="twitter:description" content="23 public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
   <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
 
   <!-- Canonical -->
@@ -36,7 +36,7 @@
     "@context": "https://schema.org",
     "@type": "SoftwareSourceCode",
     "name": "Suede Creator Skills | DAV Michelangelo",
-    "description": "A 22-skill public workflow for Codex and Claude Code covering Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, creator campaigns, and rights utilities.",
+    "description": "A 23-skill public workflow for Codex and Claude Code covering Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, creator campaigns, and rights utilities.",
     "url": "https://jasoncolapietro.github.io/suede-creator-skills/dav/",
     "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
     "programmingLanguage": ["TypeScript", "Swift", "Python"],
@@ -1523,7 +1523,7 @@
 
     <h1 id="hero-headline">Give your agent a product team <br>in one install.</h1>
 
-    <p id="hero-subline">Twenty-two public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.</p>
+    <p id="hero-subline">Twenty-three public skills for Suedify, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.</p>
 
     <div id="hero-proof">
       <span class="hero-proof-line">Open-source GitHub Pages docs generated from this repo</span>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -3,10 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Suede Creator Skills Guide | 22 Agent Skills for Claude Code & Codex</title>
+    <title>Suede Creator Skills Guide | 23 Agent Skills for Claude Code & Codex</title>
     <meta
       name="description"
-      content="The full guide to 22 MIT-licensed agent skills for Claude Code and Codex: orchestration, code review with A-F ship grades, CI ship-gates, AI evals, design, copy, SEO, and creator tools."
+      content="The full guide to 23 MIT-licensed agent skills for Claude Code and Codex: orchestration, code review with A-F ship grades, CI ship-gates, AI evals, design, copy, SEO, and creator tools."
     >
     <meta name="author" content="Jason Colapietro">
     <meta name="publisher" content="Suede Labs AI">
@@ -19,8 +19,8 @@
     <link rel="preload" as="image" href="./assets/passport-hero.webp" type="image/webp">
     <link rel="image_src" href="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Suede Creator Skills Guide | 22 Agent Skills for Claude Code & Codex">
-    <meta property="og:description" content="The full guide to 22 MIT-licensed agent skills for Claude Code and Codex: orchestration, code review with A-F ship grades, CI ship-gates, AI evals, design, copy, SEO, and creator tools.">
+    <meta property="og:title" content="Suede Creator Skills Guide | 23 Agent Skills for Claude Code & Codex">
+    <meta property="og:description" content="The full guide to 23 MIT-licensed agent skills for Claude Code and Codex: orchestration, code review with A-F ship grades, CI ship-gates, AI evals, design, copy, SEO, and creator tools.">
     <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/">
     <meta property="og:site_name" content="Suede Creator Skills">
     <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
@@ -33,7 +33,7 @@
     <meta name="twitter:site" content="@johnnysuede">
     <meta name="twitter:creator" content="@johnnysuede">
     <meta name="twitter:title" content="Suede Creator Skills">
-    <meta name="twitter:description" content="22 MIT-licensed agent skills for Claude Code and Codex: orchestration, A-F code review, CI ship-gates, AI evals, design, copy, SEO, and creator tools.">
+    <meta name="twitter:description" content="23 MIT-licensed agent skills for Claude Code and Codex: orchestration, A-F code review, CI ship-gates, AI evals, design, copy, SEO, and creator tools.">
     <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
     <meta name="twitter:image:alt" content="Suede Creator Skills - Codex and Claude skills for Suedify, design, copywriting, SEO/AEO/AI EO, and QA.">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
@@ -67,8 +67,8 @@
             "@type": "WebPage",
             "@id": "https://jasoncolapietro.github.io/suede-creator-skills/guide.html#webpage",
             "url": "https://jasoncolapietro.github.io/suede-creator-skills/guide.html",
-            "name": "Suede Creator Skills Guide | 22 Agent Skills for Claude Code & Codex",
-            "description": "The full guide to 22 MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with A-F ship grades, CI ship-gates, AI evals, Suedify restyling, design, conversion copy, SEO/AEO/AI EO audits, visibility grading, launch packaging, and a creator toolkit.",
+            "name": "Suede Creator Skills Guide | 23 Agent Skills for Claude Code & Codex",
+            "description": "The full guide to 23 MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with A-F ship grades, CI ship-gates, AI evals, Suedify restyling, design, conversion copy, SEO/AEO/AI EO audits, visibility grading, launch packaging, and a creator toolkit.",
             "isPartOf": {
               "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website"
             },
@@ -1122,7 +1122,7 @@
               </ul>
             </div>
             <div class="metric-grid" aria-label="Suede Creator Skills summary">
-              <div class="metric"><b>21</b><span>public skills</span></div>
+              <div class="metric"><b>23</b><span>public skills</span></div>
               <div class="metric"><b>0</b><span>uploads by default</span></div>
               <div class="metric"><b>7</b><span>MCP tools included</span></div>
               <div class="metric"><b>MIT</b><span>license</span></div>
@@ -1140,7 +1140,7 @@
       <section id="skills">
         <div class="shell">
           <span class="section-kicker">What installs</span>
-          <h2>Twenty-two skills, one portable operating system for agent work.</h2>
+          <h2>Twenty-three skills, one portable operating system for agent work.</h2>
           <p class="section-lead">
             The pack leads with coordinated agent teams, code review and A-F grading, CI ship-gates, AI evals, Suedify, design,
             conversion copy, SEO/AEO/GEO/AI EO, visibility grading, site alchemy, launch packaging, and MCP QA,

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Suede Creator Skills | 22 Open-Source Agent Skills for Claude Code & Codex</title>
+  <title>Suede Creator Skills | 23 Open-Source Agent Skills for Claude Code & Codex</title>
   <meta name="description" content="Install 23 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO. One-command install.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Suede Creator Skills | 22 Open-Source Agent Skills for Claude Code & Codex">
+  <meta property="og:title" content="Suede Creator Skills | 23 Open-Source Agent Skills for Claude Code & Codex">
   <meta property="og:description" content="Install 23 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO.">
   <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
   <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/">
@@ -16,7 +16,7 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Suede Creator Skills | 22 Open-Source Agent Skills for Claude Code & Codex">
+  <meta name="twitter:title" content="Suede Creator Skills | 23 Open-Source Agent Skills for Claude Code & Codex">
   <meta name="twitter:description" content="Install 23 free MIT-licensed agent skills for Claude Code and Codex: multi-agent orchestration, code review with an A-F ship grade, CI ship-gates, AI evals, and design, copy, and SEO.">
   <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
 
@@ -73,7 +73,7 @@
         "@type": "ItemList",
         "name": "Suede Creator Skills catalog",
         "description": "The 23 public skills in the Suede Creator Skills pack.",
-        "numberOfItems": 22,
+        "numberOfItems": 23,
         "itemListElement": [
           { "@type": "ListItem", "position": 1, "name": "Suede Workflow Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html" },
           { "@type": "ListItem", "position": 2, "name": "Johnny Suede Write", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html" },
@@ -96,7 +96,8 @@
           { "@type": "ListItem", "position": 19, "name": "Suede Campaign in a Box", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html" },
           { "@type": "ListItem", "position": 20, "name": "Suede Rights Audit", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html" },
           { "@type": "ListItem", "position": 21, "name": "Suede Sync Packaging", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html" },
-          { "@type": "ListItem", "position": 22, "name": "Suede Fable Fleet", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html" }
+          { "@type": "ListItem", "position": 22, "name": "Suede Fable Fleet", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html" },
+          { "@type": "ListItem", "position": 23, "name": "Site to iOS App", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html" }
         ]
       },
       {

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -253,7 +253,7 @@
   <div class="shell page-head">
     <p class="eyebrow">Public installs and MCP</p>
     <h1>Install Suede once. Stop rebuilding the agent brief.</h1>
-    <p class="lead">Twenty-two public skills your agent can load as one workflow. Install the umbrella to Suedify a target page from a reference URL, rewrite copy, grade visibility, review code A-F, design AI evals, coordinate agent teams, or package creator campaign and rights evidence. Use MCP when the agent needs structured discovery, install options, audit scaffolds, or QA checklists.</p>
+    <p class="lead">Twenty-three public skills your agent can load as one workflow. Install the umbrella to Suedify a target page from a reference URL, rewrite copy, grade visibility, review code A-F, design AI evals, coordinate agent teams, or package creator campaign and rights evidence. Use MCP when the agent needs structured discovery, install options, audit scaffolds, or QA checklists.</p>
   </div>
 
   <section class="shell" id="claude-code">

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -4,19 +4,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Suede Workflow Skills | The Umbrella Skill for the Suede Pack</title>
-    <meta name="description" content="Install the umbrella Suede Workflow Skill: one install routes the agent across all 22 skills, from agent teams, Codex CLI worker fleets, code review, CI ship-gates, and AI evals to Suedify, design, copy, SEO/AEO/GEO/AI EO, and the creator toolkit.">
+    <meta name="description" content="Install the umbrella Suede Workflow Skill: one install routes the agent across all 23 skills, from agent teams, Codex CLI worker fleets, code review, CI ship-gates, and AI evals to Suedify, design, copy, SEO/AEO/GEO/AI EO, and the creator toolkit.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
     <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Workflow Skills">
-    <meta property="og:description" content="Public Suede umbrella skill for 22 installable skills across portable preferences, Johnny Suede modes, mobile and product surfaces, Suedify, GitHub Pages polish, design, copywriting, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, code review, QA, agent teams, Codex CLI worker fleets, music/IP, artist campaigns, and creator utilities.">
+    <meta property="og:description" content="Public Suede umbrella skill for 23 installable skills across portable preferences, Johnny Suede modes, mobile and product surfaces, Suedify, GitHub Pages polish, design, copywriting, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, code review, QA, agent teams, Codex CLI worker fleets, music/IP, artist campaigns, and creator utilities.">
     <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html">
     <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Workflow Skills">
-    <meta name="twitter:description" content="Install the public Suede umbrella workflow skill for 22 public Johnny Suede, portable context, mobile product, Suedify, GitHub Pages polish, design, copywriting, AI eval, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, QA, agent teams, Codex CLI worker fleets, music/IP, and creator skills.">
+    <meta name="twitter:description" content="Install the public Suede umbrella workflow skill for 23 public Johnny Suede, portable context, mobile product, Suedify, GitHub Pages polish, design, copywriting, AI eval, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, QA, agent teams, Codex CLI worker fleets, music/IP, and creator skills.">
     <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png">
     <script type="application/ld+json">
       {
@@ -24,7 +24,7 @@
         "@type": "TechArticle",
         "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html#article",
         "headline": "Suede Workflow Skills",
-        "description": "Install Suede Workflow Skills from GitHub as the umbrella entry point for 22 public Suede skill folders across portable preferences, Johnny Suede Write, Johnny Suede Design, mobile and product surfaces, Suedify, GitHub Pages polish, design, copywriting, AI evals, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, QA, coordinated agent teams, Codex CLI worker fleets, CI ship-gates, music/IP, artist campaigns, and creator utilities.",
+        "description": "Install Suede Workflow Skills from GitHub as the umbrella entry point for 23 public Suede skill folders across portable preferences, Johnny Suede Write, Johnny Suede Design, mobile and product surfaces, Suedify, GitHub Pages polish, design, copywriting, AI evals, visibility grading, code grading, Suede SEO/AEO/GEO/AI EO, QA, coordinated agent teams, Codex CLI worker fleets, CI ship-gates, music/IP, artist campaigns, and creator utilities.",
         "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html",
         "author": {
           "@type": "Person",
@@ -218,7 +218,7 @@
     <main class="shell">
       <div class="eyebrow">Public umbrella skill</div>
       <h1>Suede Workflow Skills.</h1>
-      <p class="lead">Install one public GitHub skill to route the agent across all 22 Suede skills: Johnny Suede Write, Johnny Suede Design, Suedify, coordinated agent teams, Codex CLI worker fleets, full code review, A-F code grading, CI ship-gates, AI evals, anti-slop copywriting, visual QA, visibility and CTA grading, schema-level Suede SEO/AEO/GEO/AI EO, site polish, launch packaging, MCP QA, plus music/IP tools, artist campaign tools, and creator utilities.</p>
+      <p class="lead">Install one public GitHub skill to route the agent across all 23 Suede skills: Johnny Suede Write, Johnny Suede Design, Suedify, coordinated agent teams, Codex CLI worker fleets, full code review, A-F code grading, CI ship-gates, AI evals, anti-slop copywriting, visual QA, visibility and CTA grading, schema-level Suede SEO/AEO/GEO/AI EO, site polish, launch packaging, MCP QA, plus music/IP tools, artist campaign tools, and creator utilities.</p>
       <p><a class="button" href="../plugins.html">Install the public skill</a> <a class="button secondary" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-workflow-skills">View skill folder</a></p>
 
       <section class="panel">
@@ -291,7 +291,7 @@
       </section>
 
       <section class="panel">
-        <h2>All 22 public skill folders</h2>
+        <h2>All 23 public skill folders</h2>
         <div class="links">
           <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-workflow-skills/SKILL.md"><b>suede-workflow-skills</b><span>Public umbrella entry point for the full Suede workflow pack.</span></a>
           <a class="link-row" href="johnny-suede-write.html"><b>johnny-suede-write</b><span>Full writing mode for copy, company voice, product and mobile copy, SEO/AEO/AI EO, CTAs, launch copy, variants, and anti-slop editing.</span></a>
@@ -315,6 +315,7 @@
           <a class="link-row" href="suede-release-linter.html"><b>suede-release-linter</b><span>Release metadata, files, credits, splits, sample status, provenance, and readiness blockers.</span></a>
           <a class="link-row" href="suede-rights-passport.html"><b>suede-rights-passport</b><span>Transfer package with provenance, credits, split notes, license notes, intake JSON, and missing-info reports.</span></a>
           <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-rights-audit"><b>suede-rights-audit</b><span>Ownership, contributor, split, sample, license, and intake gap audit.</span></a>
+          <a class="link-row" href="site-to-ios-app.html"><b>site-to-ios-app</b><span>URL audit, App Store 4.2 wrapper-risk checks, Capacitor or native-shell strategy, and iOS build scaffolding for turning a site into an app.</span></a>
         </div>
       </section>
 

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -84,7 +84,7 @@
     {
       "name": "suede-workflow-skills",
       "area": "workflow",
-      "description": "Umbrella workflow for 22 public skills — johnny-suede-write, johnny-suede-design, suede-code, suede-code-review, suede-code-grader, suede-copy, suede-design, suede-agent-teams, suede-codex-fleet, suede-ai-eval, suede-ship-gate, suede-seo-audit, suede-visibility-grader, suede-site-alchemy, suede-launch-packaging, suede-mcp-qa, site-to-ios-app, and five creator skills (suede-campaign-in-a-box, suede-sync-packaging, suede-release-linter, suede-rights-passport, suede-rights-audit). Use when a user asks to load the full Suede workflow pack, improve a site, write Suede copy, audit SEO/AEO/AI EO, run AI evals, run design QA, review code with a CI gate, prepare public docs, or package an artist campaign.",
+      "description": "Umbrella workflow for 23 public skills — johnny-suede-write, johnny-suede-design, suede-code, suede-code-review, suede-code-grader, suede-copy, suede-design, suede-agent-teams, suede-codex-fleet, suede-ai-eval, suede-ship-gate, suede-seo-audit, suede-visibility-grader, suede-site-alchemy, suede-launch-packaging, suede-mcp-qa, site-to-ios-app, and five creator skills (suede-campaign-in-a-box, suede-sync-packaging, suede-release-linter, suede-rights-passport, suede-rights-audit). Use when a user asks to load the full Suede workflow pack, improve a site, write Suede copy, audit SEO/AEO/AI EO, run AI evals, run design QA, review code with a CI gate, prepare public docs, or package an artist campaign.",
       "useWhen": "Use when a user wants the full Suede workflow pack loaded from one public GitHub skill path with no-missed quality gates."
     },
     {

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -392,6 +392,79 @@ if (docsCountMatch) {
   fail.push("docs/index.html: could not find skill count (expected pattern: Install N public/free ...)");
 }
 
+// Count-drift guard: every public-facing surface that states the pack size
+// in prose, metadata, or schema must agree with the real skills/ directory.
+// This is the guard the 2026-07-05 audit found missing — a published skill
+// went in without a matching sweep of titles, OG/Twitter tags, JSON-LD, the
+// plugin manifest, the umbrella skill's own docs, and the copy bank.
+const totalSkillCount = skillNames.length;
+const companionSkillCount = totalSkillCount - 1; // total minus suede-workflow-skills itself
+const numberWords = { one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9 };
+
+function wordNumberAfterTwenty(word) {
+  const n = numberWords[word.toLowerCase()];
+  return n === undefined ? null : 20 + n;
+}
+
+const countChecks = [
+  { file: "docs/index.html", label: "title tag", re: /<title>Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "og:title", re: /property="og:title" content="Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "twitter:title", re: /name="twitter:title" content="Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "JSON-LD numberOfItems", re: /"numberOfItems":\s*(\d+)/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "title tag", re: /<title>Suede Creator Skills Guide \| (\d+) Agent Skills/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "public skills metric", re: /<div class="metric"><b>(\d+)<\/b><span>public skills<\/span><\/div>/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "h2 heading", re: /<h2>Twenty-(\w+) skills, one portable/, expected: totalSkillCount, wordNumber: true },
+  { file: "docs/copy.html", label: "og:description agent skills count", re: /og:description" content="Use this copy when explaining Suede Creator Skills: (\d+) agent skills/, expected: totalSkillCount },
+  { file: "docs/copy.html", label: "N-skill pack copy block", re: /A (\d+)-skill, MIT-licensed pack/, expected: totalSkillCount },
+  { file: "docs/copy.html", label: "Twenty-N public skills paragraph", re: /Twenty-(\w+) public skills your agent loads/, expected: totalSkillCount, wordNumber: true },
+  { file: "docs/plugins.html", label: "lead paragraph", re: /Twenty-(\w+) public skills your agent can load/, expected: totalSkillCount, wordNumber: true },
+  { file: "docs/dav/index.html", label: "meta description", re: /Install (\d+) public Codex and Claude skills/, expected: totalSkillCount },
+  { file: "docs/dav/index.html", label: "og:description", re: /property="og:description" content="(\d+) public skills for Suedify/, expected: totalSkillCount },
+  { file: "docs/dav/index.html", label: "twitter:description", re: /name="twitter:description" content="(\d+) public skills for Suedify/, expected: totalSkillCount },
+  { file: "docs/dav/index.html", label: "JSON-LD description", re: /"description":\s*"A (\d+)-skill public workflow/, expected: totalSkillCount },
+  { file: "docs/dav/index.html", label: "hero-subline", re: /Twenty-(\w+) public skills for Suedify/, expected: totalSkillCount, wordNumber: true },
+  { file: "docs/skills/suede-workflow-skills.html", label: "meta description", re: /routes the agent across all (\d+) skills/, expected: totalSkillCount },
+  { file: "docs/skills/suede-workflow-skills.html", label: "og:description", re: /Public Suede umbrella skill for (\d+) installable skills/, expected: totalSkillCount },
+  { file: "docs/skills/suede-workflow-skills.html", label: "twitter:description", re: /umbrella workflow skill for (\d+) public Johnny Suede/, expected: totalSkillCount },
+  { file: "docs/skills/suede-workflow-skills.html", label: "JSON-LD description", re: /umbrella entry point for (\d+) public Suede skill folders/, expected: totalSkillCount },
+  { file: "docs/skills/suede-workflow-skills.html", label: "lead paragraph", re: /route the agent across all (\d+) Suede skills/, expected: totalSkillCount },
+  { file: "docs/skills/suede-workflow-skills.html", label: "folders heading", re: /<h2>All (\d+) public skill folders<\/h2>/, expected: totalSkillCount },
+  { file: ".claude-plugin/plugin.json", label: "description", re: /Installs all (\d+) skills/, expected: totalSkillCount },
+  { file: "mcp/catalog.json", label: "umbrella description", re: /Umbrella workflow for (\d+) public skills/, expected: totalSkillCount },
+  { file: "skills/suede-workflow-skills/SKILL.md", label: "frontmatter description", re: /Umbrella workflow for (\d+) public skills/, expected: totalSkillCount },
+  { file: "skills/suede-workflow-skills/agents/openai.yaml", label: "short_description", re: /Umbrella workflow across (\d+) public skills/, expected: totalSkillCount },
+  { file: "COPY.md", label: "subhead", re: /Install the (\d+)-skill Suede pack/, expected: totalSkillCount },
+  { file: "PROMO.md", label: "companion skill count", re: /Twenty-(\w+) public Suede skills, led by one/, expected: companionSkillCount, wordNumber: true },
+  { file: "PROMO.md", label: "README intro pack size", re: /public (\d+)-skill agent workflow pack/, expected: totalSkillCount },
+];
+
+for (const check of countChecks) {
+  const filePath = path.join(repoRoot, check.file);
+  if (!fs.existsSync(filePath)) {
+    warn.push(`Count check skipped — ${check.file} does not exist (${check.label})`);
+    continue;
+  }
+  const text = readText(filePath);
+  const match = text.match(check.re);
+  if (!match) {
+    warn.push(`Count check pattern not found in ${check.file} (${check.label}) — copy may have moved; update scripts/validate-skill-pack.mjs`);
+    continue;
+  }
+  const found = check.wordNumber ? wordNumberAfterTwenty(match[1]) : parseInt(match[1], 10);
+  if (found === null || Number.isNaN(found)) {
+    warn.push(`Count check could not parse a number in ${check.file} (${check.label}): "${match[1]}"`);
+    continue;
+  }
+  if (found !== check.expected) {
+    fail.push(`Stale skill count in ${check.file} (${check.label}): says ${found}, expected ${check.expected}`);
+  }
+}
+
+const indexJsonLdItemMatches = docsRootText.match(/"@type":\s*"ListItem"/g) || [];
+if (indexJsonLdItemMatches.length !== totalSkillCount) {
+  fail.push(`docs/index.html JSON-LD ItemList has ${indexJsonLdItemMatches.length} entries, expected ${totalSkillCount}`);
+}
+
 if (fail.length || warn.length) {
   if (warn.length) {
     console.error("Warnings:");

--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -187,6 +187,12 @@ snippets against its own regexes and real frontmatter from this repo before
 writing the finding below. Depth: `--standard`. This is what the Output
 Shape looks like filled in, not a template.
 
+**Historical snapshot:** the pack had 21 public skills when this example was
+written; the counts and named skills below (21, "16 of 21") are frozen
+evidence from that run, not a claim about the current pack size. The finding
+itself — the regex only catching the first `(use X)` target per `NOT FOR`
+line — is still live regardless of pack size.
+
 **Simple explanation (plain, for a 10-year-old):** This robot checks that
 every skill folder has its paperwork in order before anything ships. It
 works, and running it right now says everything currently passes. But the

--- a/skills/suede-workflow-skills/SKILL.md
+++ b/skills/suede-workflow-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: suede-workflow-skills
-description: "Umbrella workflow for 22 public skills — johnny-suede-write, johnny-suede-design, suede-code, suede-code-review, suede-code-grader, suede-copy, suede-design, suede-agent-teams, suede-codex-fleet, suede-ai-eval, suede-ship-gate, suede-seo-audit, suede-visibility-grader, suede-site-alchemy, suede-launch-packaging, suede-mcp-qa, site-to-ios-app, and five creator skills (suede-campaign-in-a-box, suede-sync-packaging, suede-release-linter, suede-rights-passport, suede-rights-audit). Use when a user asks to load the full Suede workflow pack, improve a site, write Suede copy, audit SEO/AEO/AI EO, run AI evals, run design QA, review code with a CI gate, prepare public docs, or package an artist campaign."
+description: "Umbrella workflow for 23 public skills — johnny-suede-write, johnny-suede-design, suede-code, suede-code-review, suede-code-grader, suede-copy, suede-design, suede-agent-teams, suede-codex-fleet, suede-ai-eval, suede-ship-gate, suede-seo-audit, suede-visibility-grader, suede-site-alchemy, suede-launch-packaging, suede-mcp-qa, site-to-ios-app, and five creator skills (suede-campaign-in-a-box, suede-sync-packaging, suede-release-linter, suede-rights-passport, suede-rights-audit). Use when a user asks to load the full Suede workflow pack, improve a site, write Suede copy, audit SEO/AEO/AI EO, run AI evals, run design QA, review code with a CI gate, prepare public docs, or package an artist campaign."
 ---
 
 # Suede Workflow Skills

--- a/skills/suede-workflow-skills/agents/openai.yaml
+++ b/skills/suede-workflow-skills/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Suede Workflow Skills"
-  short_description: "Umbrella workflow across 21 public skills"
+  short_description: "Umbrella workflow across 23 public skills"
   default_prompt: "Use $suede-workflow-skills for Johnny Suede writing/design modes, mobile and product surfaces, Suedify reference-site restyling, copywriting, Suede SEO/AEO/AI EO, docs, code review, max-agent team loops, QA, artist campaigns, rights utilities, or launch surfaces. Preserve existing Suede features and apply the no-missed quality gates. Use MCP only if it helps."
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
- Sweeps stale `21`/`22` skill-count copy across titles, OG/Twitter tags, JSON-LD schema, the plugin manifest, the umbrella skill's docs and metadata, and the copy bank (`COPY.md`, `PROMO.md`) — brings everything to `23` following the `site-to-ios-app` publish.
- Fills a real gap, not just a label: `docs/index.html`'s JSON-LD `ItemList` and the `suede-workflow-skills` folder-listing page were both missing a `site-to-ios-app` entry entirely.
- Leaves the one genuinely historical `21`-skill reference in `skills/suede-code/SKILL.md`'s worked example untouched, but labels it as a frozen snapshot so it doesn't read as current package evidence.
- Adds a count-drift guard to `scripts/validate-skill-pack.mjs` covering every location swept here, so a future skill publish fails loudly instead of drifting again.

## Test plan
- [x] `npm install --ignore-scripts && node scripts/validate-skill-pack.mjs` → `Validated 23 skills against 23 catalog entries.` with zero warnings/failures
- [x] `lint_skill_estate.py` against this checkout → `result: OK`, zero dangling refs/missing assets
- [x] `qa_skill_estate.py --public` against this checkout → `result: OK` across all checks including `stale_estate_docs`