### PR TITLE
fix(codex-fleet): workers are codex exec processes, never Claude fan-out

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -104,7 +104,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>

--- a/docs/skills/suede-codex-fleet.html
+++ b/docs/skills/suede-codex-fleet.html
@@ -322,6 +322,8 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
             <li>Writes one self-contained markdown brief per task with job, inputs, deliverable, acceptance criteria, and output path.</li>
             <li>Uses a workspace `AGENTS.md` to carry voice, context, hard bans, and output conventions so briefs stay short.</li>
             <li>Spawns parallel `codex exec` runs in a workspace-write sandbox, with `--skip-git-repo-check` outside repos.</li>
+            <li>Workers are always `codex exec` processes billed to your OpenAI subscription — never Claude subagent fan-out on any model. "Fable" is the brand name, not the model `claude-fable-5`.</li>
+            <li>Halts and reports if Codex CLI is missing or logged out, instead of silently falling back to Claude workers and spending the budget you routed away.</li>
             <li>Requires Claude to review every output against the brief and hard bans before anything ships.</li>
             <li>Corrects with delta patches, not full regenerations: up to three genuinely different fixes per output, stopping early when the same root cause repeats.</li>
           </ul>
@@ -335,6 +337,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
             <li>Not for: coordinated Claude-side agent lanes with quality gates on one codebase change (use Suede Agent Teams).</li>
             <li>Not for: writing one scoped copy surface directly (use Suede Copy).</li>
             <li>Not for: tasks needing live conversation context that cannot be written into a brief.</li>
+            <li>Not for: any run where Codex CLI is unavailable — the skill halts rather than substituting Claude models.</li>
           </ul>
         </article>
       </section>

--- a/skills/suede-codex-fleet/SKILL.md
+++ b/skills/suede-codex-fleet/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: suede-codex-fleet
-description: "Claude-directed parallel OpenAI Codex CLI worker fleet for bulk generation. Use when a job is high-volume, well-specified, and splits into independent worker-sized tasks (content batches, test generation, bulk refactors) and Codex CLI is installed and logged in. Claude decomposes, briefs, spawns codex exec runs in parallel, and review-gates every output. NOT FOR: multi-lane Claude agents coordinating one complex change (use suede-agent-teams); low-volume, judgment-dense copy Claude should write itself (use suede-copy or johnny-suede-write)."
+description: "Claude-directed parallel OpenAI Codex CLI worker fleet for bulk generation. Use when a job is high-volume, well-specified, and splits into independent worker-sized tasks (content batches, test generation, bulk refactors) and Codex CLI is installed and logged in. Claude decomposes, briefs, spawns codex exec runs in parallel, and review-gates every output. Workers are always codex exec processes billed to the user's OpenAI subscription — never substitute Claude subagent fan-out on any model, and halt rather than fall back if Codex CLI is unavailable. NOT FOR: multi-lane Claude agents coordinating one complex change (use suede-agent-teams); low-volume, judgment-dense copy Claude should write itself (use suede-copy or johnny-suede-write)."
 ---
 
 # Suede Fable Fleet
 
 The Suede Fable Fleet: a high-end Claude model is the admiral — it decomposes, briefs, and reviews — and parallel OpenAI Codex CLI workers are the fleet. The skill id and command stay `suede-codex-fleet` on purpose: GitHub search, skill marketplaces, and MCP catalogs match the terms people actually type — Codex CLI orchestration, codex exec, multi-agent worker fleet — not the brand name. Do not rename the folder or frontmatter `name` to match the brand.
+
+> **"Fable" in the brand name is not the model `claude-fable-5`.** The workers in this fleet are always OpenAI Codex CLI processes. Never read "Fable Fleet" as license to spawn Claude models.
+
+## The workers are Codex processes — never Claude models
+
+**This is the economic point of the skill.** Codex workers bill to the user's OpenAI/ChatGPT subscription. Claude subagents bill to their Anthropic limit. Someone asking for a codex fleet is deliberately routing volume *off* the Anthropic meter — satisfying that request with Claude models inverts the cost model and spends the exact budget they were protecting.
+
+`codex exec` is therefore the only way a worker runs here. Never substitute `Agent`, `Task`, `Workflow`, subagent fan-out, or any other in-house orchestration for a worker — not with `fable`, not with `opus`, not with any model, not "just for this one batch". Claude's role is admiral only: decompose, brief, review, assemble. If you are about to spawn something that is not a `codex exec` process, you have left this skill — stop and re-read the routing table below.
+
+**Preflight failure is a halt, not a fallback.** If Codex CLI is missing, not logged in, or not on `PATH`, say which check failed and ask whether to proceed on Claude models, with a rough estimate of what that fan-out will consume. Never fall back silently.
+
+**What getting this wrong costs** (measured, 2026-07-27): a Claude-model fleet ran in place of an explicitly requested codex fleet — 3,258 turns, ~1.29 billion tokens, 97% of them cache reads from workers each hauling ~500k tokens of context per turn. About $1,843 of API-equivalent spend, 23% of one weekly allocation, for work that should have cost nothing on that account.
 
 ## When to use this skill instead of related skills
 
@@ -19,6 +31,8 @@ The Suede Fable Fleet: a high-end Claude model is the admiral — it decomposes,
 
 1. `which codex && codex --version` — CLI present (validated against codex-cli 0.138.0).
 2. `codex login status` — must show logged in (your ChatGPT subscription pays for the run).
+
+   Checks 1 and 2 are the cost boundary. If either fails, **stop and report which one** — do not substitute Claude workers to keep the job moving.
 3. Workspace has an `AGENTS.md` at its root. Codex auto-loads it; it carries voice, context, hard bans, and output conventions so briefs stay short. If missing, write it first — that is the highest-leverage file in the system.
 4. Workspace has `briefs/` and `out/` directories (create as needed).
 
@@ -71,6 +85,7 @@ Keep a persistent workspace per recurring fleet job (a social-content fleet, a t
 
 ## Hard boundaries
 
+- Workers are `codex exec` processes, always. Never substitute Claude-model fan-out (`Agent`, `Task`, `Workflow`, subagents) for a worker, on any model — the brand name "Fable Fleet" is not a reference to `claude-fable-5`.
 - Never ship worker output without the Claude review gate.
 - Workers never run git push, deploys, or credentialed commands; content and code-edit tasks only, inside the sandbox.
 - Secrets never go into briefs or AGENTS.md; workers get file paths, not tokens.

--- a/skills/suede-codex-fleet/agents/openai.yaml
+++ b/skills/suede-codex-fleet/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Suede Fable Fleet"
   short_description: "Claude-directed parallel Codex CLI worker fleet"
-  default_prompt: "Use $suede-codex-fleet to offload [job] to parallel OpenAI Codex CLI workers. Decompose into independent worker-sized tasks, write self-contained briefs plus an AGENTS.md voice/context contract, spawn one codex exec run per brief in parallel, review every output against the brief's acceptance criteria, send delta corrections instead of regenerating — up to three genuinely different fixes per output, stopping early when the same root cause repeats — then assemble the reviewed survivors into the final deliverable."
+  default_prompt: "Use $suede-codex-fleet to offload [job] to parallel OpenAI Codex CLI workers. Decompose into independent worker-sized tasks, write self-contained briefs plus an AGENTS.md voice/context contract, spawn one codex exec run per brief in parallel, review every output against the brief's acceptance criteria, send delta corrections instead of regenerating — up to three genuinely different fixes per output, stopping early when the same root cause repeats — then assemble the reviewed survivors into the final deliverable. Every worker is a codex exec process billed to the OpenAI subscription: never substitute Claude subagent fan-out on any model ('Fable' is the brand name, not claude-fable-5), and if Codex CLI is missing or logged out, halt and report rather than falling back."
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
## Why

The skill's brand name is **Suede Fable Fleet**, and `claude-fable-5` is a real model id. "Spawn the Fable Fleet" therefore reads as license to fan out Claude subagents — and nothing in the skill forbade it. Preflight checked for the Codex CLI but never said what to do when it is absent, so a missing CLI degraded into a silent fallback onto Claude models.

That inverts the entire economics of the skill: Codex workers bill to the user's OpenAI subscription, Claude subagents bill to their Anthropic limit. Someone asking for a codex fleet is deliberately routing volume *off* the Anthropic meter.

## Measured cost of the gap

On 2026-07-27 a Claude-model fleet ran in place of an explicitly requested codex fleet:

| | |
|---|---|
| turns | 3,258 |
| tokens | ~1.29 billion (97% cache reads) |
| API-equivalent spend | ~$1,843 |
| share of one weekly allocation | 23% |

Workers were each hauling ~500k tokens of context through every turn, which is why cache reads were 85% of the cost.

## What changed

- **Disambiguate the brand from the model** — an explicit callout that "Fable" is the brand name, not `claude-fable-5`.
- **New section: the workers are Codex processes** — `codex exec` is the only way a worker runs; never substitute `Agent`, `Task`, `Workflow`, or subagent fan-out, on any model.
- **Preflight failure is a halt** — report which check failed and ask, with a rough cost estimate, rather than falling back silently.
- **Carried into the frontmatter description and the picker prompt**, which stay in context when the skill body does not — the body loads on demand, so a body-only rule would not have prevented this.
- **Mirrored onto the public docs page**, per the repo's existing convention of keeping spec / picker prompt / docs in policy sync.

## Verification

- `npm run validate` — passes (67 skills, trigger routing 6 groups / 23 cases).
- Correction-policy drift guard still satisfied; the required phrases were left untouched.
- `docs/sitemap.xml` regenerated via `scripts/generate-sitemap.mjs` after the docs edit.
- One pre-existing failure in `tests/test_validator_runtime.mjs` ("Codex discovers only the full public entry") is unrelated and environment-dependent — it expects this checkout's own `.agents/plugins/marketplace.json` to be discovered, but the machine's Codex registry points at the main checkout, so it fails from any worktree. **Verified it fails identically with these changes stashed.**