### PR TITLE
Meet AA contrast: the fill-only red was being used as text

### DIFF
--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -55,7 +55,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -304,9 +304,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -58,7 +58,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -213,9 +213,9 @@
         </div>
         <div class="footer-links">
           <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-          <span class="footer-divider">|</span>
+          <span class="footer-divider" aria-hidden="true">|</span>
           <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-          <span class="footer-divider">|</span>
+          <span class="footer-divider" aria-hidden="true">|</span>
           <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
         </div>
       </div>

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -60,7 +60,7 @@
       --hairline: #1a1a18;
       --gold: #c8a96e;
       --red: #8b1a1a;
-      --red-text: #c0524a;
+      --red-text: #c6625a;
       --cream: #f0ece4;
       --muted: #888880;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -490,9 +490,9 @@ Repo: https://github.com/JasonColapietro/suede-creator-skills</pre>
     </div>
     <div class="footer-links">
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
     </div>
   </div>

--- a/docs/dav/index.html
+++ b/docs/dav/index.html
@@ -860,7 +860,7 @@
     .feature-card:nth-child(3n) .feature-label,
     .feature-card:nth-child(5) .feature-label,
     .feature-card:nth-child(7) .feature-label {
-      color: #c0524a;
+      color: #c6625a;
     }
 
     .feature-copy {
@@ -884,7 +884,7 @@
       font-size: 11px;
       letter-spacing: .18em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: #c6625a;
       font-weight: 600;
       margin-bottom: 28px;
     }
@@ -1006,7 +1006,7 @@
       font-size: 11px;
       letter-spacing: .14em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: #c6625a;
       font-weight: 600;
       margin-bottom: 24px;
     }
@@ -1785,7 +1785,7 @@
     </div>
     <div class="footer-links">
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
     </div>
   </div>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -336,7 +336,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -1001,9 +1001,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
         </div>
         <div class="footer-links">
           <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-          <span class="footer-divider">|</span>
+          <span class="footer-divider" aria-hidden="true">|</span>
           <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-          <span class="footer-divider">|</span>
+          <span class="footer-divider" aria-hidden="true">|</span>
           <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -190,6 +190,8 @@
       --color-border:        #222222;
       --color-accent-gold:   #c8a96e;
       --color-accent-red:    #8b1a1a;
+      --color-accent-red-text: #c6625a; /* readable on dark; --color-accent-red is for fills and borders only */
+      --color-text-dim: #7f7a70; /* AA-passing muted text on the dark surfaces */
       --color-text-primary:  #f0ece4;
       --color-text-secondary:#888880;
       --color-text-accent:   #c8a96e;
@@ -1073,7 +1075,7 @@
     .feature-card:nth-child(9) .feature-label,
     .feature-card:nth-child(12) .feature-label,
     .feature-card--red .feature-label {
-      color: #c0524a;
+      color: var(--color-accent-red-text);
     }
 
     .feature-copy {
@@ -1097,7 +1099,7 @@
       font-size: 11px;
       letter-spacing: .18em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: var(--color-accent-red-text);
       font-weight: 600;
       margin: 0 0 28px;
     }
@@ -1207,7 +1209,7 @@
       font-size: 11px;
       letter-spacing: .18em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: var(--color-accent-red-text);
       font-weight: 600;
       margin-bottom: 28px;
     }
@@ -1329,7 +1331,7 @@
       font-size: 11px;
       letter-spacing: .14em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: var(--color-accent-red-text);
       font-weight: 600;
       margin-bottom: 24px;
     }
@@ -1453,7 +1455,7 @@
       font-size: 11px;
       letter-spacing: .18em;
       text-transform: uppercase;
-      color: #8b1a1a;
+      color: var(--color-accent-red-text);
       font-weight: 600;
       margin-bottom: 28px;
     }
@@ -1543,7 +1545,7 @@
       color: #f0ece4;
     }
     .grade-pill.g-b { color: #888880; }
-    .grade-pill.g-c { color: #8b1a1a; border-color: rgba(139,26,26,0.35); }
+    .grade-pill.g-c { color: var(--color-accent-red-text); border-color: rgba(139,26,26,0.35); }
     .grade-pill.is-win {
       color: #c8a96e;
       background: rgba(200,169,110,0.08);
@@ -2162,7 +2164,7 @@
       font-weight: 600;
       letter-spacing: 0.16em;
       text-transform: uppercase;
-      color: #6b675f;
+      color: var(--color-text-dim);
       white-space: nowrap;
       transition: color 0.2s;
     }
@@ -2302,7 +2304,7 @@
     .feature-card:hover .feature-num { color: #c8a96e; }
     .feature-card:nth-child(3n):hover .feature-num,
     .feature-card:nth-child(5):hover .feature-num,
-    .feature-card:nth-child(7):hover .feature-num { color: #c0524a; }
+    .feature-card:nth-child(7):hover .feature-num { color: var(--color-accent-red-text); }
 
     /* ---- INSTALL terminal frame ---- */
     .install-terminal {
@@ -2344,7 +2346,7 @@
     }
     .install-code-block code::before {
       content: '$ ';
-      color: #8b1a1a;
+      color: var(--color-accent-red-text);
       font-weight: 700;
     }
 
@@ -2593,13 +2595,13 @@
       text-align: left;
     }
     .term-grade--hold {
-      color: #c0524a;
+      color: var(--color-accent-red-text);
       border-color: rgba(192, 82, 74, 0.5);
     }
     .term-line { display: block; white-space: pre-wrap; }
     .term-line .t-cmd { color: #f0ece4; font-weight: 600; }
-    .t-dim { color: #6b675f; }
-    .t-warn { color: #c0524a; }
+    .t-dim { color: var(--color-text-dim); }
+    .t-warn { color: var(--color-accent-red-text); }
     .term-grade {
       display: inline-flex;
       align-items: center;
@@ -3000,7 +3002,7 @@
     .router-arrow {
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 13px;
-      color: #6b675f;
+      color: var(--color-text-dim);
       transition: color 0.15s ease, transform 0.15s ease;
     }
     a.router-row:hover .router-arrow { color: #c8a96e; transform: translateX(3px); }
@@ -3015,7 +3017,7 @@
       margin: 18px 0 0;
       font-size: 13.5px;
       line-height: 1.65;
-      color: #6b675f;
+      color: var(--color-text-dim);
     }
     .router-note code {
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -4252,7 +4254,7 @@
     </div>
     <div class="footer-links">
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
     </div>
   </div>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -68,7 +68,7 @@
       --hairline: #1a1a18;
       --gold: #c8a96e;
       --red: #8b1a1a;
-      --red-text: #c0524a;
+      --red-text: #c6625a;
       --cream: #f0ece4;
       --muted: #888880;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -500,9 +500,9 @@ codex plugin add suede-skills@suede-codex</code></pre>
     </div>
     <div class="footer-links">
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
     </div>
   </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,7 +8,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/guide.html</loc>
-    <lastmod>2026-07-28</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -384,9 +384,9 @@ cp -R /tmp/suede-creator-skills/skills/amazon-returns-recovery .claude/skills/</
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -365,9 +365,9 @@ cp -R /tmp/suede-creator-skills/skills/android-app-factory .claude/skills/</code
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -86,7 +86,7 @@
       --hairline: #1a1a18;
       --gold: #c8a96e;
       --red: #8b1a1a;
-      --red-text: #c0524a;
+      --red-text: #c6625a;
       --cream: #f0ece4;
       --muted: #888880;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -698,9 +698,9 @@
     </div>
     <div class="footer-links">
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-      <span class="footer-divider">|</span>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
     </div>
   </div>

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -379,9 +379,9 @@ Primary CTA: book a workflow review.</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -378,9 +378,9 @@ Primary CTA: book a workflow review.</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -384,9 +384,9 @@ cp -R /tmp/suede-creator-skills/skills/site-to-ios-app .claude/skills/</code></p
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -383,9 +383,9 @@ cp -R /tmp/suede-creator-skills/skills/subscription-recovery .claude/skills/</co
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -337,9 +337,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -344,9 +344,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -346,9 +346,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -454,9 +454,9 @@ Next:</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -427,9 +427,9 @@ overall = coverage × 0.6 + infra × 0.4</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -340,9 +340,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -334,9 +334,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -387,9 +387,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-campaign-in-a-box .claude/skills/</
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -329,9 +329,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -325,9 +325,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -430,9 +430,9 @@ Overall: A-F</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -381,9 +381,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-code-review .claude/skills/</code><
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -383,9 +383,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-code .claude/skills/</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-codex-fleet.html
+++ b/docs/skills/suede-codex-fleet.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -385,9 +385,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -333,9 +333,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -321,9 +321,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -339,9 +339,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -391,9 +391,9 @@ Primary CTA:</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -329,9 +329,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -385,9 +385,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-design .claude/skills/</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -409,9 +409,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-deslop .claude/skills/</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -334,9 +334,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -331,9 +331,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -329,9 +329,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -386,9 +386,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-launch-packaging .claude/skills/</c
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -331,9 +331,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -334,9 +334,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -326,9 +326,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -333,9 +333,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -352,9 +352,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -323,9 +323,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -381,9 +381,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-mcp-qa .claude/skills/</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -334,9 +334,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -331,9 +331,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -330,9 +330,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -329,9 +329,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -336,9 +336,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -329,9 +329,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -387,9 +387,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -331,9 +331,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -403,9 +403,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -336,9 +336,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -388,9 +388,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-rights-audit .claude/skills/</code>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -413,9 +413,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -337,9 +337,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -388,9 +388,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-seo-audit .claude/skills/</code></p
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-ship-gate.html
+++ b/docs/skills/suede-ship-gate.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -384,9 +384,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship-gate .claude/skills/</code></p
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -326,9 +326,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -383,9 +383,9 @@ cp -R /tmp/suede-creator-skills/skills/suede-site-alchemy .claude/skills/</code>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -335,9 +335,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -340,9 +340,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -60,7 +60,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -387,9 +387,9 @@ Please build the sync positioning, best scenes, mood tags, lyric flags, asset ch
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -53,7 +53,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -332,9 +332,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -423,9 +423,9 @@ Overall: A-F</code></pre>
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -68,7 +68,7 @@
         --hairline: #1a1a18;
         --gold: #c8a96e;
         --red: #8b1a1a;
-        --red-text: #c0524a;
+        --red-text: #c6625a;
         --cream: #f0ece4;
         --muted: #888880;
         --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -458,9 +458,9 @@
           </div>
           <div class="footer-links">
             <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>
-            <span class="footer-divider">|</span>
+            <span class="footer-divider" aria-hidden="true">|</span>
             <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
           </div>
         </div>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1127,6 +1127,36 @@ for (const check of countChecks) {
   for (const problem of a11y) fail.push(problem);
 }
 
+// Contrast-token guard (WCAG 1.4.3). The palette has a deep red for fills and
+// borders and a lighter red for text; the homepage used the fill red as text
+// on four section labels, landing at ~2.1:1 against the near-black background.
+// The lighter values below are the measured AA-passing ones -- they clear 4.5:1
+// on every surface these labels sit on, from the page base to the lightest
+// panel. Raw literals are what drifted, so text colours must go through tokens.
+{
+  const FILL_ONLY_RED = "#8b1a1a";
+  const TEXT_TOKENS = {
+    "--red-text": "#c6625a",
+    "--color-accent-red-text": "#c6625a",
+    "--color-text-dim": "#7f7a70"
+  };
+  for (const pagePath of walk(path.join(repoRoot, "docs")).filter((f) => f.endsWith(".html"))) {
+    const text = readText(pagePath);
+    const relative = path.relative(repoRoot, pagePath);
+    // "border-color:" must not count as a text colour
+    const asText = text.match(new RegExp(String.raw`(?<![-\w])color:\s*${FILL_ONLY_RED}`, "gi")) || [];
+    if (asText.length) {
+      fail.push(`${relative} uses the fill-only red ${FILL_ONLY_RED} as a text colour ${asText.length}x — it fails contrast; use a text token`);
+    }
+    for (const [token, expected] of Object.entries(TEXT_TOKENS)) {
+      const declared = text.match(new RegExp(String.raw`${token}:\s*(#[0-9a-f]{6})`, "i"));
+      if (declared && declared[1].toLowerCase() !== expected) {
+        fail.push(`${relative} sets ${token} to ${declared[1]}; the AA-passing value is ${expected}`);
+      }
+    }
+  }
+}
+
 const indexJsonLdItemMatches = docsRootText.match(/"@type":\s*"ListItem"/g) || [];
 if (indexJsonLdItemMatches.length !== totalSkillCount) {
   fail.push(`docs/index.html JSON-LD ItemList has ${indexJsonLdItemMatches.length} entries, expected ${totalSkillCount}`);


### PR DESCRIPTION
Fifth audit pass. Structure is now clean site-wide — a tag-balance parser over all 76 pages reports **0 unclosed tags and 0 stray closers**, so nothing else has escaped its container the way the marketing lane did in #37.

The finding this pass was colour.

## The bug

The palette has always carried two reds: a deep `#8b1a1a` for fills and borders, and a lighter one for text. Every page **except the homepage** respected that split, defining both `--red` and `--red-text`.

The homepage defined no text red at all and used `#8b1a1a` directly as the colour of four section labels — `.catalog-eyebrow`, `.proof-eyebrow`, `.col-label`, `.scorecard-eyebrow` — at 11px. That measures **2.03–2.16:1** against the near-black background, where WCAG AA requires 4.5:1. The unlisted `dav` page did the same twice.

So this wasn't a brand choice; it was the homepage bypassing a token split that exists precisely to prevent it.

## Fix

Measured in a browser (compositing every ancestor background with alpha down to the page base), then solved for the *lightest* surface each label actually sits on rather than just the page base:

| token | before | after | contrast |
|---|---|---|---|
| red text | `#c0524a` | `#c6625a` | 3.92–4.34 → **4.56–5.05** |
| dim text | `#6b675f` | `#7f7a70` | 3.45–3.56 → **4.55–4.69** |

Both keep the original hue and saturation, raising lightness just past threshold, so the palette still reads as itself — confirmed by screenshot rather than assumed.

Note the existing `#c0524a` was itself marginally under 4.5 everywhere it was used, so this fixes the whole site, not only the homepage.

**Homepage: 11 failing colour pairs → 0.** The last remaining one was the footer `|` divider, which is decorative and contrast-exempt but was not marked as such — it now carries `aria-hidden="true"` on all 74 pages so screen readers skip it instead of announcing it.

## Guard

The fill-only red may not appear as a text colour anywhere under `docs/`, and the three text tokens must hold their AA-passing values. Raw hex literals are what drifted, so text colours go through tokens now.

Negative-tested for both failure modes, plus a check that `border-color:` and `outline-color:` declarations do **not** false-positive. The guard immediately caught the `dav` page, which I had missed by hand.

## Verification

Full suite green — `npm run validate`, 12 runtime, 10 MCP, 27 trigger-routing, 23 Python.