### PR TITLE
Correct Full Send release count

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -664,7 +664,7 @@
               <p class="eyebrow">The full guide</p>
               <h1 id="hero-headline">Stop rebuilding the prompt stack every time your agent forgets you.</h1>
               <p class="lead">Suede gives Claude Code or Codex a reusable engineering workflow instead of one giant bloated prompt. <strong>Every capability is an inspectable <code>SKILL.md</code> folder</strong> the agent loads on demand: Full Send outcome routing, orchestration, A-F code review, CI ship-gates, AI evals, design, copy, SEO, app shipping, and creator rights. 28 skills, MIT licensed.</p>
-              <a id="hero-shiplog" href="./#changelog" aria-label="Release log: 194 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Read the full changelog on the homepage.">
+              <a id="hero-shiplog" href="./#changelog" aria-label="Release log: 196 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Read the full changelog on the homepage.">
                 <span class="hero-spark" aria-hidden="true">
                   <span style="height:8%"></span>
                   <span style="height:2%"></span>
@@ -675,12 +675,12 @@
                   <span style="height:52%"></span>
                   <span style="height:28%"></span>
                   <span style="height:30%"></span>
-                  <span style="height:42%"></span>
+                  <span style="height:45%"></span>
                 </span>
                 <span class="hero-shiplog-text">
                   <span class="hero-shiplog-top">Released Jul 25 <b>&middot; 7cc263a</b></span>
                   <span class="hero-shiplog-title">Full Send joins the public pack</span>
-                  <span class="hero-shiplog-more">194 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+                  <span class="hero-shiplog-more">196 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
                 </span>
               </a>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3081,7 +3081,7 @@
 
         <p id="hero-subline" class="hero-anim">This pack is the supervision. 28 open-source skills that read every diff like a senior engineer with a reputation to protect, then finish the parts of shipping nobody prompts for: design that looks intentional, copy that sells, SEO that gets found, and <strong>native iOS and Android shipping workflows</strong>. Full Send routes broad, authorized work to the useful lanes and holds the result to proof. One recovery skill argued Amazon out of <strong>$448.31</strong> in one sitting. Your agent just got taste.</p>
 
-        <a id="hero-shiplog" class="hero-anim" href="#changelog" aria-label="Release log: 194 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Jump to the full changelog.">
+        <a id="hero-shiplog" class="hero-anim" href="#changelog" aria-label="Release log: 196 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Jump to the full changelog.">
           <span class="hero-spark" aria-hidden="true">
             <span style="height:8%"></span>
             <span style="height:2%"></span>
@@ -3092,12 +3092,12 @@
             <span style="height:52%"></span>
             <span style="height:28%"></span>
             <span style="height:30%"></span>
-            <span style="height:42%"></span>
+            <span style="height:45%"></span>
           </span>
           <span class="hero-shiplog-text">
             <span class="hero-shiplog-top">Released Jul 25 <b>&middot; 7cc263a</b></span>
             <span class="hero-shiplog-title">Full Send joins the public pack</span>
-            <span class="hero-shiplog-more">194 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+            <span class="hero-shiplog-more">196 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
           </span>
         </a>
 
@@ -3255,7 +3255,7 @@
 
       <p class="clog-fresh reveal reveal-d2">Version 0.7.0 released Jul 25, 2026 <span id="clog-fresh-rel" data-iso="2026-07-25"></span></p>
 
-      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last ten weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, and 27 commits.">
+      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last ten weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, and 29 commits.">
         <span style="height:8%"></span>
         <span style="height:2%"></span>
         <span style="height:2%"></span>
@@ -3265,9 +3265,9 @@
         <span style="height:52%"></span>
         <span style="height:28%"></span>
         <span style="height:30%"></span>
-        <span style="height:42%"></span>
+        <span style="height:45%"></span>
       </div>
-      <p class="clog-spark-caption reveal reveal-d2">194 commits &middot; 10 weeks &middot; newest on the right</p>
+      <p class="clog-spark-caption reveal reveal-d2">196 commits &middot; 10 weeks &middot; newest on the right</p>
 
       <div class="clog-filters reveal reveal-d2" role="group" aria-label="Filter changelog entries by type">
         <button class="clog-filter" type="button" data-filter="all" aria-pressed="true">All</button>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -352,7 +352,7 @@
     <h1>28 skills. One honest line each.</h1>
     <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Six lanes:</strong> orchestration, code review and CI, design and copy, SEO and visibility, iOS and Android shipping, and creator rights. This catalog links each skill to its deep docs and its source folder on GitHub.</p>
 
-    <a id="hero-shiplog" href="#changelog" aria-label="Release log: 194 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Jump to the changelog.">
+    <a id="hero-shiplog" href="#changelog" aria-label="Release log: 196 commits in 10 weeks. Version 0.7.0 released July 25, 2026: Full Send joins the public pack. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
         <span style="height:8%"></span>
         <span style="height:2%"></span>
@@ -363,12 +363,12 @@
         <span style="height:52%"></span>
         <span style="height:28%"></span>
         <span style="height:30%"></span>
-        <span style="height:42%"></span>
+        <span style="height:45%"></span>
       </span>
       <span class="hero-shiplog-text">
         <span class="hero-shiplog-top">Released Jul 25 <b>&middot; 7cc263a</b></span>
         <span class="hero-shiplog-title">Full Send joins the public pack</span>
-        <span class="hero-shiplog-more">194 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+        <span class="hero-shiplog-more">196 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
       </span>
     </a>
 


### PR DESCRIPTION
The merge commit that preserved the 0.7.0 feature hash increased main by one. This updates the three synchronized release-log cards and final weekly activity bin to the post-fix truth: 196 commits after this single squash commit.

Verified with npm run validate and git diff --check.