### PR TITLE
Fix changelog validation in packaged plugin caches

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   "scripts": {
     "validate": "node scripts/validate-skill-pack.mjs --strict && node scripts/validate-trigger-routing.mjs",
     "test:mcp": "node --test tests/test_mcp_protocol.mjs",
+    "test:validator-runtime": "node --test tests/test_validator_runtime.mjs",
     "test:triggers": "node --test tests/test_trigger_routing.mjs",
     "test:python": "python3 -m unittest discover -s tests -p 'test_*.py' -v",
-    "test": "npm run validate && npm run test:mcp && npm run test:triggers && npm run test:python",
+    "test": "npm run validate && npm run test:validator-runtime && npm run test:mcp && npm run test:triggers && npm run test:python",
     "audit:dependencies": "npm audit --omit=dev --audit-level=high",
     "ci": "node --check mcp/suede-skills-mcp.mjs && node --check scripts/validate-skill-pack.mjs && npm run test"
   },

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -52,6 +52,35 @@ const PUBLIC_TEXT_EXTENSIONS = new Set([
   ".zsh",
 ]);
 
+function inspectGitHistory(root) {
+  if (!fs.existsSync(path.join(root, ".git"))) {
+    return { state: "packaged" };
+  }
+
+  const topLevelProbe = spawnSync("git", ["-C", root, "rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  if (topLevelProbe.error || topLevelProbe.status !== 0) {
+    return { state: "error", detail: topLevelProbe.error?.code || `git rev-parse exited ${topLevelProbe.status}` };
+  }
+  if (path.resolve(topLevelProbe.stdout.trim()) !== path.resolve(root)) {
+    return { state: "error", detail: "Git top-level does not match the skill-pack root" };
+  }
+
+  const shallowProbe = spawnSync("git", ["-C", root, "rev-parse", "--is-shallow-repository"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"]
+  });
+  if (shallowProbe.error || shallowProbe.status !== 0) {
+    return { state: "error", detail: shallowProbe.error?.code || `shallow-history probe exited ${shallowProbe.status}` };
+  }
+  const shallowValue = shallowProbe.stdout.trim();
+  if (shallowValue === "true") return { state: "shallow" };
+  if (shallowValue === "false") return { state: "complete" };
+  return { state: "error", detail: `unexpected shallow-history response: ${JSON.stringify(shallowValue)}` };
+}
+
 const internalPhrases = [
   "suede internal",
   "not for public",
@@ -668,16 +697,23 @@ if (clogItems.length === 0) {
     return { date: date ? date[1] : null, hash: hash ? hash[1] : null };
   });
 
-  for (const entry of clogEntries) {
-    if (!entry.hash) continue;
-    const probe = spawnSync("git", ["-C", repoRoot, "cat-file", "-e", `${entry.hash}^{commit}`], { stdio: "ignore" });
-    if (probe.error) {
-      warn.push(`Changelog hash check skipped — could not run git (${probe.error.code || probe.error.message})`);
-      break;
+  const gitHistory = inspectGitHistory(repoRoot);
+  if (gitHistory.state === "complete") {
+    for (const entry of clogEntries) {
+      if (!entry.hash) continue;
+      const probe = spawnSync("git", ["-C", repoRoot, "cat-file", "-e", `${entry.hash}^{commit}`], { stdio: "ignore" });
+      if (probe.error) {
+        warn.push(`Changelog hash check skipped — could not run git (${probe.error.code || probe.error.message})`);
+        break;
+      }
+      if (probe.status !== 0) {
+        fail.push(`docs/index.html changelog cites commit ${entry.hash} which does not resolve to a commit in this repo`);
+      }
     }
-    if (probe.status !== 0) {
-      fail.push(`docs/index.html changelog cites commit ${entry.hash} which does not resolve to a commit in this repo`);
-    }
+  } else if (gitHistory.state === "packaged" || gitHistory.state === "shallow") {
+    console.log(`Changelog commit resolution skipped: ${gitHistory.state} skill-pack checkout.`);
+  } else {
+    warn.push(`Changelog hash check unavailable — ${gitHistory.detail}`);
   }
 
   for (let i = 1; i < clogEntries.length; i++) {

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, "..");
+const validatorPath = path.join(repoRoot, "scripts", "validate-skill-pack.mjs");
+
+function runValidator(targetRoot, extraEnv = {}) {
+  const nodePath = [path.join(repoRoot, "node_modules"), process.env.NODE_PATH]
+    .filter(Boolean)
+    .join(path.delimiter);
+  return spawnSync(
+    process.execPath,
+    [path.join(targetRoot, "scripts", "validate-skill-pack.mjs"), "--strict"],
+    {
+      cwd: targetRoot,
+      encoding: "utf8",
+      env: { ...process.env, NODE_PATH: nodePath, ...extraEnv }
+    }
+  );
+}
+
+function cloneWithCurrentValidator(targetRoot, extraArgs = []) {
+  const clone = spawnSync(
+    "git",
+    ["clone", "--quiet", ...extraArgs, pathToFileURL(repoRoot).href, targetRoot],
+    { encoding: "utf8" }
+  );
+  assert.equal(clone.status, 0, clone.stderr);
+  fs.copyFileSync(validatorPath, path.join(targetRoot, "scripts", "validate-skill-pack.mjs"));
+}
+
+test("validator ignores an unrelated parent Git repository in a packaged plugin cache", (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-runtime-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+  const parentRepo = path.join(tempRoot, "dotfiles");
+  const packagedRoot = path.join(parentRepo, "plugins", "cache", "suede-skills");
+  fs.mkdirSync(parentRepo, { recursive: true });
+  const init = spawnSync("git", ["init", "--quiet", parentRepo], { encoding: "utf8" });
+  assert.equal(init.status, 0, init.stderr);
+
+  fs.cpSync(repoRoot, packagedRoot, {
+    recursive: true,
+    filter(source) {
+      const relative = path.relative(repoRoot, source);
+      return !relative.split(path.sep).some((part) => part === ".git" || part === "node_modules");
+    }
+  });
+  const validation = runValidator(packagedRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.equal(validation.status, 0, diagnostics);
+  assert.match(validation.stdout, /packaged skill-pack checkout/);
+});
+
+test("validator rejects a nonexistent changelog hash in a full-history checkout", (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-full-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+  const checkoutRoot = path.join(tempRoot, "checkout");
+  cloneWithCurrentValidator(checkoutRoot);
+  const docsPath = path.join(checkoutRoot, "docs", "index.html");
+  const docs = fs.readFileSync(docsPath, "utf8");
+  const poisoned = docs.replace(
+    /(class="clog-hash"[^>]*>)[0-9a-f]{7,40}(<)/,
+    "$10000000000000000000000000000000000000001$2"
+  );
+  assert.notEqual(poisoned, docs, "test fixture must replace a changelog hash");
+  fs.writeFileSync(docsPath, poisoned);
+
+  const validation = runValidator(checkoutRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(validation.stderr, /does not resolve to a commit in this repo/);
+});
+
+test("strict source validation fails when Git history cannot be interrogated", (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-git-error-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+  const checkoutRoot = path.join(tempRoot, "checkout");
+  cloneWithCurrentValidator(checkoutRoot);
+  const validation = runValidator(checkoutRoot, { PATH: "" });
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(validation.stderr, /Changelog hash check unavailable/);
+});
+
+test("shallow checkouts skip history resolution but retain structural guards", (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-shallow-"));
+  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+
+  const checkoutRoot = path.join(tempRoot, "checkout");
+  cloneWithCurrentValidator(checkoutRoot, ["--depth", "1"]);
+  const initialValidation = runValidator(checkoutRoot);
+  const initialDiagnostics = `${initialValidation.stdout}\n${initialValidation.stderr}`;
+  assert.equal(initialValidation.status, 0, initialDiagnostics);
+  assert.match(initialValidation.stdout, /shallow skill-pack checkout/);
+
+  const docsPath = path.join(checkoutRoot, "docs", "index.html");
+  const docs = fs.readFileSync(docsPath, "utf8");
+  let seenDates = 0;
+  const malformed = docs.replace(/class="clog-date">\d{4}-\d{2}-\d{2}</g, (match) => {
+    seenDates += 1;
+    return seenDates === 2 ? 'class="clog-date">2099-01-01<' : match;
+  });
+  assert.ok(seenDates >= 2, "test fixture must contain at least two changelog dates");
+  fs.writeFileSync(docsPath, malformed);
+
+  const structuralValidation = runValidator(checkoutRoot);
+  const structuralDiagnostics = `${structuralValidation.stdout}\n${structuralValidation.stderr}`;
+  assert.notEqual(structuralValidation.status, 0, structuralDiagnostics);
+  assert.match(structuralValidation.stderr, /changelog entries out of date order/);
+});


### PR DESCRIPTION
## Summary
- distinguish complete, shallow, packaged, and indeterminate Git history states
- retain strict changelog provenance checks in full source checkouts
- skip only where packaged or shallow history cannot prove old hashes
- cover nested plugin caches, bogus hashes, missing Git, and shallow structural validation

## Verification
- `npm run ci`
- `npm run audit:dependencies`
- validator runtime regression tests: 4/4 passing
- `git diff --check`