### PR TITLE
fix(docs): regenerate sitemap after the contribution-workflow merge

### DIFF
--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -62,7 +62,7 @@
   </url>
   <url>
     <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-05</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>


### PR DESCRIPTION
`main` is currently **red**: `validate` fails with `docs/sitemap.xml is out of date`.

## Cause

`generate-sitemap.mjs` derives `lastmod` from committed git dates. Squash-merging #42 gave `docs/skills/suede-agent-teams.html` a new commit date (2026-08-02 → 2026-08-05), so the committed sitemap went stale the instant the squash landed.

**The PR's own CI could not have caught this** — the commit that changes the date is created by the merge itself. Any PR touching a docs page will red `main` the same way.

## Fix

Regenerate and commit. `npm run ci` passes with the regenerated file.

## Worth noting

This is structural, not a one-off — #50 was the same class of fix. Options if you want it to stop recurring: generate the sitemap at deploy time instead of committing it, or have the validator tolerate a `lastmod` that is newer than the committed one. Happy to do either as a follow-up.