### PR TITLE
docs(changelog): log the Aug 1 accessibility and discoverability run

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3331,6 +3331,24 @@
           <h3 class="clog-title">Reserved MCP metadata no longer breaks startup</h3>
           <p class="clog-detail">Version 0.9.2 accepts the protocol-reserved <code>_meta</code> object sent by current Codex clients while keeping closed parameter validation for every unrelated key. Both Suede MCP profiles now complete discovery instead of failing at <code>tools/list</code>.</p>
         </li>
+        <li class="clog-item" data-type="site">
+          <p class="clog-meta">
+            <span class="clog-date">2026-08-01</span>
+            <span class="clog-tag">Fix</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/f7cd12e" target="_blank" rel="noopener" aria-label="View commit f7cd12e on GitHub">f7cd12e</a>
+          </p>
+          <h3 class="clog-title">The thirty-eight marketing skills stop being invisible</h3>
+          <p class="clog-detail">The marketing and growth lane opened inside the gold install band instead of the catalog, so every skill name in it rendered gold on gold at a contrast ratio of 1.0. The same thirty-eight were absent from <code>llms.txt</code>, which listed 29 of 67, and their plugin was advertised on no page. Catalog titles, share-card alt text and lane badges still read 28. Each fix ships with a validator guard, so the gap cannot reopen silently.</p>
+        </li>
+        <li class="clog-item" data-type="site">
+          <p class="clog-meta">
+            <span class="clog-date">2026-08-01</span>
+            <span class="clog-tag">Fix</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/8e30eca" target="_blank" rel="noopener" aria-label="View commit 8e30eca on GitHub">8e30eca</a>
+          </p>
+          <h3 class="clog-title">Seventy-two pages become keyboard passable</h3>
+          <p class="clog-detail">Every page carries the same nav, and 72 of them had no way past it. All 67 skill pages plus the catalog, install, copy bank and both blog pages now ship a skip link targeting a focusable <code>&lt;main&gt;</code>, per WCAG 2.4.1. Four homepage section labels also stopped using the fill-only red as text, moving from 2.03:1 to 4.56:1 and above once every ancestor background is composited, per WCAG 1.4.3.</p>
+        </li>
         <li class="clog-item" data-type="fix">
           <p class="clog-meta">
             <span class="clog-date">2026-07-28</span>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -14,7 +14,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -577,6 +577,24 @@
         </li>
         <li>
           <p class="clog-meta">
+            <span class="clog-date">2026-08-01</span>
+            <span class="clog-tag clog-tag--fix">Site</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/f7cd12e" target="_blank" rel="noopener" aria-label="View commit f7cd12e on GitHub">f7cd12e</a>
+          </p>
+          <h3>The thirty-eight marketing skills stop being invisible</h3>
+          <p class="clog-detail">The marketing and growth lane opened inside the gold install band instead of the catalog, rendering gold on gold at a contrast ratio of 1.0. The same thirty-eight were missing from <code>llms.txt</code> and their plugin was advertised nowhere. Counts on this page still read 28. Every fix ships with a validator guard.</p>
+        </li>
+        <li>
+          <p class="clog-meta">
+            <span class="clog-date">2026-08-01</span>
+            <span class="clog-tag clog-tag--guard">Site</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/8e30eca" target="_blank" rel="noopener" aria-label="View commit 8e30eca on GitHub">8e30eca</a>
+          </p>
+          <h3>Seventy-two pages become keyboard passable</h3>
+          <p class="clog-detail">All 67 skill pages plus the catalog, install, copy bank and both blog pages now ship a skip link targeting a focusable <code>&lt;main&gt;</code>, per WCAG 2.4.1. Four homepage labels also stopped using the fill-only red as text, clearing 4.5:1 against every composited background.</p>
+        </li>
+        <li>
+          <p class="clog-meta">
             <span class="clog-date">2026-07-28</span>
             <span class="clog-tag clog-tag--fix">Rework</span>
             <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/189ae51" target="_blank" rel="noopener" aria-label="View commit 189ae51 on GitHub">189ae51</a>


### PR DESCRIPTION
Eight commits merged on 2026-08-01 (#33 through #40) never reached the ship log. Only the MCP metadata fix (#41) got an entry, so the site's changelog jumps from 2026-07-28 straight to the MCP fix and skips the largest accessibility and discoverability run the pack has had.

Backfilled as two entries, added to both hand-maintained changelog surfaces (`docs/index.html` `#clog-list` and `docs/skills/index.html` `ol.clog`):

**f7cd12e, "The thirty-eight marketing skills stop being invisible"** covers #33, #34, #37, #39, #40. The marketing lane rendered gold on gold at a contrast ratio of 1.0 inside the install band, was missing from `llms.txt` (which listed 29 of 67), and its plugin was advertised on no page. Catalog titles, share-card alt text and lane badges still read 28.

**8e30eca, "Seventy-two pages become keyboard passable"** covers #35 and #38. 72 pages had no skip link past a shared nav (WCAG 2.4.1), and four homepage section labels used the fill-only red as text at 2.03:1 (WCAG 1.4.3).

#36 is test-only isolation and is deliberately not logged; the ship log is user-facing.

Both entries are dated 2026-08-01 and sit **below** the MCP entry, which stays newest. So the three `#hero-shiplog` boxes and the release pill are untouched and still track 67a2b51. Sitemap regenerated.

`npm run validate` (strict) passes: 67 skills against 67 catalog entries, trigger routing 6 groups / 23 cases. Verified in a headless render that both new entries appear in the right position and are readable.