### PR TITLE
ci: add the required build job that branch protection expects

### DIFF
--- a/.github/workflows/skill-pack-ci.yml
+++ b/.github/workflows/skill-pack-ci.yml
@@ -68,3 +68,46 @@ jobs:
           else
             git show --check --format= --no-renames "$GITHUB_SHA"
           fi
+
+  # `build` is a required status check on main. It existed in branch protection
+  # but no job produced it, so every pull request was permanently blocked and
+  # merges only landed via admin bypass. Rather than drop the requirement, this
+  # job makes it real: it exercises install.sh — the documented user-facing
+  # install path — which nothing else in CI covered.
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install the pack into a sandboxed HOME
+        run: |
+          set -euo pipefail
+          SANDBOX="$(mktemp -d)"
+          HOME="$SANDBOX" bash install.sh
+          installed="$(find "$SANDBOX/.claude/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          expected="$(find skills -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')"
+          manifests="$(find "$SANDBOX/.claude/skills" -name SKILL.md | wc -l | tr -d ' ')"
+          echo "installed=$installed expected=$expected SKILL.md=$manifests"
+          if [ "$installed" != "$expected" ]; then
+            echo "::error::install.sh installed $installed skills, repository has $expected"
+            exit 1
+          fi
+          if [ "$manifests" != "$expected" ]; then
+            echo "::error::install.sh landed $manifests SKILL.md files, expected $expected"
+            exit 1
+          fi
+
+      - name: Verify plugin manifests parse
+        run: |
+          set -euo pipefail
+          for manifest in .claude-plugin/marketplace.json .claude-plugin/plugin.json \
+                          .codex-plugin/plugin.json .agents/plugins/marketplace.json \
+                          mcp/catalog.json; do
+            node -e "JSON.parse(require('fs').readFileSync('$manifest','utf8'))" \
+              || { echo "::error::$manifest is not valid JSON"; exit 1; }
+          done
+          echo "all plugin manifests parse"


### PR DESCRIPTION
## The problem

`main` requires two status checks:

```
required checks: ["validate", "build"]
enforce_admins: false
```

**No job produces `build`.** It can never report, so every PR sits at `MERGEABLE BLOCKED` forever. The merges that have landed did so via admin bypass. For a non-admin contributor this repository is currently unmergeable — which matters now that #42 adds a public contribution program.

## The fix

Make the check real rather than drop the requirement. The new `build` job exercises **`install.sh`** — the documented user-facing install path, which nothing in CI covered:

- installs the pack into a sandboxed `HOME`
- asserts the installed skill-folder count matches the repository
- asserts every `SKILL.md` landed
- verifies all five plugin manifests parse

## Verification

Simulated locally against the real script: `installed=71 expected=71 SKILL.md=71`, all manifests parse.

Both failure paths confirmed to fail rather than pass silently:

| Injected fault | Result |
|---|---|
| skill folder with no `SKILL.md` | `SKILL.md 71 != expected 72` → job fails |
| malformed `mcp/catalog.json` | JSON parse → job fails |

Branch protection itself is untouched by this PR.