### PR TITLE
fix: close scope laundering and make publication evidence durable

### DIFF
--- a/skills/suede-agent-teams/scripts/contribution-ledger.mjs
+++ b/skills/suede-agent-teams/scripts/contribution-ledger.mjs
@@ -564,6 +564,19 @@ function addTask(options) {
     if (ledger.items.some((entry) => entry.repo === repo && entry.ref === ref)) {
       throw new UsageError(`Duplicate repo/ref task: ${repo} ${ref}`);
     }
+    const conflictingScope = ledger.items.find(
+      (entry) => entry.repo === repo && entry.scope !== scope,
+    );
+    if (conflictingScope) {
+      // Scope is a property of the repository, not of one task. Allowing both
+      // scopes for the same repo let an "owned" twin obtain a merge grant for
+      // a repository the ledger had already classified as external — the
+      // external-merge prohibition held per task while being defeated in
+      // substance.
+      throw new UsageError(
+        `Repository ${repo} is already tracked as ${conflictingScope.scope} by task ${conflictingScope.id}; one repository cannot hold both scopes`,
+      );
+    }
     const createdAt = nowIso();
     const task = {
       id,
@@ -920,6 +933,18 @@ function requireArtifactPacket(task) {
 }
 
 function clearPackagingEvidence(task) {
+  // Publications record real, already-performed pushes and pull requests
+  // upstream. Requeuing a task must reset its working state, but it must not
+  // be able to erase evidence of what was actually published: `published ->
+  // queued` requires no authority at all, and `history` is FIFO-capped, so a
+  // handful of heartbeats used to remove the last trace. The log is
+  // append-only and exempt from that cap.
+  if (task.publications?.length) {
+    task.publicationLog ??= [];
+    for (const entry of task.publications) {
+      task.publicationLog.push({ ...entry, clearedAt: nowIso() });
+    }
+  }
   task.artifacts = {};
   task.packet = null;
   task.grants = {};

--- a/tests/test_contribution_ledger.mjs
+++ b/tests/test_contribution_ledger.mjs
@@ -1014,3 +1014,63 @@ test("the required disclosure statement cannot be used as a lint kill switch", (
   ]);
   assert.equal(accepted.task.disclosure, "required");
 });
+
+test("one repository cannot be tracked under two scopes", (t) => {
+  const { ledger } = workspace(t);
+  success(["init", "--ledger", ledger]);
+  add(ledger, { repo: "upstream/project", ref: "42", scope: "external" });
+
+  // Scope is a property of the repository. An "owned" twin for a repository
+  // already classified as external could take a merge grant, defeating the
+  // external-merge prohibition in substance while honouring it per task.
+  const laundered = cli([
+    "add", "--ledger", ledger, "--repo", "upstream/project", "--ref", "43",
+    "--title", "Owned twin", "--scope", "owned",
+    "--ownership-evidence", "trust me",
+    "--disclosure", "not-required",
+    "--disclosure-source", "Checked repository contribution instructions",
+  ]);
+  assert.equal(laundered.status, 1);
+  assert.match(laundered.stderr, /already tracked as external/);
+
+  // A second task on the same repo with the same scope is still fine.
+  const sameScope = add(ledger, { repo: "upstream/project", ref: "44", scope: "external" });
+  assert.equal(sameScope.scope, "external");
+});
+
+test("requeuing a published task preserves what was actually published", (t) => {
+  const { directory, ledger } = workspace(t);
+  success(["init", "--ledger", ledger]);
+  let task = add(ledger, { scope: "owned" });
+  const worker = "builder";
+  task = advanceToReviewed(ledger, task, worker);
+  recordArtifacts(directory, ledger, task, worker);
+  task = transition(ledger, task, worker, "packet_ready");
+  success([
+    "configure", "--ledger", ledger, "--publish-mode", "owned",
+    "--actor", "owner", "--authority-note", "Owner approved this run",
+  ]);
+  success([
+    "grant", "--ledger", ledger, "--id", task.id, "--capability", "push",
+    "--actor", "owner", "--authority-note", "Push this named branch only",
+    "--target", "refs/heads/feature/empty-metadata",
+  ]);
+  const remoteUrl = "https://github.com/example/project/tree/feature/empty-metadata";
+  success([
+    "transition", "--ledger", ledger, "--id", task.id, "--to", "published",
+    "--action", "push", "--authority-target", "refs/heads/feature/empty-metadata",
+    "--remote-url", remoteUrl, "--performed-by", "publisher",
+  ]);
+
+  // published -> queued needs no authority at all, and `history` is FIFO-capped,
+  // so this path used to erase the last trace of a real upstream push.
+  success(["transition", "--ledger", ledger, "--id", task.id, "--to", "queued"]);
+
+  const stored = JSON.parse(fs.readFileSync(ledger, "utf8"))
+    .items.find(({ id }) => id === task.id);
+  assert.equal(stored.publications.length, 0, "working state is reset");
+  assert.equal(stored.publicationLog.length, 1, "the published action survives");
+  assert.equal(stored.publicationLog[0].action, "push");
+  assert.equal(stored.publicationLog[0].remoteUrl, remoteUrl);
+  assert.ok(stored.publicationLog[0].clearedAt);
+});


### PR DESCRIPTION
The last two findings from the two-agent QA on #42.

## Scope laundering

The same repository could be tracked twice — once `external`, once `owned` with free-text `--ownership-evidence` — and the owned twin could then take a merge grant and merge.

The external-merge prohibition held *per task* while being defeated *in substance*: the ledger already knew that repository was external. Scope is a property of the repository, so a second scope for an already-tracked repo is now refused. The duplicate repo/ref check runs first, so the more specific error still wins.

```
Repository upstream/project is already tracked as external by task a8c94d0ff43c;
one repository cannot hold both scopes
```

## Publication evidence was erasable with no authority

`published -> queued` requires no worker, grant, or actor — at `published` the lease is null, so the ownership check is skipped — and it cleared `publications` outright. The only remaining trace lived in `history`, which is FIFO-capped at 100, so a handful of routine heartbeats removed the last record that a real push or PR had happened upstream. Agent B demonstrated two real pushes with the ledger reporting one.

Cleared publications now move to an append-only `publicationLog` that requeuing does not touch and the history cap does not trim:

```
before requeue: publications=1
after requeue:  publications=0  publicationLog=1
  PRESERVED: push -> https://github.com/mine/project/tree/feature/x
```

## Verification

Both original attacks reproduced against the fixes and now blocked. Two regression tests added (28 total), each mutation-verified:

| Guard removed | Result |
|---|---|
| scope-conflict | 27 pass / 1 fail |
| publication-log | 27 pass / 1 fail |

`npm run ci` passes.