### PR TITLE
38 skills were rendering invisibly (gold on gold) inside the install band

### DIFF
--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -513,6 +513,47 @@
       <a class="row" href="suede-rights-passport.html"><b>suede-rights-passport</b><span>Local creator rights package with provenance, credits, split notes, license notes, and structured metadata.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-rights-audit.html"><b>suede-rights-audit</b><span>Ownership, contributor, sample, license, split, and intake gap audit.</span><span class="arrow">-&gt;</span></a>
     </div>
+    <div class="lane">
+      <div class="lane-head"><h3>Marketing &amp; growth</h3><span class="lane-count">38</span></div>
+      <a class="row" href="./suede-ab-testing.html"><b>suede-ab-testing</b><span>Test so the result means something.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-ad-creative.html"><b>suede-ad-creative</b><span>Produce ad creative at volume.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-ads.html"><b>suede-ads</b><span>Run paid acquisition that pays back.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-analytics.html"><b>suede-analytics</b><span>Know whether any of it worked.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-aso.html"><b>suede-aso</b><span>Optimise an App Store or Play listing.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-churn-prevention.html"><b>suede-churn-prevention</b><span>Keep subscribers who are leaving and recover the ones you lose to billing.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-co-marketing.html"><b>suede-co-marketing</b><span>Find and run partner campaigns.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-cold-email.html"><b>suede-cold-email</b><span>Write B2B cold outreach that gets replies.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-community-marketing.html"><b>suede-community-marketing</b><span>Build a community that compounds.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-competitor-profiling.html"><b>suede-competitor-profiling</b><span>Research competitors from their public surfaces and turn the findings into structured profiles.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-competitors.html"><b>suede-competitors</b><span>Write comparison and alternative pages that rank and convert without misrepresenting anyone.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-content-strategy.html"><b>suede-content-strategy</b><span>Decide what to publish and why.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-customer-research.html"><b>suede-customer-research</b><span>Find out what customers actually think.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-directory-submissions.html"><b>suede-directory-submissions</b><span>Work the directory layer deliberately.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-emails.html"><b>suede-emails</b><span>Design lifecycle email that runs itself.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-free-tools.html"><b>suede-free-tools</b><span>Engineering as marketing.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-image.html"><b>suede-image</b><span>Create and optimise marketing imagery.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-lead-magnets.html"><b>suede-lead-magnets</b><span>Decide what to give away for an email.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-marketing-council.html"><b>suede-marketing-council</b><span>Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-marketing-ideas.html"><b>suede-marketing-ideas</b><span>Get unstuck with a structured idea library rather than a blank page.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-marketing-loops.html"><b>suede-marketing-loops</b><span>Turn marketing into a recurring loop an agent runs on a cadence.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-marketing-plan.html"><b>suede-marketing-plan</b><span>Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-marketing-psychology.html"><b>suede-marketing-psychology</b><span>Apply behavioural science honestly.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-offers.html"><b>suede-offers</b><span>Construct the thing you actually sell.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-onboarding.html"><b>suede-onboarding</b><span>Get a new user to first value fast.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-paywalls.html"><b>suede-paywalls</b><span>Design in-app upgrade moments that convert without resentment.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-pricing.html"><b>suede-pricing</b><span>Decide what to charge and how to package it.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-product-marketing.html"><b>suede-product-marketing</b><span>Establish the product context every other marketing lane reads from.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-programmatic-seo.html"><b>suede-programmatic-seo</b><span>Build search pages at scale without building junk.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-prospecting.html"><b>suede-prospecting</b><span>Build and qualify a target list before you write a word.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-public-relations.html"><b>suede-public-relations</b><span>Earn coverage without a retainer.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-referrals.html"><b>suede-referrals</b><span>Turn customers into a channel.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-revops.html"><b>suede-revops</b><span>Wire marketing to revenue.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-sales-enablement.html"><b>suede-sales-enablement</b><span>Arm the people doing the selling.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-signup.html"><b>suede-signup</b><span>Cut friction out of registration.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-sms.html"><b>suede-sms</b><span>Run SMS without getting blocked or resented.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-social.html"><b>suede-social</b><span>Run social as a channel rather than a chore.</span><span class="arrow">-&gt;</span></a>
+      <a class="row" href="./suede-video.html"><b>suede-video</b><span>Plan and produce marketing video.</span><span class="arrow">-&gt;</span></a>
+    </div>
   </section>
 
   <section class="shell" id="changelog" aria-labelledby="changelog-headline">
@@ -645,48 +686,6 @@
     <div class="ship-strip-row">
       <code><span class="prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills &rarr; /plugin install suede-skills@suede</code>
       <a href="../plugins.html">All install paths</a>
-    </div>
-
-    <div class="lane">
-      <div class="lane-head"><h3>Marketing &amp; growth</h3><span class="lane-count">38</span></div>
-      <a class="row" href="./suede-ab-testing.html"><b>suede-ab-testing</b><span>Test so the result means something.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-ad-creative.html"><b>suede-ad-creative</b><span>Produce ad creative at volume.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-ads.html"><b>suede-ads</b><span>Run paid acquisition that pays back.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-analytics.html"><b>suede-analytics</b><span>Know whether any of it worked.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-aso.html"><b>suede-aso</b><span>Optimise an App Store or Play listing.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-churn-prevention.html"><b>suede-churn-prevention</b><span>Keep subscribers who are leaving and recover the ones you lose to billing.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-co-marketing.html"><b>suede-co-marketing</b><span>Find and run partner campaigns.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-cold-email.html"><b>suede-cold-email</b><span>Write B2B cold outreach that gets replies.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-community-marketing.html"><b>suede-community-marketing</b><span>Build a community that compounds.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-competitor-profiling.html"><b>suede-competitor-profiling</b><span>Research competitors from their public surfaces and turn the findings into structured profiles.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-competitors.html"><b>suede-competitors</b><span>Write comparison and alternative pages that rank and convert without misrepresenting anyone.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-content-strategy.html"><b>suede-content-strategy</b><span>Decide what to publish and why.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-customer-research.html"><b>suede-customer-research</b><span>Find out what customers actually think.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-directory-submissions.html"><b>suede-directory-submissions</b><span>Work the directory layer deliberately.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-emails.html"><b>suede-emails</b><span>Design lifecycle email that runs itself.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-free-tools.html"><b>suede-free-tools</b><span>Engineering as marketing.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-image.html"><b>suede-image</b><span>Create and optimise marketing imagery.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-lead-magnets.html"><b>suede-lead-magnets</b><span>Decide what to give away for an email.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-marketing-council.html"><b>suede-marketing-council</b><span>Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-marketing-ideas.html"><b>suede-marketing-ideas</b><span>Get unstuck with a structured idea library rather than a blank page.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-marketing-loops.html"><b>suede-marketing-loops</b><span>Turn marketing into a recurring loop an agent runs on a cadence.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-marketing-plan.html"><b>suede-marketing-plan</b><span>Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-marketing-psychology.html"><b>suede-marketing-psychology</b><span>Apply behavioural science honestly.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-offers.html"><b>suede-offers</b><span>Construct the thing you actually sell.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-onboarding.html"><b>suede-onboarding</b><span>Get a new user to first value fast.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-paywalls.html"><b>suede-paywalls</b><span>Design in-app upgrade moments that convert without resentment.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-pricing.html"><b>suede-pricing</b><span>Decide what to charge and how to package it.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-product-marketing.html"><b>suede-product-marketing</b><span>Establish the product context every other marketing lane reads from.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-programmatic-seo.html"><b>suede-programmatic-seo</b><span>Build search pages at scale without building junk.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-prospecting.html"><b>suede-prospecting</b><span>Build and qualify a target list before you write a word.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-public-relations.html"><b>suede-public-relations</b><span>Earn coverage without a retainer.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-referrals.html"><b>suede-referrals</b><span>Turn customers into a channel.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-revops.html"><b>suede-revops</b><span>Wire marketing to revenue.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-sales-enablement.html"><b>suede-sales-enablement</b><span>Arm the people doing the selling.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-signup.html"><b>suede-signup</b><span>Cut friction out of registration.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-sms.html"><b>suede-sms</b><span>Run SMS without getting blocked or resented.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-social.html"><b>suede-social</b><span>Run social as a channel rather than a chore.</span><span class="arrow">-&gt;</span></a>
-      <a class="row" href="./suede-video.html"><b>suede-video</b><span>Plan and produce marketing video.</span><span class="arrow">-&gt;</span></a>
     </div>
   </div>
 </section>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -967,7 +967,23 @@ for (const check of countChecks) {
 {
   const catalogPath = path.join(repoRoot, "docs/skills/index.html");
   if (fs.existsSync(catalogPath)) {
-    const catalogText = readText(catalogPath);
+    const fullText = readText(catalogPath);
+    // Scope every row check to the catalog <section> itself. Counting rows
+    // file-wide passes even when a whole lane has escaped into another
+    // section: 38 rows once sat inside the gold install band, rendering gold
+    // text on a gold background, and a file-wide count saw all 67 and passed.
+    const catalogStart = fullText.indexOf('aria-labelledby="catalog"');
+    const catalogText = catalogStart === -1
+      ? ""
+      : fullText.slice(catalogStart, fullText.indexOf("</section>", catalogStart));
+    if (!catalogText) {
+      fail.push('docs/skills/index.html has no <section aria-labelledby="catalog"> to validate');
+    }
+    const strayRows = (fullText.match(/class="row" href=/g) || []).length
+      - (catalogText.match(/class="row" href=/g) || []).length;
+    if (strayRows > 0) {
+      fail.push(`docs/skills/index.html has ${strayRows} catalog row(s) outside the catalog section — a lane has escaped its container`);
+    }
     const rowNames = [...catalogText.matchAll(/class="row" href="\.?\/?([a-z0-9-]+)\.html"/g)]
       .map((m) => m[1]);
     const missingRows = skillNames.filter((name) => !rowNames.includes(name));


### PR DESCRIPTION
Found by measuring contrast in a real browser rather than reading markup.

## The bug

The "Marketing & growth" lane — **38 of the 67 skills** — was not inside the catalog section. It opened inside `<section class="ship-strip">`, the gold CTA band at the bottom of the page, and closed just before that section did. `.ship-strip` sets `background: var(--gold)`, and row titles use `var(--gold)` as well.

Result: every skill name in the lane rendered **gold on gold — contrast ratio 1.0, literally invisible**. Visitors saw 38 unlabelled rows with descriptions but no readable name and no visible link, stranded far below the catalog they belong to. The `38` lane badge next to the heading disappeared the same way.

This is the same 38 skills that PR #34 found were undiscoverable as a plugin. The pack's largest lane was invisible in both places.

## Fix

Moved the lane into the catalog section with the other seven, and repaired the `<div class="shell">` that the move initially left unbalanced. Tag balance verified with a parser — no unclosed tags, no stray closers.

Measured in a browser before and after:

| | before | after |
|---|---|---|
| skill-name contrast | 1.0 | 8.92 |
| rows inside ship-strip | 38 | 0 |
| rows inside catalog | 29 | 67 |
| lanes in catalog | 7 | 8 |
| ship-strip height | 4889px | 338px |

## Why the existing guard missed it

The structural check added in PR #33 counted `class="row"` occurrences across the whole file. All 67 were present, so it passed — containment was never checked. A count can't see that a lane has escaped its container.

It now scopes every row check to the catalog `<section>` and fails on any row outside it. Negative-tested by programmatically reconstructing the original bug: it reports 38 escaped rows plus every missing skill by name.

## Verification

Full suite green — `npm run validate`, 12 runtime, 10 MCP, 27 trigger-routing, 23 Python.