### PR TITLE
fix(docs): make README skill count uniformly 71 and guard repeats

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In Claude Code, add the marketplace and install the pack:
 /plugin install suede-skills@suede
 ```
 
-`suede-skills` installs all 70 skills. Two focused subsets are available if you want less: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) and `/plugin install suede-code@suede` (review, grade, ship-gate).
+`suede-skills` installs all 71 skills. Two focused subsets are available if you want less: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) and `/plugin install suede-code@suede` (review, grade, ship-gate).
 
 In Codex, add the repo's Codex-native marketplace and install the complete
 plugin:
@@ -41,10 +41,10 @@ codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main
 codex plugin add suede-skills@suede-codex
 ```
 
-The Codex plugin loads all 70 skills and registers both read-only MCP discovery
+The Codex plugin loads all 71 skills and registers both read-only MCP discovery
 profiles. Restart Codex after installing or updating it.
 
-Prefer a clone? `install.sh` copies all 70 skills into `~/.claude/skills/` and prints the installed count:
+Prefer a clone? `install.sh` copies all 71 skills into `~/.claude/skills/` and prints the installed count:
 
 ```bash
 git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
@@ -202,7 +202,7 @@ codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main
 codex plugin add suede-skills@suede-codex
 ```
 
-This installs all 70 skills and registers both read-only MCP discovery
+This installs all 71 skills and registers both read-only MCP discovery
 profiles. Restart Codex after installing or updating.
 
 For one selected skill, use the built-in skill installer:
@@ -218,7 +218,7 @@ set instead of the full plugin.
 
 ## Install for Claude Code
 
-All 70 skills:
+All 71 skills:
 
 ```bash
 git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -934,6 +934,12 @@ const countChecks = [
   { file: "README.md", label: "skills badge URL value", re: /img\.shields\.io\/badge\/Skills-(\d+)-black/, expected: totalSkillCount },
   { file: "README.md", label: "skills badge alt text", re: /!\[Skills: (\d+)\]/, expected: totalSkillCount },
   { file: "README.md", label: "intro toolkit size", re: /A (\d+)-skill toolkit for Claude Code/, expected: totalSkillCount },
+  // The install sections repeat "all N skills" five times — plugin, Codex
+  // plugin, install.sh, Codex clone, and the Claude Code heading. All five sat
+  // at 70 while the badge and intro said 71, because nothing guarded them and
+  // a first-match check would have cleared the file on occurrence one.
+  { file: "README.md", label: "install-section pack size", re: /[Aa]ll (\d+) skills/, expected: totalSkillCount, every: true },
+  { file: "README.md", label: "public skill folders", re: /\*\*(\d+) public skill folders\*\*/, expected: totalSkillCount },
   { file: "CITATION.cff", label: "abstract skill count", re: /pack of (\d+) installable Agent Skills/, expected: totalSkillCount },
   { file: "docs/llms.txt", label: "summary skill count", re: /pack of (\d+) installable Agent Skills/, expected: totalSkillCount },
   { file: "docs/llms.txt", label: "skill index line", re: /Browse all (\d+) skills\./, expected: totalSkillCount },
@@ -962,19 +968,29 @@ for (const check of countChecks) {
     continue;
   }
   const text = readText(filePath);
-  const match = text.match(check.re);
-  if (!match) {
+  // Most checks guard a phrase that appears once. `every: true` guards a phrase
+  // that repeats — every occurrence is validated, not just the first. Without
+  // it, a repeated sentence drifts silently past the first hit: README said
+  // "71" in three places and "all 70 skills" in five others, and a first-match
+  // check on either phrasing would have reported the file clean.
+  const matches = check.every
+    ? [...text.matchAll(new RegExp(check.re.source, `${check.re.flags.replace(/g/g, "")}g`))]
+    : [text.match(check.re)].filter(Boolean);
+  if (matches.length === 0) {
     warn.push(`Count check pattern not found in ${check.file} (${check.label}) — copy may have moved; update scripts/validate-skill-pack.mjs`);
     continue;
   }
-  const found = check.wordNumber ? wordNumber(match[1]) : parseInt(match[1], 10);
-  if (found === null || Number.isNaN(found)) {
-    warn.push(`Count check could not parse a number in ${check.file} (${check.label}): "${match[1]}"`);
-    continue;
-  }
-  if (found !== check.expected) {
-    fail.push(`Stale skill count in ${check.file} (${check.label}): says ${found}, expected ${check.expected}`);
-  }
+  matches.forEach((match, i) => {
+    const where = check.every ? ` [occurrence ${i + 1} of ${matches.length}]` : "";
+    const found = check.wordNumber ? wordNumber(match[1]) : parseInt(match[1], 10);
+    if (found === null || Number.isNaN(found)) {
+      warn.push(`Count check could not parse a number in ${check.file} (${check.label})${where}: "${match[1]}"`);
+      return;
+    }
+    if (found !== check.expected) {
+      fail.push(`Stale skill count in ${check.file} (${check.label})${where}: says ${found}, expected ${check.expected}`);
+    }
+  });
 }
 
 // Structural guard for the docs catalog page. String checks above prove the


### PR DESCRIPTION
## What

The README stated **71** in three places (badge URL, badge alt text, intro line) and **70** in five others — plugin install, Codex plugin, `install.sh`, Codex clone, and the "Install for Claude Code" heading. `find skills -mindepth 1 -maxdepth 1 -type d` returns **71**, and `suede-skills` bundles all of them (no subset array in `.claude-plugin/marketplace.json`), so 71 is correct everywhere.

## Why the guard missed it

`scripts/validate-skill-pack.mjs` built its count checks on `text.match(re)`, which returns **only the first hit**. Every guarded phrase was validated once regardless of how many times it appeared — so a sentence repeated five times could drift on occurrences 2-5 while the file still validated clean. That is exactly what happened here.

## Changes

- README: all five `70` occurrences corrected to `71`.
- Validator: new `every: true` check mode using `matchAll`, which validates every occurrence and names the stale one in the failure message.
- Two new guards: the repeated `all N skills` install copy (`every: true`), and the `**N public skill folders**` intro line.

## Verification

Breaking occurrence 4 of 5 fails as intended:

```
- Stale skill count in README.md (install-section pack size) [occurrence 4 of 5]: says 70, expected 71
```

`npm run ci` passes — 29 tests, validator reports `Validated 71 skills against 71 catalog entries`.