### PR TITLE
Make the Codex discovery test hermetic (it was failing on maintainers' machines)

### DIFF
--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -39,9 +39,18 @@ function runValidator(targetRoot, extraEnv = {}) {
 }
 
 function startCodexAppServer(t) {
+  // Isolate CODEX_HOME. Codex discovers marketplaces from the cwd *and* from
+  // the ones registered in the developer's own config, and when a name appears
+  // in both the registered copy wins and the local one is hidden. A maintainer
+  // who has installed this pack in their own Codex -- the expected thing to do
+  // -- therefore shadows the repo checkout and this test fails on a working
+  // tree. The isolated home keeps discovery limited to what the repo ships.
+  const codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "suede-codex-home-"));
+  t.after(() => fs.rmSync(codexHome, { recursive: true, force: true }));
   const child = spawn("codex", ["app-server", "--stdio"], {
     cwd: repoRoot,
-    stdio: ["pipe", "pipe", "pipe"]
+    stdio: ["pipe", "pipe", "pipe"],
+    env: { ...process.env, CODEX_HOME: codexHome }
   });
   const lines = readline.createInterface({ input: child.stdout });
   const pending = new Map();


### PR DESCRIPTION
Resolves the item flagged across the previous three audit passes.

## The failure was the test, not the pack

`tests/test_validator_runtime.mjs` → "Codex discovers only the full public entry" failed locally on codex-cli 0.146.0. It is skipped in CI (no codex CLI there), so it never went red — which meant the Codex install path was effectively unverified for anyone who noticed the local failure and assumed it was environmental.

It *was* environmental, but for a specific and fixable reason.

## Diagnosis

Codex discovers marketplaces from the `cwds` you pass **and** from the ones registered in the developer's own config. When the same marketplace *name* appears in both, the registered copy wins and the local one is hidden.

`suede-codex` is registered globally from the git source in `~/.codex/config.toml`, so codex served it from `~/.codex/.tmp/marketplaces/suede-codex/` and the repo checkout was shadowed. Any maintainer who installs their own pack — the expected thing to do — hits this.

Confirmed three ways:

1. A probe from the repo returned `suede-codex` from `~/.codex/.tmp/marketplaces/`, never from the checkout.
2. The same probe against a scratch directory with a **uniquely named** marketplace found the local file immediately — proving codex does scan `cwds`, so this was never a codex regression.
3. Rerunning the repo probe with an isolated `CODEX_HOME` found the checkout's own `.agents/plugins/marketplace.json` exactly as the test asserts.

## Fix

`startCodexAppServer` now spawns codex with a temp `CODEX_HOME`, removed after the test. Discovery is limited to what the repo ships, so the test measures the pack instead of the developer's machine.

## Verification

The full suite is green — `npm run validate`, 12 runtime tests, 10 MCP, 27 trigger-routing, 23 Python. Test 9 passes for the first time on this machine.