### PR TITLE
Add optional Hermes first run to Suede SEO Audit

### DIFF
--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -310,6 +310,12 @@ cp -R /tmp/suede-creator-skills/skills/suede-seo-audit .claude/skills/</code></p
     --path skills/suede-seo-audit</code></pre>
       </section>
 
+      <section class="panel">
+        <h2>Optional first run in Hermes</h2>
+        <p>The repository's Claude Code, project-level copy, Codex, and <a href="../plugins.html#mcp">MCP</a> routes remain the primary ways to use this skill.</p>
+        <p>Want to try the audit before installing? <a href="https://app.clawmama.run/skills/yecnyj/hermes" target="_blank" rel="noopener noreferrer">Run Suede SEO Audit in Hermes with ClawMama</a>.</p>
+      </section>
+
       <section class="grid">
         <article class="card">
           <h2>What it covers</h2>


### PR DESCRIPTION
## Summary

- add an optional Hermes/ClawMama first-run link to the `suede-seo-audit` public page
- keep Claude Code, project-copy, Codex, and MCP routes primary and ahead of the optional path

## Validation

- `node scripts/validate-skill-pack.mjs` (`27/27`)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -p 'test_*.py'` (`15` passed)
- `git diff --check`
- exact ClawMama Hermes URL returned first-hop HTTP 200

Closes #12
