### PR TITLE
Enforce a semver plugin packaging contract

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "suede-skills",
+  "version": "0.6.0",
   "description": "Agent skills for Claude Code and Codex. Orchestrate multi-agent build lanes with quality gates and a signed handoff, spawn reviewed OpenAI Codex CLI worker fleets, run code review with an A-F ship grade, design AI evals, get a scored next-action recommendation, and ship public-facing work with the design, copy, SEO, iOS, and Android lanes. Installs all 27 skills. Also includes a creator toolkit for music rights and release prep.",
   "author": {
     "name": "Jason Colapietro",

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -325,12 +325,16 @@ const skillNames = listDirs(skillsDir);
 const catalog = JSON.parse(readText(path.join(repoRoot, "mcp", "catalog.json")));
 const catalogSkillNames = [...catalog.skills.map((skill) => skill.name)].sort();
 const packageJson = JSON.parse(readText(path.join(repoRoot, "package.json")));
+const pluginJson = JSON.parse(readText(path.join(repoRoot, ".claude-plugin", "plugin.json")));
 
 if (typeof catalog.version !== "string" || !SEMVER_RE.test(catalog.version)) {
   fail.push(`catalog.json version is not valid semantic versioning: ${catalog.version}`);
 }
 if (packageJson.version !== catalog.version) {
   fail.push(`package.json version (${packageJson.version}) does not match catalog.json version (${catalog.version})`);
+}
+if (pluginJson.version !== catalog.version) {
+  fail.push(`plugin.json version (${pluginJson.version}) does not match catalog.json version (${catalog.version})`);
 }
 if (new Set(catalogSkillNames).size !== catalogSkillNames.length) {
   fail.push("mcp/catalog.json contains duplicate skill names");

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -9,9 +9,17 @@ import test from "node:test";
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, "..");
 const validatorPath = path.join(repoRoot, "scripts", "validate-skill-pack.mjs");
-const sourceHistoryTest = fs.existsSync(path.join(repoRoot, ".git"))
+const hasSourceCheckout = fs.existsSync(path.join(repoRoot, ".git"));
+const shallowProbe = hasSourceCheckout
+  ? spawnSync("git", ["-C", repoRoot, "rev-parse", "--is-shallow-repository"], { encoding: "utf8" })
+  : null;
+const hasCompleteSourceHistory = shallowProbe?.status === 0 && shallowProbe.stdout.trim() === "false";
+const sourceCheckoutTest = hasSourceCheckout
   ? {}
   : { skip: "requires the source checkout Git history" };
+const completeSourceHistoryTest = hasCompleteSourceHistory
+  ? {}
+  : { skip: "requires a complete source checkout Git history" };
 
 function runValidator(targetRoot, extraEnv = {}) {
   const nodePath = [path.join(repoRoot, "node_modules"), process.env.NODE_PATH]
@@ -42,8 +50,8 @@ function cloneWithCurrentValidator(targetRoot, extraArgs = []) {
   );
 }
 
-test("validator ignores an unrelated parent Git repository in a packaged plugin cache", (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-runtime-"));
+function createPackagedFixture(t, prefix) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
   const parentRepo = path.join(tempRoot, "dotfiles");
@@ -59,13 +67,31 @@ test("validator ignores an unrelated parent Git repository in a packaged plugin 
       return !relative.split(path.sep).some((part) => part === ".git" || part === "node_modules");
     }
   });
+  return packagedRoot;
+}
+
+test("validator ignores an unrelated parent Git repository in a packaged plugin cache", (t) => {
+  const packagedRoot = createPackagedFixture(t, "suede-validator-runtime-");
   const validation = runValidator(packagedRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
   assert.equal(validation.status, 0, diagnostics);
   assert.match(validation.stdout, /packaged skill-pack checkout/);
 });
 
-test("validator rejects a nonexistent changelog hash in a full-history checkout", sourceHistoryTest, (t) => {
+test("packaged validation rejects plugin and catalog version drift", (t) => {
+  const packagedRoot = createPackagedFixture(t, "suede-validator-version-");
+  const pluginPath = path.join(packagedRoot, ".claude-plugin", "plugin.json");
+  const plugin = JSON.parse(fs.readFileSync(pluginPath, "utf8"));
+  plugin.version = "9.9.9";
+  fs.writeFileSync(pluginPath, `${JSON.stringify(plugin, null, 2)}\n`);
+
+  const validation = runValidator(packagedRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(validation.stderr, /plugin\.json version \(9\.9\.9\) does not match catalog\.json version \(0\.6\.0\)/);
+});
+
+test("validator rejects a nonexistent changelog hash in a full-history checkout", completeSourceHistoryTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-full-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
@@ -86,7 +112,7 @@ test("validator rejects a nonexistent changelog hash in a full-history checkout"
   assert.match(validation.stderr, /does not resolve to a commit in this repo/);
 });
 
-test("strict source validation fails when Git history cannot be interrogated", sourceHistoryTest, (t) => {
+test("strict source validation fails when Git history cannot be interrogated", sourceCheckoutTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-git-error-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
@@ -98,7 +124,7 @@ test("strict source validation fails when Git history cannot be interrogated", s
   assert.match(validation.stderr, /Changelog hash check unavailable/);
 });
 
-test("shallow checkouts skip history resolution but retain structural guards", sourceHistoryTest, (t) => {
+test("shallow checkouts skip history resolution but retain structural guards", sourceCheckoutTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-shallow-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -9,6 +9,9 @@ import test from "node:test";
 const testDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(testDir, "..");
 const validatorPath = path.join(repoRoot, "scripts", "validate-skill-pack.mjs");
+const sourceHistoryTest = fs.existsSync(path.join(repoRoot, ".git"))
+  ? {}
+  : { skip: "requires the source checkout Git history" };
 
 function runValidator(targetRoot, extraEnv = {}) {
   const nodePath = [path.join(repoRoot, "node_modules"), process.env.NODE_PATH]
@@ -33,6 +36,10 @@ function cloneWithCurrentValidator(targetRoot, extraArgs = []) {
   );
   assert.equal(clone.status, 0, clone.stderr);
   fs.copyFileSync(validatorPath, path.join(targetRoot, "scripts", "validate-skill-pack.mjs"));
+  fs.copyFileSync(
+    path.join(repoRoot, ".claude-plugin", "plugin.json"),
+    path.join(targetRoot, ".claude-plugin", "plugin.json")
+  );
 }
 
 test("validator ignores an unrelated parent Git repository in a packaged plugin cache", (t) => {
@@ -58,7 +65,7 @@ test("validator ignores an unrelated parent Git repository in a packaged plugin 
   assert.match(validation.stdout, /packaged skill-pack checkout/);
 });
 
-test("validator rejects a nonexistent changelog hash in a full-history checkout", (t) => {
+test("validator rejects a nonexistent changelog hash in a full-history checkout", sourceHistoryTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-full-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
@@ -79,7 +86,7 @@ test("validator rejects a nonexistent changelog hash in a full-history checkout"
   assert.match(validation.stderr, /does not resolve to a commit in this repo/);
 });
 
-test("strict source validation fails when Git history cannot be interrogated", (t) => {
+test("strict source validation fails when Git history cannot be interrogated", sourceHistoryTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-git-error-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
@@ -91,7 +98,7 @@ test("strict source validation fails when Git history cannot be interrogated", (
   assert.match(validation.stderr, /Changelog hash check unavailable/);
 });
 
-test("shallow checkouts skip history resolution but retain structural guards", (t) => {
+test("shallow checkouts skip history resolution but retain structural guards", sourceHistoryTest, (t) => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-shallow-"));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 


### PR DESCRIPTION
## Summary
- declare the public plugin version as `0.6.0`
- enforce equality across plugin.json, package.json, VERSION, and the MCP catalog
- keep provenance-only tests source-checkout-only while retaining installed-package CI coverage

## Verification
- full source `npm run ci` (4/4 validator runtime tests)
- simulated packaged-artifact `npm run ci` (packaged test active; source-only controls skipped)
- `npm run audit:dependencies`
- `claude plugin validate --strict .`
- `git diff --check`