### PR TITLE
Make all claim/verification gates advisory recommendations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "suede-creator-skills",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/skills/android-app-factory/SKILL.md
+++ b/skills/android-app-factory/SKILL.md
@@ -5,6 +5,27 @@ description: "Plan, build, test, and release a production-grade native Android a
 
 # Android App Factory
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Principle
 
 Build the product, policy evidence, and Play listing together. A successful

--- a/skills/johnny-suede-design/SKILL.md
+++ b/skills/johnny-suede-design/SKILL.md
@@ -5,6 +5,27 @@ description: "Design and write polished product surfaces people understand fast:
 
 # Johnny Suede Design — The Any-Creatives Enchilada
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 This is the full design-plus-copy stack for building any creative surface, not just websites. Landing pages, brand surfaces, product UI, dashboards, campaigns, components, and creative projects all route through here. It classifies the surface, locks a visual direction, writes the words that carry it, renders and QAs the result, and can run the whole thing as a coordinated agent team when the build is big. Writing mode is ON by default: a surface is not finished until the copy pulls its weight.
 
 This skill organizes and prepares creative work. It does not clear rights, confirm ownership, approve payouts, write to a registry, guarantee placements, or guarantee outcomes. It produces drafts, designs, tokens, plans, and QA evidence for a human to verify and ship.
@@ -326,7 +347,7 @@ Revise below 58/70. For public launch, homepage, GitHub, product listing, invest
 
 ## Copy Ship Gate
 
-Do not ship copy when: the primary action is unclear; the page promises a feature the product does not implement; proof is fake or unverified; the copy hides a legal, payment, privacy, or release caveat; the score is below threshold; or the copy fails the competitor-swap test. End copy-only requests with the exact copy, not a long explanation of the copy.
+Recommend against shipping copy — and say why, leaving the call to the user — when: the primary action is unclear; the page promises a feature the product does not implement; proof is fake or unverified; the copy hides a legal, payment, privacy, or release caveat; the score is below threshold; or the copy fails the competitor-swap test. End copy-only requests with the exact copy, not a long explanation of the copy.
 
 ---
 
@@ -436,7 +457,7 @@ If any of these thoughts appear, stop and run the check you were about to skip:
 
 `hold` when: a core user path is broken; rendered output contradicts the implementation; text overflows or truncates on any breakpoint; mobile layout is unintentionally stacked; any accessibility issue blocks the primary action; copy makes unsupported claims; the live surface cannot be verified; screenshots do not match implementation; or the live route cannot be verified.
 
-`ship-with-caveats` is only valid when all P0 issues are resolved and remaining issues have a documented owner and timeline, and the caveat is explicit, non-critical, and acceptable for the launch stage. Public surfaces cannot ship if the design gate passes while visual or accessibility blockers are open. Findings lead, rationale follows. Name the file and line. For builds, state what changed and show the render evidence.
+`ship-with-caveats` is only valid when all P0 issues are resolved and remaining issues have a documented owner and timeline, and the caveat is explicit, non-critical, and acceptable for the launch stage. For public surfaces, recommend `hold` when the design gate passes while visual or accessibility blockers are open, and name those blockers so the user can decide. Findings lead, rationale follows. Name the file and line. For builds, state what changed and show the render evidence.
 
 ## Routing
 

--- a/skills/johnny-suede-write/SKILL.md
+++ b/skills/johnny-suede-write/SKILL.md
@@ -5,6 +5,27 @@ description: "Write sharper Suede copy for docs, pages, email, social, headlines
 
 # Johnny Suede Write
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 The writing enchilada. Route any writing request through one skill: long-form, short-form, GitHub and docs, social, email, product listing copy, brand-voice alignment, and public explainer talk-tracks. Default voice is the Suede house voice. A supplied company brief overrides everything.
 
 **Core principle:** copy earns its place on the page with concrete nouns, buyer-visible outcomes, real proof, and one primary action. Nothing decorative, nothing invented.
@@ -379,7 +400,7 @@ If any of these thoughts appear, stop and run the gate you were about to skip:
 
 ## Ship Gate
 
-Do not ship copy when:
+Recommend against shipping copy — and say why, leaving the call to the user — when:
 - the primary action is unclear
 - the page promises a feature the product does not implement
 - proof is fake or unverified

--- a/skills/site-to-ios-app/SKILL.md
+++ b/skills/site-to-ios-app/SKILL.md
@@ -5,6 +5,27 @@ description: "Turn a website, PWA, dashboard, or marketplace into an iOS app wit
 
 # Site to iOS App
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Principle
 
 Turn a site into an iOS app only when the app has native value, stable iOS

--- a/skills/suede-agent-teams/SKILL.md
+++ b/skills/suede-agent-teams/SKILL.md
@@ -5,6 +5,27 @@ description: "Split complex work into coordinated agent lanes with WIP checks, q
 
 # Agent Team Orchestrator
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 The orchestrator assigns lanes, not conversations. Output is a delivery artifact, not a status update.
 
 ## Team Contract

--- a/skills/suede-ai-eval/SKILL.md
+++ b/skills/suede-ai-eval/SKILL.md
@@ -5,14 +5,35 @@ description: "Design AI evals that catch regressions before users do: rubrics, t
 
 # Suede AI Eval
 
-Make AI behavior testable before it becomes a vague product promise. **No eval plan, no ship verdict: an AI feature without one cannot be graded `ship`.**
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
+Make AI behavior testable before it becomes a vague product promise. **No eval plan, no `ship` recommendation: for an AI feature without one, the recommended verdict stays below `ship` — report that gap and let the user decide.**
 
 The deliverable is an eval plan or coverage audit, not a model benchmark leaderboard. Keep it grounded in the actual product surface, user promise, data sources, prompts, tools, logs, tests, and failure modes available now.
 
 ## Hard Gates
 
 - No AI-SPEC → no eval plan. Write the one-paragraph spec first; cases written without a spec test nothing.
-- No eval plan → no ship verdict. Never emit `ship` or `ship-with-caveats` for an AI feature that lacks a failure-mode map and eval cases.
+- No eval plan → no `ship` recommendation. Do not recommend `ship` or `ship-with-caveats` for an AI feature that lacks a failure-mode map and eval cases; name the gap and leave the ship decision with the user.
 - A failure mode without an eval case, an owner, and a gate is uncovered — regardless of how unlikely it feels.
 - A live surface that was never sampled gets the output stamped `source-only`; do not present source-only review as runtime evidence.
 - A model grading its own output is not evidence. LLM-as-judge scores count only after spot-checked agreement with a human-reviewed sample.

--- a/skills/suede-campaign-in-a-box/SKILL.md
+++ b/skills/suede-campaign-in-a-box/SKILL.md
@@ -5,6 +5,27 @@ description: "Turn a song or release into a full artist campaign: hooks, rituals
 
 # Suede Campaign In A Box (Whole Enchilada)
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 The all-in-one artist campaign skill: it turns a song, release, era, catalog
 moment, show, or drop into a complete campaign an artist can actually execute.
 Every campaign capability lives here as a labeled lane. Pick the lane you need,

--- a/skills/suede-code-grader/SKILL.md
+++ b/skills/suede-code-grader/SKILL.md
@@ -5,6 +5,27 @@ description: "Give a blunt A-F ship verdict for a code change across correctness
 
 # Suede Code Grader
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 Blunt A-F read on whether code is ready to ship. The output is a grade with evidence, not a lint score or a pile of style notes.
 
 ## Source Truth
@@ -85,8 +106,8 @@ Score each lane A-F, then give one overall grade. When grading non-Suede work, s
 - **A:** All lanes pass. Behavior is verified at runtime. No known follow-ups. Example: new feature with unit + integration tests, live readback confirmed, env vars documented, rollback is trivial.
 - **B:** No blockers. One or more lanes have named, bounded follow-ups that do not affect correctness or safety in the current release. Example: happy-path tested but edge-case coverage is thin; or migration is forward-only but rollback risk is low and documented.
 - **C:** At least one lane has a real defect or unverified risk that could surface in production but is not immediately catastrophic. Hold until that lane is fixed and rechecked. Example: auth path not fully tested; or a data migration with no rollback plan on a low-traffic table; or a God object in a payment module that obscures correctness.
-- **D:** A serious defect exists that is likely to cause data loss, auth bypass, broken payments, or a user-visible production failure. Do not ship until the defect is fixed and verified. Example: missing auth check on a state-changing endpoint; migration with no tested rollback on a high-traffic table; payment flow that silently swallows errors.
-- **F:** Do not ship. The change breaks core behavior, introduces an Instant-F pattern, or verification evidence is absent for a critical surface. Example: hardcoded API key in source, SQL injection via string concatenation, auth middleware that can be bypassed, or a payment handler with zero test coverage and no live readback.
+- **D:** A serious defect exists that is likely to cause data loss, auth bypass, broken payments, or a user-visible production failure. Recommend not shipping until the defect is fixed and verified, and because these are extreme-risk categories, pause and put the choice to the user before any ship step. Example: missing auth check on a state-changing endpoint; migration with no tested rollback on a high-traffic table; payment flow that silently swallows errors.
+- **F:** Strongly recommend against shipping. The change breaks core behavior, introduces an Instant-F pattern, or verification evidence is absent for a critical surface. Example: hardcoded API key in source, SQL injection via string concatenation, auth middleware that can be bypassed, or a payment handler with zero test coverage and no live readback.
 
 ## Grade Caps by Surface Type
 
@@ -207,7 +228,7 @@ Silence = accepted.
 
 - Do not block on style preferences unless they create real maintenance, behavior, accessibility, release, or product-risk cost.
 - Do not invent tests, screenshots, live checks, deploy status, or evidence for published statements.
-- Do not ship a C, D, or F without naming the required upgrade that would move the grade.
+- Never report a C, D, or F without naming the required upgrade that would move the grade.
 - Keep the grade independent. Do not raise a grade because the implementation was hard, because CI passed without exercising the changed behavior, or because the author explains the intent well.
 
 ## Worked Example

--- a/skills/suede-code-review/SKILL.md
+++ b/skills/suede-code-review/SKILL.md
@@ -5,6 +5,27 @@ description: "Find the bugs a diff can actually ship: TypeScript, React, Next.js
 
 # Suede Code Review
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 Review code with full context: changed files, callers, contracts, deploy surface. Find real breakage. Rank by production impact. Every finding has a file, evidence, and a fix path. No findings without evidence. No volume without signal.
 
 ## Model Routing
@@ -248,14 +269,14 @@ Run this automatically at the end of every review. No exceptions. It answers one
 
 Grade each dimension. Each is pass / conditional / block:
 
-- **Breaking changes**: Does this change any public API signature, database schema, config key, or interface contract without a versioned migration or backward-compatible fallback? Block if yes without migration path.
-- **Rollback safety**: Can a `git revert` fully undo this? Red flags: schema migrations, irreversible external API calls (email sent, payment charged, data permanently deleted), S3/storage mutations, message queue publishes. Block if rollback requires manual data repair.
+- **Breaking changes**: Does this change any public API signature, database schema, config key, or interface contract without a versioned migration or backward-compatible fallback? Recommend blocking if yes without migration path.
+- **Rollback safety**: Can a `git revert` fully undo this? Red flags: schema migrations, irreversible external API calls (email sent, payment charged, data permanently deleted), S3/storage mutations, message queue publishes. Recommend blocking if rollback requires manual data repair.
 - **Blast radius**: What fraction of users or requests does this code path serve? State it: `~0%` (new feature, flagged), `~partial` (specific flow), `~100%` (shared middleware, auth, DB query in hot path). Higher blast radius requires more evidence before deploy.
-- **Environment readiness**: Are all required env vars, secrets, feature flags, and config values already deployed to production? Block if a required env var doesn't exist in production yet.
-- **Dependency changes**: Are new or updated packages pinned to an exact version, from a trusted source, and CVE-free? Block if a new dependency has a known CVE or is unpinned in a production context.
-- **Data mutations**: Does this write, update, or delete production data in a way that can't be undone by revert alone? Block if yes without a tested restore path.
-- **Security delta**: Does this change improve, hold neutral, or worsen the security posture? Block if it introduces new attack surface without mitigation.
-- **Automation coverage**: Does `.github/workflows/` (or equivalent CI) exist and cover the changed surface (build, types, tests)? Are required status checks enforced on `main`? Block if the changed surface has no automated gate and the repo is production-connected.
+- **Environment readiness**: Are all required env vars, secrets, feature flags, and config values already deployed to production? Recommend blocking if a required env var doesn't exist in production yet.
+- **Dependency changes**: Are new or updated packages pinned to an exact version, from a trusted source, and CVE-free? Recommend blocking if a new dependency has a known CVE or is unpinned in a production context.
+- **Data mutations**: Does this write, update, or delete production data in a way that can't be undone by revert alone? Recommend blocking if yes without a tested restore path.
+- **Security delta**: Does this change improve, hold neutral, or worsen the security posture? Recommend blocking if it introduces new attack surface without mitigation.
+- **Automation coverage**: Does `.github/workflows/` (or equivalent CI) exist and cover the changed surface (build, types, tests)? Are required status checks enforced on `main`? Recommend blocking if the changed surface has no automated gate and the repo is production-connected.
 
 Output block — required at the end of every review:
 
@@ -332,7 +353,7 @@ Confidence: high
 
 Severity:
 
-- **P0:** data loss, security exposure, payment loss, broken release, or public behavior that must not ship.
+- **P0:** data loss, security exposure, payment loss, broken release, or public behavior that should not ship — extreme-risk findings that also warrant a pause-and-ask to the user before any ship step.
 - **P1:** likely production regression, auth/permission bug, broken primary path, false published statement, or missing critical deploy requirement.
 - **P2:** meaningful edge-case failure, incomplete state handling, test gap on changed behavior, or maintainability issue with real cost.
 - **P3:** low-risk improvement, clarity issue, local cleanup, or follow-up.

--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -5,6 +5,27 @@ description: "Review and grade code in one pass: real findings, A-F ship verdict
 
 # Suede Code
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 One pass for code: a deep, evidence-based review **and** a blunt A-F ship grade, together by default. Findings tell you what is wrong; the grade tells you whether it ships. Every finding has a file, evidence, and a fix path. No findings without evidence. No volume without signal.
 
 **Runs only when asked.** This skill never auto-fires on a diff, a save, or a commit. Invoke it explicitly (review this, grade this, security-check this, is this safe to ship). Do not run it as a side effect of other work.
@@ -108,9 +129,9 @@ Score each lane A-F, then one overall. For non-Suede work, substitute "domain tr
 - **Tests and verification** — changed behavior has meaningful tests, builds, screenshots, simulator runs, live/API readbacks, or named caveats.
 - **Deploy readiness** — env vars, flags, configs, migrations, rollback notes, install paths, docs, release sequencing are clear.
 
-**Grade meaning:** **A** all lanes pass, runtime-verified, no follow-ups. **B** no blockers, named bounded follow-ups. **C** a real defect or unverified risk that could surface in production — hold until fixed. **D** a serious defect likely to cause data loss, auth bypass, broken payments, or user-visible failure — do not ship. **F** breaks core behavior, hits an Instant-F, or critical-surface evidence is absent.
+**Grade meaning:** **A** all lanes pass, runtime-verified, no follow-ups. **B** no blockers, named bounded follow-ups. **C** a real defect or unverified risk that could surface in production — recommend hold until fixed. **D** a serious defect likely to cause data loss, auth bypass, broken payments, or user-visible failure — recommend against shipping and, because these are extreme-risk categories, pause and put the ship choice to the user. **F** breaks core behavior, hits an Instant-F, or critical-surface evidence is absent.
 
-**Gate follows the grade, mechanically:** A → `ship`; B → `ship-with-caveats`; C, D, F → `hold`. A Deploy Safety block (Step 5) also forces `hold` regardless of grade.
+**Recommended gate follows the grade, mechanically:** A → `ship`; B → `ship-with-caveats`; C, D, F → `hold`. A Deploy Safety finding (Step 5) also moves the recommended gate to `hold` regardless of grade. The gate is a recommendation the user acts on, not a lock on the agent.
 
 **Grade caps by surface** (state explicitly when they apply):
 - **Auth** (login, session, token, middleware, roles) — A needs the bypass/escalation path tested, not just happy path; B needs happy-path + named caveats; else cap **C**.
@@ -401,7 +422,7 @@ Verify that threat mitigations declared in a threat model (ADR threat table, PLA
 | --- | --- | --- | --- | --- | --- |
 ```
 
-**Blockers:** OPEN and UNREGISTERED are BLOCKERS. Do not ship until closed.
+**Blockers:** OPEN and UNREGISTERED items are reported as blockers — the recommendation is to close them before shipping; the user makes the final call.
 
 **What this is NOT:** This mode does not scan for new vulnerabilities (that is what the OWASP lane does). It only verifies previously declared mitigations exist.
 

--- a/skills/suede-copy/SKILL.md
+++ b/skills/suede-copy/SKILL.md
@@ -5,6 +5,27 @@ description: "Write conversion copy that earns the click: landing sections, emai
 
 # Suede Copy
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## When to use this skill instead of related skills
 - **suede-copy** (this skill): standalone conversion email, landing page copy, CTAs, microcopy, button labels
 - **johnny-suede-write**: full writing stack (copy + SEO + AI Engine Optimization)
@@ -519,7 +540,7 @@ If any of these thoughts appear, stop and run the gate you were about to skip:
 
 ## Ship Gate
 
-Do not ship copy when:
+Recommend against shipping copy — and say why, leaving the call to the user — when:
 
 - the primary action is unclear
 - the page promises a feature the product does not implement

--- a/skills/suede-launch-packaging/SKILL.md
+++ b/skills/suede-launch-packaging/SKILL.md
@@ -5,6 +5,27 @@ description: "Package finished work so people can use it: README, docs, install 
 
 # Suede Launch Packaging
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Approved Suede S Mark
 
 Launch art, social cards, docs headers, app assets, and release visuals may use only `docs/assets/suede-ai-logo-transparent.png` from `JasonColapietro/suede-creator-skills` as the Suede S mark (SHA-256 `83a7ee0317e4debe2e7b076c20ba067feb76a587f9e829dc6310ae4be4b44dfa`). Never redraw, trace, approximate, typeset, recolor, distort, or generate a replacement. If the canonical asset is missing or its checksum differs, block the branded visual and request the approved file.
@@ -29,13 +50,16 @@ Before picking a lane, name exactly what is being launched. Do not assume from t
 | App feature | Feature is live behind the public route, not just merged | Live route readback |
 | Social or email copy | Every link resolves; every claim matches the live product | Link sweep results |
 
-## Hard gates
+## Hard gates (advisory)
 
-Do not rationalize past these. Each one blocks the step after it.
+Do not rationalize past these silently. Each one is a strong recommendation
+about ordering: run the check before the step it guards. If the user directs
+you past one, proceed as directed and label the output with exactly which
+verification is missing.
 
 1. **No launch copy until the live surface is verified.** Fetch the live URL or public artifact and confirm the expected status or render first. Copy drafted against "it should be live" is a violation.
 2. **No install doc until the install command was run from a clean temporary directory after pushing.** Success from inside the local repo does not count — the local checkout masks missing pushes and private paths.
-3. **No announcement until the ship gate is set.** `hold` means nothing goes out, including "soft" posts.
+3. **Set the ship gate before recommending any announcement.** A `hold` verdict is your recommendation that nothing goes out yet, including "soft" posts — state it plainly with the reasons, then let the user decide.
 4. **`@personal` and local plugin aliases never appear in public docs, READMEs, MCP catalog output, or explainer copy.** They are local operator notes only.
 
 ## Pick the lane

--- a/skills/suede-mcp-qa/SKILL.md
+++ b/skills/suede-mcp-qa/SKILL.md
@@ -5,6 +5,27 @@ description: "Catch MCP drift before release: skill catalogs, tool and resource 
 
 # Suede MCP QA
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 Use this skill when a Suede MCP server or MCP docs surface changes.
 
 **Core principle:** a check that did not run against the live server did not
@@ -133,7 +154,7 @@ uses `id: null`. A raw stack trace or any non-JSON stdout is a High failure.
 | Docs/catalog language mismatch | Medium | List each mismatch. Flag as hold-with-caveat. |
 | Tool implemented but not in catalog | Low | Flag as undocumented. Not a blocker. |
 
-Ship gate rules:
+Recommended ship gate rules (advice to the user, not a lock on any action):
 - Any Critical or High failure → **hold**
 - Medium failures only → **ship-with-caveats** (list each caveat)
 - No failures → **ship**

--- a/skills/suede-release-linter/SKILL.md
+++ b/skills/suede-release-linter/SKILL.md
@@ -5,6 +5,27 @@ description: "Audit creative release folders before handoff: metadata, file stru
 
 # Release Metadata Linter
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Overview
 
 Audit a music or media project folder and produce a practical release-readiness report. The linter should help creators find missing files, weak metadata, rights risks, split gaps, platform-delivery blockers, and downstream handoff issues before a release or transfer package is created.

--- a/skills/suede-release-linter/references/lint-rules.md
+++ b/skills/suede-release-linter/references/lint-rules.md
@@ -2,8 +2,8 @@
 
 ## Severity Levels
 
-- `error`: Blocks release, Suede intake, registry, licensing, royalty routing, or agent commerce.
-- `warning`: Does not always block work, but should be fixed before public release or monetization.
+- `error`: Recommends blocking release, Suede intake, registry, licensing, royalty routing, or agent commerce. The status is a report to the creator, not an action lock; the creator decides what proceeds.
+- `warning`: Does not usually warrant a blocked recommendation, but should be fixed before public release or monetization.
 - `info`: Useful improvement or optional cleanup.
 
 ## Score

--- a/skills/suede-rights-audit/SKILL.md
+++ b/skills/suede-rights-audit/SKILL.md
@@ -5,6 +5,27 @@ description: "Find the rights gaps before packaging: ownership, splits, samples,
 
 # Suede Rights Audit
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 The rights-readiness enchilada. Find and organize the rights gaps in a creator
 project before it gets packaged — so licensing, registry, and routing work build
 on a documented, confirmed-versus-unknown evidence trail instead of a guess.

--- a/skills/suede-rights-passport/SKILL.md
+++ b/skills/suede-rights-passport/SKILL.md
@@ -5,6 +5,27 @@ description: "Package creative projects into evidence-scoped rights handoffs wit
 
 # Creator Rights Package Builder
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Overview
 
 Create a local rights and provenance transfer package from messy creator materials. The package should make the work easier for a creator, collaborator, advisor, registry, marketplace, label, or optional Suede reviewer to inspect, optimize, register, route royalties for, license, and expose to agent-readable commerce systems.

--- a/skills/suede-seo-audit/SKILL.md
+++ b/skills/suede-seo-audit/SKILL.md
@@ -5,6 +5,27 @@ description: "Run a nine-lane evidence-based SEO and generative-search audit: ac
 
 # Suede SEO Audit
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 This skill goes deeper than an inline copy audit. It inspects live page source,
 validates schema, traces crawl access, checks whether content can be understood
 and sourced accurately, and produces exact rewrites with a lane-by-lane grade.
@@ -354,7 +375,7 @@ Overall grade:
 
 --- EVIDENCE BOUNDARIES ---
 Safe to publish:
-Do not publish until verified:
+Recommend holding until verified (user's call):
 Remove entirely:
 
 --- VERIFICATION CHECKLIST ---
@@ -409,7 +430,7 @@ through 3.
 
 8. **Score each lane** A-F using the rules from Section 4. Apply hard caps.
 
-9. **Set the ship gate.** `ship` only if no HIGH findings remain and all hard
+9. **Set the recommended ship gate.** Recommend `ship` only if no HIGH findings remain and all hard
    caps are met. `ship-with-caveats` if only MEDIUM or LOW findings remain and
    no claim is false. `hold` if any HIGH finding is unresolved, any claim is
    false, or the CTA destination is broken. Name any lane items that could not

--- a/skills/suede-ship-gate/SKILL.md
+++ b/skills/suede-ship-gate/SKILL.md
@@ -5,6 +5,27 @@ description: "Make CI hold the line: path-aware builds, required checks, branch 
 
 # Suede Ship Gate
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 Set up CI and branch protection that actually block a bad merge — in any repo, any stack. The output is a working pipeline plus the exact protection settings, not advice.
 
 **Runs only when asked.** This skill never auto-fires on a commit, push, or other side effect of unrelated work — invoke it explicitly (set up CI, protect main, fix this hanging check).

--- a/skills/suede-site-alchemy/SKILL.md
+++ b/skills/suede-site-alchemy/SKILL.md
@@ -5,6 +5,27 @@ description: "Turn a page into a conversion path: hero, friction, proof, CTA, pr
 
 # Suede Site Alchemy
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 **Core principle:** evidence before certainty. Diagnose friction, verify the
 measurement, and turn design ideas into falsifiable hypotheses. Do not present
 a heuristic, benchmark, or scenario as observed impact.
@@ -18,8 +39,9 @@ Use your company name, voice, and positioning throughout.
 - For Promo/Sites work, position Suede as a brand growth platform: creator
   campaigns create demand; Suede Sites converts it with pages, SEO/AEO/AI EO,
   visitor signals, CRM follow-up, and campaign attribution.
-- Do not publish module pricing unless current product docs or source already
-  authorize it.
+- Module pricing without backing in current product docs or source is an
+  extreme-risk claim: pause, show the user what is and is not authorized, and
+  let them decide whether it publishes.
 - "Sexy" means precise, visual, confident, and conversion-aware. Avoid vague
   hype, fake numbers, fake testimonials, and generic SaaS fog.
 - For public pages, use the visibility grade when the page needs an A-F read on
@@ -267,7 +289,7 @@ it.
 10. For any experiment, pre-register the ledger row, validate assignment and
     exposure, check sample-ratio mismatch (SRM) before interpreting outcomes,
     and report the effect estimate with uncertainty and guardrail results.
-11. Ship gate:
+11. Recommended ship gate:
     - `ship`: page passes the done signal and no launch-critical gaps remain.
     - `ship-with-caveats`: only non-critical caveats remain and they are named.
     - `hold`: core CTA, visible layout, false claim, accessibility, build, or

--- a/skills/suede-sync-packaging/SKILL.md
+++ b/skills/suede-sync-packaging/SKILL.md
@@ -5,6 +5,27 @@ description: "Prep songs for sync pitches: scene angles, one-sheets, clean and i
 
 # Suede Sync Package
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 **Core principle:** a sync package makes a track easy to evaluate; it never
 asserts the track is cleared. Confirmed facts and open clearance questions
 travel in separate, labeled piles, every time.
@@ -39,8 +60,11 @@ Do not rationalize past these:
    version marked exists / missing / unknown, with at minimum a confirmed
    master file path. Missing instrumental or clean versions are flagged in the
    one-sheet, not glossed.
-4. **Unresolved sample = no pitch copy.** Mark sample status "OPEN — do not
-   pitch until cleared" and stop at the checklist and clearance questions.
+4. **Unresolved sample = pause and put it to the user.** Uncleared samples are
+   a legal-risk finding: mark sample status "OPEN — recommend not pitching
+   until cleared," tell the user exactly what is unresolved, and let them
+   decide whether pitch copy is still drafted. If they proceed, the OPEN flag
+   stays embedded in the one-sheet and pitch materials.
 5. **Lyric flags are mandatory.** Screen the lyrics and flag profanity, brand
    and product names, artist name-drops, violence, drugs and alcohol, sexual
    content, religious and political content, and date-stamped references. If

--- a/skills/suede-visibility-grader/SKILL.md
+++ b/skills/suede-visibility-grader/SKILL.md
@@ -5,6 +5,27 @@ description: "Grade a public page for launch appeal: findability, first-screen c
 
 # Suede Visibility Grader
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 Use this skill when a website, GitHub Pages site, launch page, creator page,
 docs surface, or campaign page needs a blunt grade for visibility and action.
 The goal is not generic SEO advice. The goal is to answer one question:
@@ -80,10 +101,10 @@ Grade caps — non-negotiable:
 - No live inspection → Overall cap: `C`.
 - Broken primary CTA → Overall cap: `D`.
 - False or unsupported published statement → Overall cap: `D`. (If the statement is central to the product promise, `F`.)
-- Design signal `D` or `F` → Ship gate is **hold**, regardless of other lanes.
+- Design signal `D` or `F` → Recommended ship gate is **hold**, regardless of other lanes.
 - Mobile not inspected → `A` is blocked. State the caveat explicitly in Verification.
 
-Ship gate — mechanical:
+Recommended ship gate — mechanical (a recommendation to the user, not a lock on any action):
 
 - **ship:** Overall B or better, no grade cap triggered, no lane below C.
 - **ship-with-caveats:** Overall C, or a higher grade blocked only by uninspected surfaces (mobile, live URL). Name every caveat in Verification.

--- a/skills/suede-workflow-skills/SKILL.md
+++ b/skills/suede-workflow-skills/SKILL.md
@@ -5,6 +5,27 @@ description: "Umbrella workflow for 27 public skills: copy, design, code review,
 
 # Suede Workflow Skills
 
+## Gate policy — advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky — data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage — pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+
 ## Approved Brand Asset
 
 Any lane that creates or edits a Suede visual must use only `docs/assets/suede-ai-logo-transparent.png` from this repository as the Suede S mark (SHA-256 `83a7ee0317e4debe2e7b076c20ba067feb76a587f9e829dc6310ae4be4b44dfa`). Never redraw, trace, approximate, typeset, recolor, distort, or generate a replacement Suede S. `suede-skill-icon.png` is not the brand mark. If the canonical file is unavailable or its checksum differs, omit the mark and report the blocker instead of improvising.


### PR DESCRIPTION
Every claim-verification check, quality gate, and ship verdict across the pack is now explicitly a recommendation to the user, not a control on the agent.

## What changed

- Added a **Gate policy — advisory, not blocking** section to the 22 skills that carry claim/verification checks or gates (code review/grader, ai-eval, visibility grader, seo audit, launch packaging, mcp-qa, release linter, rights audit/passport, sync packaging, site alchemy, copy, write/design routers, agent teams, campaign, workflow, ship gate, app factories).
- Rewrote hard action-forcing lines into recommendation language: "Do not ship" grades, "hold means nothing goes out", "No eval plan, no ship verdict", Deploy Safety "Block if" items, "Do not ship copy when", "Unresolved sample = no pitch copy", release-linter error severity semantics.
- Gates still run and report honestly — a failed gate changes what is reported, never what is done.
- Extremely risky findings (data loss, security/credential exposure, legal/rights violations, payments, irreversible public damage) pause and put the choice to the user instead of silently blocking.
- Kept user-authorization rules intact (e.g. no App Store / Play submission without explicit delegation) since those already leave the decision with the user.

## Verification

Full suite green: `npm test` — skill-pack validator (strict) + trigger routing, 7 validator-runtime tests, 9 MCP protocol tests, 23 trigger tests, 23 Python tests. The inserted section was reworded to avoid the reserved-signature bigram the validator caught on first pass.