### PR TITLE
llms.txt claimed the guide documents every skill; it documents 17

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@ Install the full pack for Codex: `codex plugin marketplace add JasonColapietro/s
 ## Start here
 
 - [Overview](https://jasoncolapietro.github.io/suede-creator-skills/): Public landing page with install commands, the full skill catalog, FAQ, schema, and proof links.
-- [Full guide](https://jasoncolapietro.github.io/suede-creator-skills/guide.html): Complete documentation of every skill, the MCP server, and the agent workflow.
+- [Full guide](https://jasoncolapietro.github.io/suede-creator-skills/guide.html): How the pack fits together as one workflow, plus the MCP server, install paths, and the FAQ. Covers the core orchestration, code, design, and creator skills in depth; the complete list of all 67 is on the skill index above.
 - [Skill index](https://jasoncolapietro.github.io/suede-creator-skills/skills/): Browse all 67 skills.
 - [Installs and MCP](https://jasoncolapietro.github.io/suede-creator-skills/plugins.html): Install commands for Claude Code and Codex, plus the optional Suede Skills MCP server.
 - [Copy bank](https://jasoncolapietro.github.io/suede-creator-skills/copy.html): Public-safe explainer copy and reusable launch language.

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1182,6 +1182,25 @@ for (const check of countChecks) {
     if (uncovered.length) {
       fail.push(`docs/llms.txt does not reference ${uncovered.length} of ${skillNames.length} skills: ${uncovered.join(", ")}`);
     }
+    // Completeness claims must be true of the page they describe. llms.txt
+    // called guide.html "Complete documentation of every skill" while that page
+    // covers the core workflow skills only, so an agent following the link to
+    // enumerate the pack would come away with a fraction of it. A claim like
+    // this is only allowed when the linked page actually references every skill.
+    const COMPLETENESS = /\b(complete documentation of every skill|documentation of every skill|every skill|all \d+ skills)\b/i;
+    for (const entry of llmsText.split("\n").filter((line) => line.trim().startsWith("- ["))) {
+      if (!COMPLETENESS.test(entry)) continue;
+      const linked = entry.match(/\]\((https:\/\/jasoncolapietro\.github\.io\/suede-creator-skills\/[^)]*)\)/)?.[1];
+      if (!linked) continue;
+      const rel = linked.slice("https://jasoncolapietro.github.io/suede-creator-skills/".length) || "index.html";
+      const target = path.join(repoRoot, "docs", rel.endsWith("/") ? `${rel}index.html` : rel);
+      if (!fs.existsSync(target)) continue;
+      const pageText = readText(target);
+      const absent = skillNames.filter((name) => !pageText.includes(name));
+      if (absent.length) {
+        fail.push(`docs/llms.txt claims completeness for ${rel} but that page omits ${absent.length} of ${skillNames.length} skills`);
+      }
+    }
     const siteBase = "https://jasoncolapietro.github.io/suede-creator-skills/";
     const blobBase = "https://github.com/JasonColapietro/suede-creator-skills/blob/main/";
     for (const rawUrl of llmsText.match(/https:\/\/[^\s)\]]+/g) || []) {
@@ -1195,6 +1214,40 @@ for (const check of countChecks) {
       }
       if (target && !fs.existsSync(target)) {
         fail.push(`docs/llms.txt links to a path that does not exist: ${url}`);
+      }
+    }
+  }
+}
+
+// The MCP surface counts are published as prose in two docs. The test suite
+// already pins mcp/catalog.json against the live server, so the numbers are
+// true at the source; what was unguarded is the sentence quoting them. Adding
+// a tool would update the server, the catalog, and the test while leaving both
+// pages advertising the old figure -- the same drift that stranded the skill
+// count on unguarded surfaces.
+{
+  const mcpCatalogPath = path.join(repoRoot, "mcp/catalog.json");
+  if (fs.existsSync(mcpCatalogPath)) {
+    const mcp = JSON.parse(readText(mcpCatalogPath)).mcp ?? {};
+    const expected = {
+      tools: mcp.tools?.length,
+      resources: mcp.resources?.length,
+      prompts: mcp.prompts?.length
+    };
+    for (const surface of ["docs/llms.txt", "docs/plugins.html"]) {
+      const surfacePath = path.join(repoRoot, surface);
+      if (!fs.existsSync(surfacePath)) continue;
+      const claim = readText(surfacePath).match(/(\d+) tools?, (\d+) resources?, (\d+) prompts?/);
+      if (!claim) {
+        warn.push(`${surface} no longer states the MCP tool/resource/prompt counts — guard may need updating`);
+        continue;
+      }
+      const [, tools, resources, prompts] = claim.map(Number);
+      const actual = { tools, resources, prompts };
+      for (const key of ["tools", "resources", "prompts"]) {
+        if (expected[key] !== undefined && actual[key] !== expected[key]) {
+          fail.push(`${surface} advertises ${actual[key]} MCP ${key}; mcp/catalog.json declares ${expected[key]}`);
+        }
       }
     }
   }


### PR DESCRIPTION
Seventh audit pass. Having found the same 38 skills hidden in three surfaces (#34, #37, #39), this pass checked **every** remaining inventory that claims to list the pack.

## Result

| surface | coverage | verdict |
|---|---|---|
| README.md | 67/67 | clean |
| docs/index.html | 67/67 | clean |
| docs/skills/index.html | 67/67 | clean |
| docs/llms.txt | 67/67 | clean (fixed in #39) |
| mcp/catalog.json | 67/67 | clean |
| **live MCP server** | **67/67** | clean — probed directly |
| **docs/guide.html** | **17/67** | **advertised as complete** |
| COPY.md / PROMO.md / copy.html | partial | correct — copy banks, no completeness claim |

## The finding

`docs/llms.txt` described `guide.html` as *"Complete documentation of every skill, the MCP server, and the agent workflow."* That page references **17 of 67**.

The guide isn't a catalog — it's the workflow narrative plus the MCP server, install paths, and FAQ. And the skill index directly above it in the same file already lists all 67. So the fix is the description, not the page: an agent following that link to enumerate the pack would come away with a quarter of it and no signal anything was missing.

**Guard** generalises the class: any `llms.txt` entry claiming completeness must link to a page that actually references every skill. Negative-tested both ways — the false claim on `guide.html` fails, and the identical wording attached to the skill index, where it is true, passes.

## Also: the published MCP counts were unguarded

The suite already pins `mcp/catalog.json` against the live server, so those numbers are true at the source. What was unguarded was the *sentence quoting them* in `llms.txt` and `plugins.html`. Adding a tool would update the server, the catalog, and the test while both pages kept advertising the old figure — exactly the drift that stranded the skill count on unguarded surfaces in #33.

Verified live before guarding by driving the server over stdio: **7 tools, 6 resources, 5 prompts** — all correct as published. Guard negative-tested by simulating a new tool; both surfaces are caught.

## Clean

The homepage JSON-LD `ItemList` holds 67 items with contiguous positions 1–67, no duplicate positions, and every URL resolving to a real page.

## Verification

Full suite green, read untruncated this time: `npm run validate`, 12 runtime, 10 MCP, 27 trigger-routing, 23 Python — `OK`.