### PR TITLE
Fix artist MCP profile and classify_file ancestor-path leakage

### DIFF
--- a/mcp/suede-skills-mcp.mjs
+++ b/mcp/suede-skills-mcp.mjs
@@ -31,7 +31,7 @@ function boundedString(value, fallback = "") {
 
 function profileCatalog() {
   if (profile === "workflow" || profile === "artist" || profile === "creator") {
-    const areaSet = profile === "creator" ? new Set(["artist", "creator"]) : new Set([profile]);
+    const areaSet = profile === "creator" || profile === "artist" ? new Set(["artist", "creator"]) : new Set([profile]);
     return {
       ...catalog,
       plugins: catalog.plugins.filter((plugin) =>
@@ -492,7 +492,9 @@ function callTool(name, args = {}) {
   const data = profileCatalog();
   if (name === "list_suede_skills") {
     const area = args.area || (profile === "creator" ? "all" : profile);
-    const scoped = area === "all" ? data.skills : data.skills.filter((skill) => skill.area === area);
+    const scoped = area === "all"
+      ? data.skills
+      : data.skills.filter((skill) => (area === "artist" ? skill.area === "artist" || skill.area === "creator" : skill.area === area));
     return {
       content: [text(asMarkdownSkillList({ skills: scoped }))],
       structuredContent: { skills: scoped }

--- a/skills/suede-release-linter/scripts/lint_release.py
+++ b/skills/suede-release-linter/scripts/lint_release.py
@@ -237,10 +237,14 @@ def nested(data: dict[str, Any], key: str, default: Any = None) -> Any:
     return value if value not in (None, "") else default
 
 
-def classify_file(path: Path) -> tuple[str, str]:
+def classify_file(path: Path, source: Path) -> tuple[str, str]:
     ext = path.suffix.lower()
     name = path.name.lower()
-    context = "/".join(part.lower() for part in path.parts)
+    try:
+        context_parts = path.relative_to(source).parts
+    except ValueError:
+        context_parts = (path.name,)
+    context = "/".join(part.lower() for part in context_parts)
 
     if ext in AUDIO_EXTS:
         if any(keyword in context for keyword in STEM_KEYWORDS) and "master" not in context and "final" not in context:
@@ -341,7 +345,7 @@ def inventory_files(source: Path, output: Path, include_hidden: bool, include_ot
             continue
         if not include_hidden and is_hidden_path(path, source):
             continue
-        category, role = classify_file(path)
+        category, role = classify_file(path, source)
         if category == "other" and not include_other:
             continue
         assets.append(

--- a/skills/suede-rights-passport/scripts/create_transfer_package.py
+++ b/skills/suede-rights-passport/scripts/create_transfer_package.py
@@ -372,9 +372,13 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def classify_file(path: Path) -> tuple[str, str]:
+def classify_file(path: Path, source: Path) -> tuple[str, str]:
     name = path.name.lower()
-    context = "/".join(part.lower() for part in path.parts)
+    try:
+        context_parts = path.relative_to(source).parts
+    except ValueError:
+        context_parts = (path.name,)
+    context = "/".join(part.lower() for part in context_parts)
     ext = path.suffix.lower()
 
     if ext in AUDIO_EXTS:
@@ -459,7 +463,7 @@ def discover_assets(
         if not include_hidden and is_hidden_path(path, source):
             continue
 
-        category, role = classify_file(path)
+        category, role = classify_file(path, source)
         if category == "other" and not include_other:
             continue
         rel_source = path.relative_to(source).as_posix()


### PR DESCRIPTION
## Summary
- `mcp/suede-skills-mcp.mjs`: the `artist` profile (and `area: "artist"` argument on `list_suede_skills`) always returned zero skills because no catalog skill is tagged `area: "artist"` — only `workflow` and `creator`. Map `artist` onto the creator-tagged skills in both `profileCatalog()` and the `list_suede_skills` tool handler, matching the existing `suede-creator-skills` plugin special-case already in `profileCatalog()`.
- `skills/suede-release-linter/scripts/lint_release.py` and `skills/suede-rights-passport/scripts/create_transfer_package.py`: `classify_file()` built its keyword-matching context from the full absolute filesystem path, so unrelated ancestor directory names above the inventoried project (e.g. a parent folder named "Master Sessions") could misclassify assets as masters/stems/mixes. Context is now built from the path relative to the `source` folder being linted/packaged.

## Test plan
- [x] `node --check mcp/suede-skills-mcp.mjs`
- [x] `python3 -m py_compile` on both edited Python scripts
- [x] `node scripts/validate-skill-pack.mjs` — 23/23 skills validate clean
- [x] Ran the MCP server directly with `--profile artist`; `resources/read suede://catalog` and `tools/call list_suede_skills {"area":"artist"}` both now return the 5 creator-tagged skills instead of an empty list
- [x] Reproduced the ancestor-path bug (`.../Master Sessions/MyProject/raw/verse_take2.wav`) against both fixed `classify_file()` implementations — now correctly returns `('audio', 'audio')` instead of `('audio', 'master')`
- [x] End-to-end smoke run of `lint_release.py` and `create_transfer_package.py` against a sample project folder — both complete successfully