### PR TITLE
Surface the unadvertised suede-marketing plugin (38 of 67 skills)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3839,7 +3839,7 @@
 
   <div class="install-inner">
     <h2 class="install-headline reveal">Install the open-source pack.</h2>
-    <p class="install-sub reveal reveal-d1">Two lines in Claude Code install the full 67-skill pack. Prefer less? <code>suede-agent-workflows@suede</code> and <code>suede-code@suede</code> install focused subsets, and <code>install.sh</code> covers the clone route. Either way the agent gets orchestration, code review with A-F grading, AI evals, design, copy, SEO, and CI rails it can reuse across your own work. Bring your own company, repo, page, or product.</p>
+    <p class="install-sub reveal reveal-d1">Two lines in Claude Code install the full 67-skill pack. Prefer less? <code>suede-marketing@suede</code> (38 growth skills), <code>suede-agent-workflows@suede</code>, and <code>suede-code@suede</code> install focused subsets, and <code>install.sh</code> covers the clone route. Either way the agent gets orchestration, code review with A-F grading, AI evals, design, copy, SEO, and CI rails it can reuse across your own work. Bring your own company, repo, page, or product.</p>
 
     <div class="install-terminal reveal reveal-d1">
       <div class="install-terminal-bar" aria-hidden="true">

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -310,7 +310,7 @@
     </div>
 
     <div class="prose">
-      <p>Want less than the full pack? Two focused subsets install the same way: <code>/plugin install suede-agent-workflows@suede</code> (orchestration, workflows, evals) or <code>/plugin install suede-code@suede</code> (review, grade, ship-gate).</p>
+      <p>Want less than the full pack? Three focused subsets install the same way: <code>/plugin install suede-marketing@suede</code> (38 skills &mdash; paid acquisition, outbound, pricing, offers, lifecycle, analytics), <code>/plugin install suede-agent-workflows@suede</code> (orchestration, workflows, evals), or <code>/plugin install suede-code@suede</code> (review, grade, ship-gate).</p>
       <p>Prefer a clone? <code>install.sh</code> copies all 67 skills into <code>~/.claude/skills/</code> and never touches skills that are not part of the pack:</p>
     </div>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/plugins.html</loc>
-    <lastmod>2026-07-27</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -865,6 +865,9 @@ const tensWords = { twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60, sev
 // which silently capped the pack at twenty-nine skills.
 function wordNumber(word) {
   const parts = String(word).toLowerCase().split("-");
+  // Bare single digits ("three") for small counts such as the number of
+  // focused subset plugins. Tens callers are unaffected.
+  if (parts.length === 1 && numberWords[parts[0]] !== undefined) return numberWords[parts[0]];
   const tens = tensWords[parts[0]];
   if (tens === undefined) return null;
   if (parts.length === 1) return tens;
@@ -1035,6 +1038,47 @@ for (const check of countChecks) {
       if (!heroStrip.includes(tileLabel) && !heroStrip.toLowerCase().includes(tileLabel.toLowerCase())) {
         warn.push(`docs/index.html hero strip omits beat-both category "${category}"`);
       }
+    }
+  }
+}
+
+// Discoverability guard. Every plugin the marketplace ships is installable by
+// name, so a plugin that appears in no install copy is a product nobody can
+// find. suede-marketing bundles 38 of the skills and went unmentioned on every
+// page while both 4-skill subsets were advertised. Each subset's advertised
+// skill count must match the manifest too, or the copy oversells the bundle.
+{
+  const marketplacePath = path.join(repoRoot, ".claude-plugin/marketplace.json");
+  const installPagePath = path.join(repoRoot, "docs/plugins.html");
+  if (fs.existsSync(marketplacePath) && fs.existsSync(installPagePath)) {
+    const manifest = JSON.parse(readText(marketplacePath));
+    const installText = readText(installPagePath);
+    const umbrella = "suede-skills";
+    for (const plugin of manifest.plugins ?? []) {
+      if (plugin.name === umbrella) continue;
+      if (!installText.includes(`${plugin.name}@suede`)) {
+        fail.push(`docs/plugins.html never advertises the ${plugin.name} plugin, so nobody can discover it`);
+        continue;
+      }
+      const bundled = Array.isArray(plugin.skills) ? plugin.skills.length : null;
+      if (bundled === null) continue;
+      const advertised = installText.match(
+        new RegExp(`${plugin.name}@suede</code>\\s*\\((\\d+)\\s+skills`)
+      );
+      if (advertised && Number(advertised[1]) !== bundled) {
+        fail.push(`docs/plugins.html says ${plugin.name} bundles ${advertised[1]} skills; the manifest lists ${bundled}`);
+      }
+      for (const entry of plugin.skills) {
+        const dir = path.join(repoRoot, entry.replace(/^\.\//, ""));
+        if (!fs.existsSync(dir)) {
+          fail.push(`${plugin.name} bundles a skill that does not exist: ${entry}`);
+        }
+      }
+    }
+    const subsetCount = (manifest.plugins ?? []).filter((p) => p.name !== umbrella).length;
+    const wordClaim = installText.match(/([A-Za-z]+) focused subsets install the same way/);
+    if (wordClaim && wordNumber(wordClaim[1]) !== subsetCount) {
+      fail.push(`docs/plugins.html claims "${wordClaim[1]}" focused subsets; the manifest ships ${subsetCount}`);
     }
   }
 }

--- a/tests/test_neutral_oss_positioning.py
+++ b/tests/test_neutral_oss_positioning.py
@@ -106,8 +106,14 @@ class NeutralOssPositioningTests(unittest.TestCase):
         self.assertIn(f"{count}-skill", read("docs/index.html"))
         stale_counts = [f"{n} skills" for n in range(20, 40) if n != count]
         stale_counts += [f"{n}-skill" for n in range(20, 40) if n != count]
+        # A focused subset plugin advertises how many skills *it* bundles, which
+        # is legitimately smaller than the pack total. Only counts tied to a
+        # named "<plugin>@suede" install are exempt; a bare number in prose is
+        # still a stale pack-size claim. The bundle sizes themselves are checked
+        # against the marketplace manifest by scripts/validate-skill-pack.mjs.
+        subset_claim = re.compile(r"suede-[a-z-]+@suede</code>\s*\((?:\d+)[^)]*\bskills\b[^)]*\)")
         for surface in ["README.md", "docs/index.html", "docs/guide.html", "docs/plugins.html", "docs/copy.html", "docs/skills/index.html", "docs/llms.txt"]:
-            text = read(surface)
+            text = subset_claim.sub("", read(surface))
             for stale in stale_counts:
                 with self.subTest(surface=surface, stale=stale):
                     self.assertNotIn(stale, text)


### PR DESCRIPTION
Second audit pass over all 76 pages. Structure came back clean — 0 broken internal links, 0 duplicate titles or descriptions, 0 images missing `alt`, 75/75 JSON-LD blocks valid, all 187 GitHub tree links / 11 blob links / 19 commit hashes resolve, canonicals accurate. `dav/index.html` canonicalizing to root is correct: it is `noindex, nofollow` and unlisted.

The defect was not structural.

## A shipped plugin nobody could find

The marketplace manifest ships **four** plugins. Three were advertised. `suede-marketing` was mentioned on no page, not in the README, not in `llms.txt` — while bundling **38 of the 67 skills**, making it the largest subset by a wide margin. Both 4-skill subsets were advertised on two pages each.

Two surfaces also still said "Two focused subsets" after a third shipped.

- `docs/plugins.html`: advertise `suede-marketing@suede` with its real bundle size; correct the subset count
- `docs/index.html`: add it to the focused-subset line in the install section

## Guards

All four negative-tested by breaking each and confirming a hard failure:

- every non-umbrella plugin in the manifest must appear in install-page copy
- an advertised bundle size must match the manifest's skill list
- the spelled-out subset count must match the number of subsets shipped
- every skill path a plugin bundles must exist on disk

`wordNumber()` resolved only tens, so it returned `null` for a bare "three" and silently skipped the check rather than failing. It now resolves single digits; tens callers are unaffected.

## Test change

`test_skill_count_copy_matches_catalog_and_folders` banned every `"N skills"` string for N in 20..39 as a stale pack-size claim — correct for prose, wrong for a subset that legitimately bundles 38. The exemption added is narrow: only a count tied to a named `<plugin>@suede` install is skipped, and those sizes are separately asserted against the manifest by the validator. Verified by planting a bare `"29 skills"` in prose and confirming the test still goes red.

## Verification

`npm run validate` green; 23 Python page-quality tests pass.