### PR TITLE
fix: correct six stale skill counts the validator was not guarding

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
     {
       "name": "suede-skills",
       "source": "./",
-      "description": "All 29 public Suede skills and both read-only MCP discovery servers."
+      "description": "All 67 public Suede skills and both read-only MCP discovery servers."
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "suede",
-  "description": "Agent skills for Claude Code and Codex: decisive full-send routing, multi-agent orchestration, Codex CLI worker fleets, code review with an A-F ship grade, CI ship gates, AI evals, and design/copy/SEO lanes. 29 MIT-licensed skills.",
+  "description": "Agent skills for Claude Code and Codex: decisive full-send routing, multi-agent orchestration, Codex CLI worker fleets, code review with an A-F ship grade, CI ship gates, AI evals, and design/copy/SEO lanes. 67 MIT-licensed skills.",
   "owner": {
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
@@ -9,7 +9,7 @@
     {
       "name": "suede-skills",
       "source": "./",
-      "description": "Complete Suede workflow: Full Send orchestration, reviewed multi-agent execution, code and release gates, design, copy, SEO, app shipping, and creator utilities. Installs all 29 skills."
+      "description": "Complete Suede workflow: Full Send orchestration, reviewed multi-agent execution, code and release gates, design, copy, SEO, app shipping, and creator utilities. Installs all 67 skills."
     },
     {
       "name": "suede-agent-workflows",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -46,7 +46,7 @@
   "interface": {
     "displayName": "Suede Creator Skills",
     "shortDescription": "Full-send agent skills with MCP discovery",
-    "longDescription": "Twenty-nine public Suede skills for Full Send execution, coordinated agent teams, reviewed Codex worker fleets, code quality, design, copy, SEO, app shipping, creator workflows, and structured MCP discovery.",
+    "longDescription": "Sixty-seven public Suede skills for Full Send execution, coordinated agent teams, reviewed Codex worker fleets, code quality, design, copy, SEO, app shipping, creator workflows, and structured MCP discovery.",
     "developerName": "Suede Labs AI",
     "category": "Developer Tools",
     "capabilities": [

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -40,7 +40,7 @@ workflow pack with a clear install path and unusually strong ship discipline.
 
 ## Constraints
 
-- Keep all 29 public skills, install commands, benchmark disclosures, canonical
+- Keep all 67 public skills, install commands, benchmark disclosures, canonical
   URLs, structured data, and GitHub Pages paths accurate.
 - Preserve evidence integrity: comparisons remain self-graded and losses stay
   visible.

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -902,6 +902,10 @@ const countChecks = [
   { file: "skills/suede-workflow-skills/agents/openai.yaml", label: "short_description", re: /Umbrella workflow across (\d+) public skills/, expected: totalSkillCount },
   { file: "COPY.md", label: "subhead", re: /Install the (\d+)-skill Suede pack/, expected: totalSkillCount },
   { file: "PROMO.md", label: "companion skill count", re: /with ([A-Za-z]+-[A-Za-z]+) companion skills/, expected: companionSkillCount, wordNumber: true },
+  { file: "PRODUCT.md", label: "public skills count", re: /(\d+) public skills/, expected: totalSkillCount },
+  { file: ".agents/plugins/marketplace.json", label: "Codex catalog skill count", re: /(\d+) public Suede skills/, expected: totalSkillCount },
+  { file: ".claude-plugin/marketplace.json", label: "marketplace description", re: /(\d+) MIT-licensed skills/, expected: totalSkillCount },
+  { file: ".claude-plugin/marketplace.json", label: "umbrella plugin description", re: /Installs all (\d+) skills/, expected: totalSkillCount },
   { file: "PROMO.md", label: "README intro pack size", re: /public (\d+)-skill agent workflow pack/, expected: totalSkillCount },
 ];
 

--- a/skills/suede-workflow-skills/SKILL.md
+++ b/skills/suede-workflow-skills/SKILL.md
@@ -529,7 +529,7 @@ Useful lanes:
 /plugin install suede-skills@suede
 ```
 
-`suede-skills` installs all 29 skills. Smaller subsets: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) or `/plugin install suede-code@suede` (review, grade, ship-gate). Prefer a clone? `install.sh` copies all 29 skills into `~/.claude/skills/`:
+`suede-skills` installs all 67 skills. Smaller subsets: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) or `/plugin install suede-code@suede` (review, grade, ship-gate). Prefer a clone? `install.sh` copies all 67 skills into `~/.claude/skills/`:
 
 ```bash
 git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh


### PR DESCRIPTION
The 29 → 67 sweep in #28 covered every surface the validator checks. Six it *doesn't* check were still saying 29 — including two public product surfaces.

| Surface | Was | Public? |
|---|---|---|
| `.agents/plugins/marketplace.json` | "All 29 public Suede skills" | **yes** — the Codex catalog |
| `.claude-plugin/marketplace.json` | "29 MIT-licensed skills" / "Installs all 29 skills" | **yes** — marketplace listing |
| `.codex-plugin/plugin.json` | "Twenty-nine public Suede skills" | yes |
| `PRODUCT.md` | "29 public skills" | repo doc |
| `skills/suede-workflow-skills/SKILL.md` | "29 skills" ×2 | skill body |

## The durable part

Correcting six numbers fixes today. Four of those surfaces now have **count checks in the validator**, so they fail the build instead of drifting the next time the pack grows.

## The checks were verified to fire

Reverting `PRODUCT.md` to 29 produced:

```
- Stale skill count in PRODUCT.md (public skills count): says 29, expected 67
```

then restored. A guard that has never been observed failing is not evidence of anything — this session produced three separate false cleans from exactly that pattern, so new guards get a positive control now.

## Verification

`validate` green · `python` 23/23 · `mcp` 10/10 · `triggers` 27/27