### PR TITLE
fix(docs): regenerate sitemap from committed git dates

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,37 +2,37 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/guide.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/copy.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/plugins.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
@@ -254,7 +254,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -410,7 +410,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
The sitemap generator derives `lastmod` from committed git dates, so a sitemap generated before the publish commit lands is stale the moment it does. Same follow-up the `suede-ship` publish needed — CI on `main` caught it after [#49](https://github.com/JasonColapietro/suede-creator-skills/pull/49).

8 `lastmod` values corrected. `validate-skill-pack --strict`: 70 skills against 70 catalog entries, clean.