### PR TITLE
llms.txt listed 29 of 67 skills — the whole marketing lane was missing

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 Maintained by Jason Colapietro (Suede Labs AI; alternate name Suede AI, https://suedeai.ai). Repository: https://github.com/JasonColapietro/suede-creator-skills (MIT License). The GitHub Pages site is generated from the same repo: landing page, skill folders, docs, install commands, MCP source, copy bank, sitemap, schema, Open Graph metadata, and founder attribution live beside the source.
 
-Install for Claude Code: `/plugin marketplace add JasonColapietro/suede-creator-skills` then `/plugin install suede-skills@suede`. Focused subsets: `suede-agent-workflows@suede` (orchestration, workflows, evals) and `suede-code@suede` (review, grade, ship-gate).
+Install for Claude Code: `/plugin marketplace add JasonColapietro/suede-creator-skills` then `/plugin install suede-skills@suede`. Focused subsets: `suede-marketing@suede` (38 skills for paid acquisition, outbound, pricing, offers, lifecycle, and analytics), `suede-agent-workflows@suede` (orchestration, workflows, evals), and `suede-code@suede` (review, grade, ship-gate).
 
 Install the full pack for Codex: `codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main` then `codex plugin add suede-skills@suede-codex`. For one skill only, use the built-in skill installer with `--repo JasonColapietro/suede-creator-skills --path skills/<name>`.
 
@@ -42,6 +42,47 @@ Install the full pack for Codex: `codex plugin marketplace add JasonColapietro/s
 - [Android App Factory](https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html): Plan or build a native Android app end to end from a keyword: Kotlin + Jetpack Compose scaffolding, Play Billing, Play Store screenshots and ASO listing copy, Data Safety disclosure, signing, and Google Play Console release.
 - [Amazon Returns Recovery](https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html): Scan Amazon order and return history for restocking fees and short refunds, then drive Amazon live chat to get the money waived and refunded (requires the Claude in Chrome extension).
 - [Subscription Recovery](https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html): Audit any recurring subscription (Netflix, Spotify, gyms, App Store, Google Play, PayPal) and cancel or negotiate a refund through that service's own support.
+
+## Marketing and growth skills
+
+- [Suede A/B Testing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html): Test so the result means something.
+- [Suede Ad Creative](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html): Produce ad creative at volume.
+- [Suede Ads](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html): Run paid acquisition that pays back.
+- [Suede Analytics](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html): Know whether any of it worked.
+- [Suede ASO](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html): Optimise an App Store or Play listing.
+- [Suede Churn Prevention](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html): Keep subscribers who are leaving and recover the ones you lose to billing.
+- [Suede Co Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html): Find and run partner campaigns.
+- [Suede Cold Email](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html): Write B2B cold outreach that gets replies.
+- [Suede Community Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html): Build a community that compounds.
+- [Suede Competitor Profiling](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html): Research competitors from their public surfaces and turn the findings into structured profiles.
+- [Suede Competitors](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html): Write comparison and alternative pages that rank and convert without misrepresenting anyone.
+- [Suede Content Strategy](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html): Decide what to publish and why.
+- [Suede Customer Research](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html): Find out what customers actually think.
+- [Suede Directory Submissions](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html): Work the directory layer deliberately.
+- [Suede Emails](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html): Design lifecycle email that runs itself.
+- [Suede Free Tools](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html): Engineering as marketing.
+- [Suede Image](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html): Create and optimise marketing imagery.
+- [Suede Lead Magnets](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html): Decide what to give away for an email.
+- [Suede Marketing Council](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html): Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.
+- [Suede Marketing Ideas](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html): Get unstuck with a structured idea library rather than a blank page.
+- [Suede Marketing Loops](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html): Turn marketing into a recurring loop an agent runs on a cadence.
+- [Suede Marketing Plan](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html): Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.
+- [Suede Marketing Psychology](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html): Apply behavioural science honestly.
+- [Suede Offers](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html): Construct the thing you actually sell.
+- [Suede Onboarding](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html): Get a new user to first value fast.
+- [Suede Paywalls](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html): Design in-app upgrade moments that convert without resentment.
+- [Suede Pricing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html): Decide what to charge and how to package it.
+- [Suede Product Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html): Establish the product context every other marketing lane reads from.
+- [Suede Programmatic SEO](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html): Build search pages at scale without building junk.
+- [Suede Prospecting](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html): Build and qualify a target list before you write a word.
+- [Suede Public Relations](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html): Earn coverage without a retainer.
+- [Suede Referrals](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html): Turn customers into a channel.
+- [Suede RevOps](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html): Wire marketing to revenue.
+- [Suede Sales Enablement](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html): Arm the people doing the selling.
+- [Suede Signup](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html): Cut friction out of registration.
+- [Suede SMS](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html): Run SMS without getting blocked or resented.
+- [Suede Social](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html): Run social as a channel rather than a chore.
+- [Suede Video](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html): Plan and produce marketing video.
 
 ## Creator skills (music, rights, campaigns)
 

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1070,8 +1070,17 @@ for (const check of countChecks) {
     const manifest = JSON.parse(readText(marketplacePath));
     const installText = readText(installPagePath);
     const umbrella = "suede-skills";
+    // llms.txt is the file agents read to learn what the pack contains, so a
+    // plugin missing there is as undiscoverable as one missing from the install
+    // page. Guarding only plugins.html let llms.txt keep advertising two
+    // subsets after a third shipped.
+    const llmsPath = path.join(repoRoot, "docs/llms.txt");
+    const llmsText = fs.existsSync(llmsPath) ? readText(llmsPath) : "";
     for (const plugin of manifest.plugins ?? []) {
       if (plugin.name === umbrella) continue;
+      if (llmsText && !llmsText.includes(`${plugin.name}@suede`)) {
+        fail.push(`docs/llms.txt never mentions the ${plugin.name} plugin — agents reading it cannot discover the subset`);
+      }
       if (!installText.includes(`${plugin.name}@suede`)) {
         fail.push(`docs/plugins.html never advertises the ${plugin.name} plugin, so nobody can discover it`);
         continue;
@@ -1152,6 +1161,40 @@ for (const check of countChecks) {
       const declared = text.match(new RegExp(String.raw`${token}:\s*(#[0-9a-f]{6})`, "i"));
       if (declared && declared[1].toLowerCase() !== expected) {
         fail.push(`${relative} sets ${token} to ${declared[1]}; the AA-passing value is ${expected}`);
+      }
+    }
+  }
+}
+
+// llms.txt coverage. This file exists so an agent can learn what the pack
+// contains without crawling; a skill absent from it is invisible to exactly
+// the audience the pack is built for. It listed 29 of 67 -- the whole
+// marketing lane was missing -- while the count line above it said 67, so no
+// count check could have caught the gap. Every link must also resolve, since a
+// 404 in this file teaches an agent a URL that does not exist.
+{
+  const llmsPath = path.join(repoRoot, "docs/llms.txt");
+  if (!fs.existsSync(llmsPath)) {
+    fail.push("docs/llms.txt is missing");
+  } else {
+    const llmsText = readText(llmsPath);
+    const uncovered = skillNames.filter((name) => !llmsText.includes(name));
+    if (uncovered.length) {
+      fail.push(`docs/llms.txt does not reference ${uncovered.length} of ${skillNames.length} skills: ${uncovered.join(", ")}`);
+    }
+    const siteBase = "https://jasoncolapietro.github.io/suede-creator-skills/";
+    const blobBase = "https://github.com/JasonColapietro/suede-creator-skills/blob/main/";
+    for (const rawUrl of llmsText.match(/https:\/\/[^\s)\]]+/g) || []) {
+      const url = rawUrl.replace(/[.,)]+$/, "");
+      let target = null;
+      if (url.startsWith(siteBase)) {
+        const rel = url.slice(siteBase.length) || "index.html";
+        target = path.join(repoRoot, "docs", rel.endsWith("/") ? `${rel}index.html` : rel);
+      } else if (url.startsWith(blobBase)) {
+        target = path.join(repoRoot, url.slice(blobBase.length));
+      }
+      if (target && !fs.existsSync(target)) {
+        fail.push(`docs/llms.txt links to a path that does not exist: ${url}`);
       }
     }
   }

--- a/tests/test_neutral_oss_positioning.py
+++ b/tests/test_neutral_oss_positioning.py
@@ -111,7 +111,12 @@ class NeutralOssPositioningTests(unittest.TestCase):
         # named "<plugin>@suede" install are exempt; a bare number in prose is
         # still a stale pack-size claim. The bundle sizes themselves are checked
         # against the marketplace manifest by scripts/validate-skill-pack.mjs.
-        subset_claim = re.compile(r"suede-[a-z-]+@suede</code>\s*\((?:\d+)[^)]*\bskills\b[^)]*\)")
+        # The surfaces span HTML and Markdown, so the plugin name may be closed
+        # by </code> or by a backtick. Matching only the HTML form silently
+        # stopped exempting llms.txt the moment a subset was documented there.
+        subset_claim = re.compile(
+            r"suede-[a-z-]+@suede(?:</code>|`)\s*\((?:\d+)[^)]*\bskills\b[^)]*\)"
+        )
         for surface in ["README.md", "docs/index.html", "docs/guide.html", "docs/plugins.html", "docs/copy.html", "docs/skills/index.html", "docs/llms.txt"]:
             text = subset_claim.sub("", read(surface))
             for stale in stale_counts:


### PR DESCRIPTION
Sixth audit pass.

## The finding

`docs/llms.txt` is the file an agent reads to learn what the pack contains without crawling it. It referenced **29 skills**. The 38 it omitted were the entire marketing and growth lane.

That is the **third** time this same set of 38 has turned up hidden:

| PR | Where they were invisible |
|---|---|
| #34 | undiscoverable as a plugin — `suede-marketing@suede` unadvertised |
| #37 | rendering gold-on-gold, literally unreadable, on the catalog page |
| this | absent from the agent-facing index |

For a pack whose entire pitch is that agents can find and load its skills, missing 57% of it from `llms.txt` is the worst possible place for the gap.

**No count check could have caught this.** The summary line at the top of the file already said 67, and it was accurate. The number was right; the list was not. That is a different failure mode from every stale-count bug found in passes 1–5, and it needed a different kind of guard.

## Also fixed

The install line still advertised two focused subsets after a third shipped. That was a miss in PR #34 — the discoverability guard I added there checked only `docs/plugins.html`, so `llms.txt` drifted unwatched.

## Changes

- new "Marketing and growth skills" section with all 38 entries, generated from the catalog page's own descriptions so the copy matches what the site already says
- install line now lists all three subsets
- **guard**: every skill folder must be referenced in `llms.txt`
- **guard**: every `llms.txt` link must resolve to a real path, so the file cannot teach an agent a URL that 404s
- **guard**: every non-umbrella plugin must appear in `llms.txt`, not only `plugins.html`

All negative-tested. The dead-link check was verified in isolation, using a break that keeps the skill name present, so it is proven to fire on its own rather than being masked by the coverage check.

## Checked and found clean

- 4 pages matched an animation grep but carry only 0.15s hover/focus transitions — no autoplaying or infinite animation, so `prefers-reduced-motion` is not required. Not a finding.
- All 60 links in `llms.txt` resolve.
- `robots.txt` correctly allows all and points at the sitemap.

## Verification

Full suite green — `npm run validate`, 12 runtime, 10 MCP, 27 trigger-routing, 23 Python.