### PR TITLE
feat(site): move Pages origin to skills.suedeai.ai [BLOCKED: awaiting DNS]

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },
-  "homepage": "https://jasoncolapietro.github.io/suede-creator-skills/",
+  "homepage": "https://skills.suedeai.ai/",
   "repository": "https://github.com/JasonColapietro/suede-creator-skills",
   "license": "MIT",
   "keywords": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },
-  "homepage": "https://jasoncolapietro.github.io/suede-creator-skills/",
+  "homepage": "https://skills.suedeai.ai/",
   "repository": "https://github.com/JasonColapietro/suede-creator-skills",
   "license": "MIT",
   "keywords": [
@@ -55,7 +55,7 @@
       "Multi-Agent Workflows",
       "Code Review"
     ],
-    "websiteURL": "https://jasoncolapietro.github.io/suede-creator-skills/",
+    "websiteURL": "https://skills.suedeai.ai/",
     "defaultPrompt": [
       "Full send this authorized outcome with useful lanes and concise proof.",
       "Audit this surface with independent adversarial lanes.",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ authors:
     affiliation: "Suede Labs AI"
     website: "https://suedeai.ai/founder"
 repository-code: "https://github.com/JasonColapietro/suede-creator-skills"
-url: "https://jasoncolapietro.github.io/suede-creator-skills/"
+url: "https://skills.suedeai.ai/"
 license: MIT
 keywords:
   - Claude Code

--- a/COPY.md
+++ b/COPY.md
@@ -456,7 +456,7 @@ copywriting, AI evals, SEO/AEO/AI EO, Suedify website restyling, visibility
 grading, code review, CI gating, iOS/Android app shipping, launch packaging,
 artist campaigns, and creator rights workflows.
 
-Docs: https://jasoncolapietro.github.io/suede-creator-skills/skills/
+Docs: https://skills.suedeai.ai/skills/
 
 ### Builder post
 

--- a/PROMO.md
+++ b/PROMO.md
@@ -638,7 +638,7 @@ Repo:
 https://github.com/JasonColapietro/suede-creator-skills
 
 Docs:
-https://jasoncolapietro.github.io/suede-creator-skills/
+https://skills.suedeai.ai/
 ```
 
 ## Landing Page Blocks

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ If the pack saves you an hour, [star the repo](https://github.com/JasonColapietr
 | [`amazon-returns-recovery`](skills/amazon-returns-recovery) | The pack's contract negotiator, run against a real account instead of a repo: scan Amazon order/return history and digital subscriptions (Britbox, Starz, Audible, Kindle Unlimited, and more) for restocking fees, short refunds, and forgotten charges, then drive Amazon live chat to waive, refund, or cancel them — includes a validated click-path and popup workaround for the fee-dispute flow. Real recoveries: $448.31, including a previously denied refund overturned after the return window closed |
 | [`subscription-recovery`](skills/subscription-recovery) | Audit recurring charges outside Amazon across App Store, Google Play, PayPal, bank/card evidence, and direct-bill services; report findings first and require confirmation before cancellation or refund contact |
 
-Plus a creator toolkit (rights, release prep) — see [docs](https://jasoncolapietro.github.io/suede-creator-skills/skills/): `suede-campaign-in-a-box`, `suede-sync-packaging`, `suede-release-linter`, `suede-rights-passport`, `suede-rights-audit`.
+Plus a creator toolkit (rights, release prep) — see [docs](https://skills.suedeai.ai/skills/): `suede-campaign-in-a-box`, `suede-sync-packaging`, `suede-release-linter`, `suede-rights-passport`, `suede-rights-audit`.
 
 ### Marketing & growth
 
@@ -176,10 +176,10 @@ under the MIT License — see [NOTICE.md](NOTICE.md).
 ## Public pages
 
 - [GitHub repository](https://github.com/JasonColapietro/suede-creator-skills)
-- [GitHub Pages site](https://jasoncolapietro.github.io/suede-creator-skills/) — public documentation generated from this repo
-- [Skill docs catalog](https://jasoncolapietro.github.io/suede-creator-skills/skills/) — every skill with install and resource links
-- [Installs and MCP page](https://jasoncolapietro.github.io/suede-creator-skills/plugins.html) — install commands plus the Suede Skills MCP
-- [Copy bank](https://jasoncolapietro.github.io/suede-creator-skills/copy.html) ([source](COPY.md)) and [public explainer pack](PROMO.md)
+- [GitHub Pages site](https://skills.suedeai.ai/) — public documentation generated from this repo
+- [Skill docs catalog](https://skills.suedeai.ai/skills/) — every skill with install and resource links
+- [Installs and MCP page](https://skills.suedeai.ai/plugins.html) — install commands plus the Suede Skills MCP
+- [Copy bank](https://skills.suedeai.ai/copy.html) ([source](COPY.md)) and [public explainer pack](PROMO.md)
 
 ## MCP server
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+skills.suedeai.ai

--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -7,31 +7,31 @@
     <meta name="description" content="Suede Creator Skills adds suede-recommend-next-action and android-app-factory, bringing the pack to 27 public skills. Here's what shipped and how the end-to-end workflow routes to both.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Two new lanes: a next-action recommender and a one-prompt Android app factory">
     <meta property="og:description" content="Suede Creator Skills adds suede-recommend-next-action and android-app-factory, bringing the pack to 27 public skills. Here's what shipped and how the end-to-end workflow routes to both.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Two new lanes: a next-action recommender and a one-prompt Android app factory">
     <meta name="twitter:description" content="Suede Creator Skills adds suede-recommend-next-action and android-app-factory, bringing the pack to 27 public skills. Here's what shipped and how the end-to-end workflow routes to both.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html#article",
+        "@id": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html#article",
         "headline": "Two new lanes: a next-action recommender and a one-prompt Android app factory",
         "description": "Suede Creator Skills adds suede-recommend-next-action and android-app-factory, bringing the pack to 27 public skills, and routes both through the existing end-to-end workflow umbrella.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html",
+        "url": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html",
         "datePublished": "2026-07-19",
         "dateModified": "2026-07-19",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Android app development", "next action recommendation", "agent workflow"],
-        "mainEntityOfPage": "https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html"
+        "mainEntityOfPage": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html"
       }
     </script>
     <style>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -7,23 +7,23 @@
     <meta name="description" content="Product updates for Suede Creator Skills: new skills, workflow changes, and what shipped in the open-source Claude Code and Codex skill pack.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/blog/">
+    <link rel="canonical" href="https://skills.suedeai.ai/blog/">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Blog - Suede Creator Skills">
     <meta property="og:description" content="Product updates for Suede Creator Skills: new skills, workflow changes, and what shipped in the open-source Claude Code and Codex skill pack.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/blog/">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/blog/">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Blog - Suede Creator Skills">
     <meta name="twitter:description" content="Product updates for Suede Creator Skills: new skills, workflow changes, and what shipped in the open-source Claude Code and Codex skill pack.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "Blog",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/blog/#blog",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/blog/",
+        "@id": "https://skills.suedeai.ai/blog/#blog",
+        "url": "https://skills.suedeai.ai/blog/",
         "name": "Suede Creator Skills Blog",
         "description": "Product updates for the Suede Creator Skills pack: new skills, workflow changes, and what shipped.",
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
@@ -31,7 +31,7 @@
           {
             "@type": "BlogPosting",
             "headline": "Two new lanes: a next-action recommender and a one-prompt Android app factory",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html",
+            "url": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html",
             "datePublished": "2026-07-19"
           }
         ]

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -7,25 +7,25 @@
   <meta name="description" content="Reusable copy for Suede Creator Skills: repo blurbs, page copy, CTAs, Suedify, SEO/AEO/AI EO, code grades, agent teams, and safety notes.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/copy.html">
+  <link rel="canonical" href="https://skills.suedeai.ai/copy.html">
   <link rel="icon" href="./assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Suede Creator Skills Copy Bank">
   <meta property="og:description" content="Use this copy when explaining Suede Creator Skills: 71 agent skills for Claude Code and Codex covering Full Send, Suedify, Instagram growth, agent teams, code review, AEO/GEO/AI EO, and creator workflows.">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/copy.html">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/copy.html">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills Copy Bank">
   <meta name="twitter:description" content="Repo copy, page copy, CTA, visibility, anti-slop copy, Suede SEO/AEO/AI EO, FAQ, and social copy for Suede Creator Skills.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "TechArticle",
-      "@id": "https://jasoncolapietro.github.io/suede-creator-skills/copy.html#article",
+      "@id": "https://skills.suedeai.ai/copy.html#article",
       "headline": "Suede Creator Skills Copy Bank",
       "description": "Public copy bank for Suede Creator Skills: repo descriptions, page copy, docs copy, CTAs, anti-slop copy, visibility grading, A-F code grades, coordinated agent-team loops, SEO/AEO/AI EO metadata, and safety language.",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/copy.html",
+      "url": "https://skills.suedeai.ai/copy.html",
       "author": {
         "@type": "Person",
         "name": "Jason Colapietro",
@@ -438,8 +438,8 @@
       <div class="terminal-body">
         <pre>Suede Creator Skills are live: 70 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.
 
-Docs: https://jasoncolapietro.github.io/suede-creator-skills/skills/</pre>
-        <button class="copy-btn" data-copy="Suede Creator Skills are live: 70 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.&#10;&#10;Docs: https://jasoncolapietro.github.io/suede-creator-skills/skills/">Copy</button>
+Docs: https://skills.suedeai.ai/skills/</pre>
+        <button class="copy-btn" data-copy="Suede Creator Skills are live: 70 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.&#10;&#10;Docs: https://skills.suedeai.ai/skills/">Copy</button>
       </div>
     </div>
 

--- a/docs/dav/index.html
+++ b/docs/dav/index.html
@@ -11,18 +11,18 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills | DAV Michelangelo">
   <meta property="og:description" content="71 public skills for Suedify, Full Send outcome routing, Instagram growth, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/dav/">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/dav/">
   <meta property="og:site_name" content="Suede Creator Skills">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills | DAV Michelangelo">
   <meta name="twitter:description" content="71 public skills for Suedify, Full Send outcome routing, Instagram growth, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, and creator rights workflows.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
 
   <!-- Canonical -->
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/">
+  <link rel="canonical" href="https://skills.suedeai.ai/">
 
   <!-- Favicon -->
   <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
@@ -37,7 +37,7 @@
     "@type": "SoftwareSourceCode",
     "name": "Suede Creator Skills | DAV Michelangelo",
     "description": "A 71-skill public workflow for Codex and Claude Code covering Full Send outcome routing, Suedify, Instagram growth, copy, SEO/AEO/AI EO, visibility grading, code grading, agent teams, MCP, creator campaigns, and rights utilities.",
-    "url": "https://jasoncolapietro.github.io/suede-creator-skills/dav/",
+    "url": "https://skills.suedeai.ai/dav/",
     "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
     "programmingLanguage": ["Markdown", "JavaScript", "Python", "HTML"],
     "author": {
@@ -1526,7 +1526,7 @@
 
     <div id="hero-ctas">
       <a id="hero-cta-primary" href="#install">Install the workflow skill</a>
-      <a id="hero-cta-secondary" href="https://jasoncolapietro.github.io/suede-creator-skills/" target="_blank" rel="noopener">Browse the index</a>
+      <a id="hero-cta-secondary" href="https://skills.suedeai.ai/" target="_blank" rel="noopener">Browse the index</a>
     </div>
   </div>
 
@@ -1765,9 +1765,9 @@
     </div>
 
     <div class="install-links">
-      <a class="install-link install-link-primary" href="https://jasoncolapietro.github.io/suede-creator-skills/" target="_blank" rel="noopener">Browse the index</a>
+      <a class="install-link install-link-primary" href="https://skills.suedeai.ai/" target="_blank" rel="noopener">Browse the index</a>
       <a class="install-link" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub repo</a>
-      <a class="install-link" href="https://jasoncolapietro.github.io/suede-creator-skills/plugins.html" target="_blank" rel="noopener">MCP docs</a>
+      <a class="install-link" href="https://skills.suedeai.ai/plugins.html" target="_blank" rel="noopener">MCP docs</a>
     </div>
   </div>
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -13,17 +13,17 @@
     <meta name="creator" content="Jason Colapietro">
     <meta name="application-name" content="Suede Creator Skills">
     <meta name="theme-color" content="#35100d">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/guide.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/guide.html">
     <link rel="icon" href="./assets/suede-skill-icon.png" type="image/png">
     <link rel="apple-touch-icon" href="./assets/suede-skill-icon.png">
     <link rel="preload" as="image" href="./assets/passport-hero.webp" type="image/webp">
-    <link rel="image_src" href="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <link rel="image_src" href="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Suede Creator Skills Guide | 70 Agent Skills">
     <meta property="og:description" content="Read the guide to 70 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/guide.html">
+    <meta property="og:url" content="https://skills.suedeai.ai/guide.html">
     <meta property="og:site_name" content="Suede Creator Skills">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -34,7 +34,7 @@
     <meta name="twitter:creator" content="@johnnysuede">
     <meta name="twitter:title" content="Suede Creator Skills">
     <meta name="twitter:description" content="70 MIT-licensed agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and creator tools.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:image:alt" content="Suede Creator Skills - Codex and Claude skills for Suedify, design, copywriting, SEO/AEO/AI EO, and QA.">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
     <script type="application/ld+json">
@@ -46,7 +46,7 @@
             "@id": "https://suedeai.ai/#org",
             "name": "Suede Labs AI",
             "url": "https://suedeai.ai",
-            "logo": "https://jasoncolapietro.github.io/suede-creator-skills/assets/suede-ai-logo-transparent.png",
+            "logo": "https://skills.suedeai.ai/assets/suede-ai-logo-transparent.png",
             "sameAs": [
               "https://twitter.com/johnnysuede",
               "https://github.com/JasonColapietro"
@@ -54,8 +54,8 @@
           },
           {
             "@type": "WebSite",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+            "@id": "https://skills.suedeai.ai/#website",
+            "url": "https://skills.suedeai.ai/",
             "name": "Suede Creator Skills",
             "description": "Public, open-source pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server: Full Send outcome routing, multi-agent orchestration, Codex CLI worker fleets, code review with A-F ship grades, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and a creator toolkit.",
             "publisher": {
@@ -65,16 +65,16 @@
           },
           {
             "@type": "WebPage",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/guide.html#webpage",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/guide.html",
+            "@id": "https://skills.suedeai.ai/guide.html#webpage",
+            "url": "https://skills.suedeai.ai/guide.html",
             "name": "Suede Creator Skills Guide | 70 Agent Skills",
             "description": "Read the guide to 70 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.",
             "isPartOf": {
-              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website"
+              "@id": "https://skills.suedeai.ai/#website"
             },
             "primaryImageOfPage": {
               "@type": "ImageObject",
-              "url": "https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png",
+              "url": "https://skills.suedeai.ai/assets/og-image-v2.png",
               "width": 1200,
               "height": 630
             },
@@ -93,19 +93,19 @@
               "AI EO"
             ],
             "breadcrumb": {
-              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#breadcrumb"
+              "@id": "https://skills.suedeai.ai/#breadcrumb"
             },
             "mainEntity": {
-              "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#faq"
+              "@id": "https://skills.suedeai.ai/#faq"
             },
             "inLanguage": "en-US"
           },
           {
             "@type": "SoftwareSourceCode",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#skills",
+            "@id": "https://skills.suedeai.ai/#skills",
             "name": "Suede Creator Skills",
             "description": "70 public, MIT-licensed agent skills for Claude Code and Codex: Full Send outcome routing, multi-agent orchestration, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/GEO/AI EO, visibility grading, site alchemy, launch packaging, MCP QA, iOS and Android app shipping, and a creator toolkit for campaigns, release prep, and rights evidence.",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+            "url": "https://skills.suedeai.ai/",
             "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
             "programmingLanguage": ["Markdown", "JavaScript", "Python", "HTML"],
             "applicationCategory": "DeveloperTool",
@@ -114,16 +114,16 @@
             "softwareRequirements": ["Codex", "Claude Code", "Python 3"],
             "hasPart": [
               {
-                "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html#article"
+                "@id": "https://skills.suedeai.ai/skills/suede-rights-passport.html#article"
               },
               {
-                "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html#article"
+                "@id": "https://skills.suedeai.ai/skills/suede-release-linter.html#article"
               },
               {
-                "@id": "https://jasoncolapietro.github.io/suede-creator-skills/copy.html#article"
+                "@id": "https://skills.suedeai.ai/copy.html#article"
               },
               {
-                "@id": "https://jasoncolapietro.github.io/suede-creator-skills/plugins.html#article"
+                "@id": "https://skills.suedeai.ai/plugins.html#article"
               }
             ],
             "creator": {
@@ -171,10 +171,10 @@
           },
           {
             "@type": "SoftwareSourceCode",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#skill-suede-rights-passport",
+            "@id": "https://skills.suedeai.ai/#skill-suede-rights-passport",
             "name": "Creator Rights Package Builder",
             "description": "A public Codex and Claude skill for organizing music and media folders into local rights and provenance packages for downstream review.",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html",
+            "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html",
             "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-rights-passport",
             "programmingLanguage": "Python",
             "applicationCategory": "DeveloperTool",
@@ -190,10 +190,10 @@
           },
           {
             "@type": "SoftwareSourceCode",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#skill-suede-release-linter",
+            "@id": "https://skills.suedeai.ai/#skill-suede-release-linter",
             "name": "Release Metadata Linter",
             "description": "A public Codex and Claude skill for auditing music release folders for metadata, rights, split, artwork, lyric, stem, and downstream-readiness gaps.",
-            "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html",
+            "url": "https://skills.suedeai.ai/skills/suede-release-linter.html",
             "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-release-linter",
             "programmingLanguage": "Python",
             "applicationCategory": "DeveloperTool",
@@ -224,7 +224,7 @@
           },
           {
             "@type": "Book",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#book-the-signal-chain",
+            "@id": "https://skills.suedeai.ai/#book-the-signal-chain",
             "name": "The Signal Chain",
             "url": "https://guitar.solutions",
             "author": {
@@ -233,7 +233,7 @@
           },
           {
             "@type": "Book",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#book-the-guitar-without-a-number",
+            "@id": "https://skills.suedeai.ai/#book-the-guitar-without-a-number",
             "name": "The Guitar Without a Number",
             "url": "https://www.amazon.com/stores/author/B0GD5FX6N6",
             "author": {
@@ -242,7 +242,7 @@
           },
           {
             "@type": "Book",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#book-human-authenticity-layer",
+            "@id": "https://skills.suedeai.ai/#book-human-authenticity-layer",
             "name": "Suede Labs: The Human Authenticity Layer",
             "url": "https://www.amazon.com/dp/B0GD5FX6N6",
             "author": {
@@ -251,7 +251,7 @@
           },
           {
             "@type": "Book",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#book-proof-as-infrastructure",
+            "@id": "https://skills.suedeai.ai/#book-proof-as-infrastructure",
             "name": "Proof as Infrastructure",
             "url": "https://www.amazon.com/dp/B0GMB2VLXQ",
             "author": {
@@ -260,7 +260,7 @@
           },
           {
             "@type": "Book",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#book-stake-your-claim",
+            "@id": "https://skills.suedeai.ai/#book-stake-your-claim",
             "name": "Stake Your Claim",
             "url": "https://www.amazon.com/dp/B0GRG8LGQQ",
             "author": {
@@ -269,7 +269,7 @@
           },
           {
             "@type": "FAQPage",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#faq",
+            "@id": "https://skills.suedeai.ai/#faq",
             "mainEntity": [
               {
                 "@type": "Question",
@@ -307,7 +307,7 @@
           },
           {
             "@type": "BreadcrumbList",
-            "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#breadcrumb",
+            "@id": "https://skills.suedeai.ai/#breadcrumb",
             "itemListElement": [
               {
                 "@type": "ListItem",
@@ -319,7 +319,7 @@
                 "@type": "ListItem",
                 "position": 2,
                 "name": "Suede Creator Skills",
-                "item": "https://jasoncolapietro.github.io/suede-creator-skills/"
+                "item": "https://skills.suedeai.ai/"
               }
             ]
           }

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,22 +10,22 @@
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills | 71 Open-Source Agent Skills">
   <meta property="og:description" content="Install 71 free open-source Claude Code and Codex skills for outcome-bound orchestration, code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, MCP, and creator workflows.">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Suede Creator Skills: 71 open-source agent skills for Claude Code and OpenAI Codex">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/">
+  <meta property="og:url" content="https://skills.suedeai.ai/">
   <meta property="og:site_name" content="Suede Creator Skills">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills | 71 Open-Source Agent Skills">
   <meta name="twitter:description" content="Install 71 free open-source Claude Code and Codex skills for outcome-bound orchestration, code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, MCP, and creator workflows.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:image:alt" content="Suede Creator Skills: 71 open-source agent skills for Claude Code and OpenAI Codex">
 
   <!-- Canonical -->
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/">
+  <link rel="canonical" href="https://skills.suedeai.ai/">
 
   <!-- Favicon -->
   <link rel="icon" href="./assets/suede-ai-logo-transparent.png" type="image/png">
@@ -40,9 +40,9 @@
     "@graph": [
       {
         "@type": "WebSite",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website",
+        "@id": "https://skills.suedeai.ai/#website",
         "name": "Suede Creator Skills",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+        "url": "https://skills.suedeai.ai/",
         "description": "Public, open-source pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server for discovery, audits, and QA. The pack carries preferences, linked context, quality gates, and reusable workflow rules across agents and computers.",
         "publisher": { "@id": "https://suedeai.ai/#org" }
       },
@@ -65,7 +65,7 @@
         "@type": "SoftwareSourceCode",
         "name": "Suede Creator Skills",
         "description": "Public, open-source (MIT) pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server. One install gives an AI coding agent a reusable engineering workflow: Suede Full Send for broad, authorized outcome-bound work, coordinated multi-agent build lanes with quality gates and a signed handoff, reviewed OpenAI Codex CLI worker fleets, code review with a blunt A-F ship grade, CI ship-gates, AI evaluation specs and acceptance gates, account-specific Instagram growth, and design, copy, SEO, and visibility lanes for shipping public work. Also includes a small creator toolkit for music rights and release prep. Users can bring their own company, repo, page, or product.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+        "url": "https://skills.suedeai.ai/",
         "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
         "programmingLanguage": ["Markdown", "JavaScript", "Python", "HTML"],
         "runtimePlatform": ["Claude Code", "OpenAI Codex", "Model Context Protocol"],
@@ -80,83 +80,83 @@
         "description": "The 71 public skills in the Suede Creator Skills pack.",
         "numberOfItems": 71,
         "itemListElement": [
-          { "@type": "ListItem", "position": 1, "name": "Suede Workflow Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html" },
-          { "@type": "ListItem", "position": 2, "name": "Johnny Suede Write", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html" },
-          { "@type": "ListItem", "position": 3, "name": "Johnny Suede Design", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html" },
-          { "@type": "ListItem", "position": 4, "name": "Suede Code Grader", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html" },
-          { "@type": "ListItem", "position": 5, "name": "Suede Visibility Grader", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html" },
-          { "@type": "ListItem", "position": 6, "name": "Suede AI Eval", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html" },
-          { "@type": "ListItem", "position": 7, "name": "Suede Agent Teams", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html" },
-          { "@type": "ListItem", "position": 8, "name": "Suede Code", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html" },
-          { "@type": "ListItem", "position": 9, "name": "Suede Code Review", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html" },
-          { "@type": "ListItem", "position": 10, "name": "Suede Copy", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html" },
-          { "@type": "ListItem", "position": 11, "name": "Suede Design", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html" },
-          { "@type": "ListItem", "position": 12, "name": "Suede SEO Audit", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html" },
-          { "@type": "ListItem", "position": 13, "name": "Suede Site Alchemy", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html" },
-          { "@type": "ListItem", "position": 14, "name": "Suede Ship", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html" },
-          { "@type": "ListItem", "position": 15, "name": "Suede Ship Copy", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html" },
-          { "@type": "ListItem", "position": 16, "name": "Suede CI Gate", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html" },
-          { "@type": "ListItem", "position": 17, "name": "Suede Launch Packaging", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html" },
-          { "@type": "ListItem", "position": 18, "name": "Suede MCP QA", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html" },
-          { "@type": "ListItem", "position": 19, "name": "Suede Rights Passport", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html" },
-          { "@type": "ListItem", "position": 20, "name": "Suede Release Linter", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html" },
-          { "@type": "ListItem", "position": 21, "name": "Suede Campaign in a Box", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html" },
-          { "@type": "ListItem", "position": 22, "name": "Suede Rights Audit", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html" },
-          { "@type": "ListItem", "position": 23, "name": "Suede Sync Packaging", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html" },
-          { "@type": "ListItem", "position": 24, "name": "Suede Fable Fleet", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html" },
-          { "@type": "ListItem", "position": 25, "name": "Site to iOS App", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html" },
-          { "@type": "ListItem", "position": 26, "name": "Amazon Returns Recovery", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html" },
-          { "@type": "ListItem", "position": 27, "name": "Subscription Recovery", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html" },
-          { "@type": "ListItem", "position": 28, "name": "Android App Factory", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html" },
-          { "@type": "ListItem", "position": 29, "name": "Suede Recommend Next Action", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html" },
-          { "@type": "ListItem", "position": 30, "name": "Suede Full Send", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html" },
-          { "@type": "ListItem", "position": 31, "name": "Suede Deslop", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html" },
-          { "@type": "ListItem", "position": 32, "name": "Suede Ab Testing", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html" },
-          { "@type": "ListItem", "position": 33, "name": "Suede Ad Creative", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html" },
-          { "@type": "ListItem", "position": 34, "name": "Suede Ads", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html" },
-          { "@type": "ListItem", "position": 35, "name": "Suede Analytics", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html" },
-          { "@type": "ListItem", "position": 36, "name": "Suede Aso", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html" },
-          { "@type": "ListItem", "position": 37, "name": "Suede Churn Prevention", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html" },
-          { "@type": "ListItem", "position": 38, "name": "Suede Co Marketing", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html" },
-          { "@type": "ListItem", "position": 39, "name": "Suede Cold Email", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html" },
-          { "@type": "ListItem", "position": 40, "name": "Suede Community Marketing", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html" },
-          { "@type": "ListItem", "position": 41, "name": "Suede Competitor Profiling", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html" },
-          { "@type": "ListItem", "position": 42, "name": "Suede Competitors", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html" },
-          { "@type": "ListItem", "position": 43, "name": "Suede Content Strategy", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html" },
-          { "@type": "ListItem", "position": 44, "name": "Suede Customer Research", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html" },
-          { "@type": "ListItem", "position": 45, "name": "Suede Directory Submissions", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html" },
-          { "@type": "ListItem", "position": 46, "name": "Suede Emails", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html" },
-          { "@type": "ListItem", "position": 47, "name": "Suede Free Tools", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html" },
-          { "@type": "ListItem", "position": 48, "name": "Suede Image", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html" },
-          { "@type": "ListItem", "position": 49, "name": "Suede Lead Magnets", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html" },
-          { "@type": "ListItem", "position": 50, "name": "Suede Marketing Council", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html" },
-          { "@type": "ListItem", "position": 51, "name": "Suede Marketing Ideas", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html" },
-          { "@type": "ListItem", "position": 52, "name": "Suede Marketing Loops", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html" },
-          { "@type": "ListItem", "position": 53, "name": "Suede Marketing Plan", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html" },
-          { "@type": "ListItem", "position": 54, "name": "Suede Marketing Psychology", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html" },
-          { "@type": "ListItem", "position": 55, "name": "Suede Offers", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html" },
-          { "@type": "ListItem", "position": 56, "name": "Suede Onboarding", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html" },
-          { "@type": "ListItem", "position": 57, "name": "Suede Paywalls", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html" },
-          { "@type": "ListItem", "position": 58, "name": "Suede Pricing", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html" },
-          { "@type": "ListItem", "position": 59, "name": "Suede Product Marketing", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html" },
-          { "@type": "ListItem", "position": 60, "name": "Suede Programmatic Seo", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html" },
-          { "@type": "ListItem", "position": 61, "name": "Suede Prospecting", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html" },
-          { "@type": "ListItem", "position": 62, "name": "Suede Public Relations", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html" },
-          { "@type": "ListItem", "position": 63, "name": "Suede Referrals", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html" },
-          { "@type": "ListItem", "position": 64, "name": "Suede Revops", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html" },
-          { "@type": "ListItem", "position": 65, "name": "Suede Sales Enablement", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html" },
-          { "@type": "ListItem", "position": 66, "name": "Suede Signup", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html" },
-          { "@type": "ListItem", "position": 67, "name": "Suede Sms", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html" },
-          { "@type": "ListItem", "position": 68, "name": "Suede Social", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html" },
-          { "@type": "ListItem", "position": 69, "name": "Suede Video", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html" },
-          { "@type": "ListItem", "position": 71, "name": "Suede Instagram Growth", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html" },
-          { "@type": "ListItem", "position": 72, "name": "Suede Clip to Guide", "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html" }
+          { "@type": "ListItem", "position": 1, "name": "Suede Workflow Skills", "url": "https://skills.suedeai.ai/skills/suede-workflow-skills.html" },
+          { "@type": "ListItem", "position": 2, "name": "Johnny Suede Write", "url": "https://skills.suedeai.ai/skills/johnny-suede-write.html" },
+          { "@type": "ListItem", "position": 3, "name": "Johnny Suede Design", "url": "https://skills.suedeai.ai/skills/johnny-suede-design.html" },
+          { "@type": "ListItem", "position": 4, "name": "Suede Code Grader", "url": "https://skills.suedeai.ai/skills/suede-code-grader.html" },
+          { "@type": "ListItem", "position": 5, "name": "Suede Visibility Grader", "url": "https://skills.suedeai.ai/skills/suede-visibility-grader.html" },
+          { "@type": "ListItem", "position": 6, "name": "Suede AI Eval", "url": "https://skills.suedeai.ai/skills/suede-ai-eval.html" },
+          { "@type": "ListItem", "position": 7, "name": "Suede Agent Teams", "url": "https://skills.suedeai.ai/skills/suede-agent-teams.html" },
+          { "@type": "ListItem", "position": 8, "name": "Suede Code", "url": "https://skills.suedeai.ai/skills/suede-code.html" },
+          { "@type": "ListItem", "position": 9, "name": "Suede Code Review", "url": "https://skills.suedeai.ai/skills/suede-code-review.html" },
+          { "@type": "ListItem", "position": 10, "name": "Suede Copy", "url": "https://skills.suedeai.ai/skills/suede-copy.html" },
+          { "@type": "ListItem", "position": 11, "name": "Suede Design", "url": "https://skills.suedeai.ai/skills/suede-design.html" },
+          { "@type": "ListItem", "position": 12, "name": "Suede SEO Audit", "url": "https://skills.suedeai.ai/skills/suede-seo-audit.html" },
+          { "@type": "ListItem", "position": 13, "name": "Suede Site Alchemy", "url": "https://skills.suedeai.ai/skills/suede-site-alchemy.html" },
+          { "@type": "ListItem", "position": 14, "name": "Suede Ship", "url": "https://skills.suedeai.ai/skills/suede-ship.html" },
+          { "@type": "ListItem", "position": 15, "name": "Suede Ship Copy", "url": "https://skills.suedeai.ai/skills/suede-ship-copy.html" },
+          { "@type": "ListItem", "position": 16, "name": "Suede CI Gate", "url": "https://skills.suedeai.ai/skills/suede-ci-gate.html" },
+          { "@type": "ListItem", "position": 17, "name": "Suede Launch Packaging", "url": "https://skills.suedeai.ai/skills/suede-launch-packaging.html" },
+          { "@type": "ListItem", "position": 18, "name": "Suede MCP QA", "url": "https://skills.suedeai.ai/skills/suede-mcp-qa.html" },
+          { "@type": "ListItem", "position": 19, "name": "Suede Rights Passport", "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html" },
+          { "@type": "ListItem", "position": 20, "name": "Suede Release Linter", "url": "https://skills.suedeai.ai/skills/suede-release-linter.html" },
+          { "@type": "ListItem", "position": 21, "name": "Suede Campaign in a Box", "url": "https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html" },
+          { "@type": "ListItem", "position": 22, "name": "Suede Rights Audit", "url": "https://skills.suedeai.ai/skills/suede-rights-audit.html" },
+          { "@type": "ListItem", "position": 23, "name": "Suede Sync Packaging", "url": "https://skills.suedeai.ai/skills/suede-sync-packaging.html" },
+          { "@type": "ListItem", "position": 24, "name": "Suede Fable Fleet", "url": "https://skills.suedeai.ai/skills/suede-codex-fleet.html" },
+          { "@type": "ListItem", "position": 25, "name": "Site to iOS App", "url": "https://skills.suedeai.ai/skills/site-to-ios-app.html" },
+          { "@type": "ListItem", "position": 26, "name": "Amazon Returns Recovery", "url": "https://skills.suedeai.ai/skills/amazon-returns-recovery.html" },
+          { "@type": "ListItem", "position": 27, "name": "Subscription Recovery", "url": "https://skills.suedeai.ai/skills/subscription-recovery.html" },
+          { "@type": "ListItem", "position": 28, "name": "Android App Factory", "url": "https://skills.suedeai.ai/skills/android-app-factory.html" },
+          { "@type": "ListItem", "position": 29, "name": "Suede Recommend Next Action", "url": "https://skills.suedeai.ai/skills/suede-recommend-next-action.html" },
+          { "@type": "ListItem", "position": 30, "name": "Suede Full Send", "url": "https://skills.suedeai.ai/skills/suede-full-send.html" },
+          { "@type": "ListItem", "position": 31, "name": "Suede Deslop", "url": "https://skills.suedeai.ai/skills/suede-deslop.html" },
+          { "@type": "ListItem", "position": 32, "name": "Suede Ab Testing", "url": "https://skills.suedeai.ai/skills/suede-ab-testing.html" },
+          { "@type": "ListItem", "position": 33, "name": "Suede Ad Creative", "url": "https://skills.suedeai.ai/skills/suede-ad-creative.html" },
+          { "@type": "ListItem", "position": 34, "name": "Suede Ads", "url": "https://skills.suedeai.ai/skills/suede-ads.html" },
+          { "@type": "ListItem", "position": 35, "name": "Suede Analytics", "url": "https://skills.suedeai.ai/skills/suede-analytics.html" },
+          { "@type": "ListItem", "position": 36, "name": "Suede Aso", "url": "https://skills.suedeai.ai/skills/suede-aso.html" },
+          { "@type": "ListItem", "position": 37, "name": "Suede Churn Prevention", "url": "https://skills.suedeai.ai/skills/suede-churn-prevention.html" },
+          { "@type": "ListItem", "position": 38, "name": "Suede Co Marketing", "url": "https://skills.suedeai.ai/skills/suede-co-marketing.html" },
+          { "@type": "ListItem", "position": 39, "name": "Suede Cold Email", "url": "https://skills.suedeai.ai/skills/suede-cold-email.html" },
+          { "@type": "ListItem", "position": 40, "name": "Suede Community Marketing", "url": "https://skills.suedeai.ai/skills/suede-community-marketing.html" },
+          { "@type": "ListItem", "position": 41, "name": "Suede Competitor Profiling", "url": "https://skills.suedeai.ai/skills/suede-competitor-profiling.html" },
+          { "@type": "ListItem", "position": 42, "name": "Suede Competitors", "url": "https://skills.suedeai.ai/skills/suede-competitors.html" },
+          { "@type": "ListItem", "position": 43, "name": "Suede Content Strategy", "url": "https://skills.suedeai.ai/skills/suede-content-strategy.html" },
+          { "@type": "ListItem", "position": 44, "name": "Suede Customer Research", "url": "https://skills.suedeai.ai/skills/suede-customer-research.html" },
+          { "@type": "ListItem", "position": 45, "name": "Suede Directory Submissions", "url": "https://skills.suedeai.ai/skills/suede-directory-submissions.html" },
+          { "@type": "ListItem", "position": 46, "name": "Suede Emails", "url": "https://skills.suedeai.ai/skills/suede-emails.html" },
+          { "@type": "ListItem", "position": 47, "name": "Suede Free Tools", "url": "https://skills.suedeai.ai/skills/suede-free-tools.html" },
+          { "@type": "ListItem", "position": 48, "name": "Suede Image", "url": "https://skills.suedeai.ai/skills/suede-image.html" },
+          { "@type": "ListItem", "position": 49, "name": "Suede Lead Magnets", "url": "https://skills.suedeai.ai/skills/suede-lead-magnets.html" },
+          { "@type": "ListItem", "position": 50, "name": "Suede Marketing Council", "url": "https://skills.suedeai.ai/skills/suede-marketing-council.html" },
+          { "@type": "ListItem", "position": 51, "name": "Suede Marketing Ideas", "url": "https://skills.suedeai.ai/skills/suede-marketing-ideas.html" },
+          { "@type": "ListItem", "position": 52, "name": "Suede Marketing Loops", "url": "https://skills.suedeai.ai/skills/suede-marketing-loops.html" },
+          { "@type": "ListItem", "position": 53, "name": "Suede Marketing Plan", "url": "https://skills.suedeai.ai/skills/suede-marketing-plan.html" },
+          { "@type": "ListItem", "position": 54, "name": "Suede Marketing Psychology", "url": "https://skills.suedeai.ai/skills/suede-marketing-psychology.html" },
+          { "@type": "ListItem", "position": 55, "name": "Suede Offers", "url": "https://skills.suedeai.ai/skills/suede-offers.html" },
+          { "@type": "ListItem", "position": 56, "name": "Suede Onboarding", "url": "https://skills.suedeai.ai/skills/suede-onboarding.html" },
+          { "@type": "ListItem", "position": 57, "name": "Suede Paywalls", "url": "https://skills.suedeai.ai/skills/suede-paywalls.html" },
+          { "@type": "ListItem", "position": 58, "name": "Suede Pricing", "url": "https://skills.suedeai.ai/skills/suede-pricing.html" },
+          { "@type": "ListItem", "position": 59, "name": "Suede Product Marketing", "url": "https://skills.suedeai.ai/skills/suede-product-marketing.html" },
+          { "@type": "ListItem", "position": 60, "name": "Suede Programmatic Seo", "url": "https://skills.suedeai.ai/skills/suede-programmatic-seo.html" },
+          { "@type": "ListItem", "position": 61, "name": "Suede Prospecting", "url": "https://skills.suedeai.ai/skills/suede-prospecting.html" },
+          { "@type": "ListItem", "position": 62, "name": "Suede Public Relations", "url": "https://skills.suedeai.ai/skills/suede-public-relations.html" },
+          { "@type": "ListItem", "position": 63, "name": "Suede Referrals", "url": "https://skills.suedeai.ai/skills/suede-referrals.html" },
+          { "@type": "ListItem", "position": 64, "name": "Suede Revops", "url": "https://skills.suedeai.ai/skills/suede-revops.html" },
+          { "@type": "ListItem", "position": 65, "name": "Suede Sales Enablement", "url": "https://skills.suedeai.ai/skills/suede-sales-enablement.html" },
+          { "@type": "ListItem", "position": 66, "name": "Suede Signup", "url": "https://skills.suedeai.ai/skills/suede-signup.html" },
+          { "@type": "ListItem", "position": 67, "name": "Suede Sms", "url": "https://skills.suedeai.ai/skills/suede-sms.html" },
+          { "@type": "ListItem", "position": 68, "name": "Suede Social", "url": "https://skills.suedeai.ai/skills/suede-social.html" },
+          { "@type": "ListItem", "position": 69, "name": "Suede Video", "url": "https://skills.suedeai.ai/skills/suede-video.html" },
+          { "@type": "ListItem", "position": 71, "name": "Suede Instagram Growth", "url": "https://skills.suedeai.ai/skills/suede-instagram-growth.html" },
+          { "@type": "ListItem", "position": 72, "name": "Suede Clip to Guide", "url": "https://skills.suedeai.ai/skills/suede-clip-to-guide.html" }
 
         ]
       },
       {
         "@type": "FAQPage",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#faq",
+        "@id": "https://skills.suedeai.ai/#faq",
         "mainEntity": [
           {
             "@type": "Question",

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,88 +10,88 @@ Install the full pack for Codex: `codex plugin marketplace add JasonColapietro/s
 
 ## Start here
 
-- [Overview](https://jasoncolapietro.github.io/suede-creator-skills/): Public landing page with install commands, the full skill catalog, FAQ, schema, and proof links.
-- [Full guide](https://jasoncolapietro.github.io/suede-creator-skills/guide.html): How the pack fits together as one workflow, plus the MCP server, install paths, and the FAQ. Covers the core orchestration, code, design, and creator skills in depth; the complete list of all 70 is on the skill index above.
-- [Skill index](https://jasoncolapietro.github.io/suede-creator-skills/skills/): Browse all 71 skills.
-- [Installs and MCP](https://jasoncolapietro.github.io/suede-creator-skills/plugins.html): Install commands for Claude Code and Codex, plus the optional Suede Skills MCP server.
-- [Copy bank](https://jasoncolapietro.github.io/suede-creator-skills/copy.html): Public-safe explainer copy and reusable launch language.
+- [Overview](https://skills.suedeai.ai/): Public landing page with install commands, the full skill catalog, FAQ, schema, and proof links.
+- [Full guide](https://skills.suedeai.ai/guide.html): How the pack fits together as one workflow, plus the MCP server, install paths, and the FAQ. Covers the core orchestration, code, design, and creator skills in depth; the complete list of all 70 is on the skill index above.
+- [Skill index](https://skills.suedeai.ai/skills/): Browse all 71 skills.
+- [Installs and MCP](https://skills.suedeai.ai/plugins.html): Install commands for Claude Code and Codex, plus the optional Suede Skills MCP server.
+- [Copy bank](https://skills.suedeai.ai/copy.html): Public-safe explainer copy and reusable launch language.
 
 ## Workflow skills (orchestration, code, evals, design, copy, SEO, QA, launch)
 
-- [Suede Workflow Skills](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html): Umbrella skill that loads the full Suede workflow from one install path.
-- [Suede Full Send](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html): Routes broad, authorized outcome-bound work to one controller, the maximum useful set of non-colliding lanes, adversarial review, and an evidence-backed final handoff.
-- [Suede Agent Teams](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html): Coordinate complex changes and public-repository contribution programs with collision checks, atomic issue leases, review gates, authority boundaries, and a signed handoff.
+- [Suede Workflow Skills](https://skills.suedeai.ai/skills/suede-workflow-skills.html): Umbrella skill that loads the full Suede workflow from one install path.
+- [Suede Full Send](https://skills.suedeai.ai/skills/suede-full-send.html): Routes broad, authorized outcome-bound work to one controller, the maximum useful set of non-colliding lanes, adversarial review, and an evidence-backed final handoff.
+- [Suede Agent Teams](https://skills.suedeai.ai/skills/suede-agent-teams.html): Coordinate complex changes and public-repository contribution programs with collision checks, atomic issue leases, review gates, authority boundaries, and a signed handoff.
 - Suede Fable Fleet (suede-codex-fleet) — Orchestrate parallel OpenAI Codex CLI workers from Claude with self-contained briefs, an AGENTS.md contract, and a mandatory review gate: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-codex-fleet/SKILL.md
-- [Suede AI Eval](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html): Design AI evaluation strategy, failure-mode rubrics, test cases, and acceptance gates.
-- [Suede Recommend Next Action](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html): Scores candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then hands back one recommendation as a short runnable prompt.
+- [Suede AI Eval](https://skills.suedeai.ai/skills/suede-ai-eval.html): Design AI evaluation strategy, failure-mode rubrics, test cases, and acceptance gates.
+- [Suede Recommend Next Action](https://skills.suedeai.ai/skills/suede-recommend-next-action.html): Scores candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then hands back one recommendation as a short runnable prompt.
 - Suede Code — Review and grade code in one pass: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-code/SKILL.md
 - Suede Code Review — Deep diff review with TS/React/Next.js/Swift-iOS/OWASP/DB checklists, iOS traps, and native contract drift checks: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-code-review/SKILL.md
-- [Suede Code Grader](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html): Blunt A-F ship verdict on any code change with evidence-backed lanes and instant-F triggers.
+- [Suede Code Grader](https://skills.suedeai.ai/skills/suede-code-grader.html): Blunt A-F ship verdict on any code change with evidence-backed lanes and instant-F triggers.
 - Suede Ship — Canonical shipping DAG: scout, research, lane plan, disjoint parallel build, adversarial review, release verification: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-ship/SKILL.md
 - Suede Ship Copy — The same graph for copy: blind research lenses, an audit of every agent-generated claim, one message per section, adversarial review, deslop pass, and a publish-readiness gate. Never audits what the requester supplied: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-ship-copy/SKILL.md
 - Suede CI Gate — Wire any repo so CI actually gates the merge: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-ci-gate/SKILL.md
 - Suede Clip to Guide — Turn a clip or transcript into a clip-to-guide funnel package with rights routing: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-clip-to-guide/SKILL.md
-- [Johnny Suede Write](https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html): One loadable writing mode for copy, brand voice, SEO/AEO/GEO/AI EO, CTAs, and anti-slop editing.
-- [Johnny Suede Design](https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html): One loadable design mode for landing pages, brand pages, product UI, Suedify restyling, and visual QA.
+- [Johnny Suede Write](https://skills.suedeai.ai/skills/johnny-suede-write.html): One loadable writing mode for copy, brand voice, SEO/AEO/GEO/AI EO, CTAs, and anti-slop editing.
+- [Johnny Suede Design](https://skills.suedeai.ai/skills/johnny-suede-design.html): One loadable design mode for landing pages, brand pages, product UI, Suedify restyling, and visual QA.
 - Suede Design — Evolve any interface from generic to intentional with design laws and tokens: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-design/SKILL.md
 - Suede Copy — Click-earning copy with headline formulas and persuasion frameworks: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-copy/SKILL.md
-- [Suede Deslop](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html): Strips AI writing patterns from prose before it ships: merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.
+- [Suede Deslop](https://skills.suedeai.ai/skills/suede-deslop.html): Strips AI writing patterns from prose before it ships: merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.
 - Suede SEO Audit — SEO, AEO, GEO, AI EO, metadata, schema, link, and crawlability audit: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-seo-audit/SKILL.md
-- [Suede Visibility Grader](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html): Grade any public page for findability, first-screen clarity, CTA pull, proof, and AI citation readiness.
+- [Suede Visibility Grader](https://skills.suedeai.ai/skills/suede-visibility-grader.html): Grade any public page for findability, first-screen clarity, CTA pull, proof, and AI citation readiness.
 - Suede Site Alchemy — Turn a page into a conversion engine with funnel and friction analysis: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-site-alchemy/SKILL.md
 - Suede Launch Packaging — Ship work as a launch people can actually install: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-launch-packaging/SKILL.md
 - Suede MCP QA — Catch a broken Suede Skills MCP before it ships: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-mcp-qa/SKILL.md
-- [Site to iOS App](https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html): Convert any website or web app into an App Store-ready iOS app plan or shell: URL audit, App Store 4.2 wrapper-risk gate, Capacitor or native-shell strategy, native value requirements, QA matrix, and an explicit release gate.
-- [Android App Factory](https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html): Plan or build a native Android app end to end from a keyword: Kotlin + Jetpack Compose scaffolding, Play Billing, Play Store screenshots and ASO listing copy, Data Safety disclosure, signing, and Google Play Console release.
-- [Amazon Returns Recovery](https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html): Scan Amazon order and return history for restocking fees and short refunds, then drive Amazon live chat to get the money waived and refunded (requires the Claude in Chrome extension).
-- [Subscription Recovery](https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html): Audit any recurring subscription (Netflix, Spotify, gyms, App Store, Google Play, PayPal) and cancel or negotiate a refund through that service's own support.
+- [Site to iOS App](https://skills.suedeai.ai/skills/site-to-ios-app.html): Convert any website or web app into an App Store-ready iOS app plan or shell: URL audit, App Store 4.2 wrapper-risk gate, Capacitor or native-shell strategy, native value requirements, QA matrix, and an explicit release gate.
+- [Android App Factory](https://skills.suedeai.ai/skills/android-app-factory.html): Plan or build a native Android app end to end from a keyword: Kotlin + Jetpack Compose scaffolding, Play Billing, Play Store screenshots and ASO listing copy, Data Safety disclosure, signing, and Google Play Console release.
+- [Amazon Returns Recovery](https://skills.suedeai.ai/skills/amazon-returns-recovery.html): Scan Amazon order and return history for restocking fees and short refunds, then drive Amazon live chat to get the money waived and refunded (requires the Claude in Chrome extension).
+- [Subscription Recovery](https://skills.suedeai.ai/skills/subscription-recovery.html): Audit any recurring subscription (Netflix, Spotify, gyms, App Store, Google Play, PayPal) and cancel or negotiate a refund through that service's own support.
 
 ## Marketing and growth skills
 
-- [Suede A/B Testing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html): Test so the result means something.
-- [Suede Ad Creative](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html): Produce ad creative at volume.
-- [Suede Ads](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html): Run paid acquisition that pays back.
-- [Suede Analytics](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html): Know whether any of it worked.
-- [Suede ASO](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html): Optimise an App Store or Play listing.
-- [Suede Churn Prevention](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html): Keep subscribers who are leaving and recover the ones you lose to billing.
-- [Suede Co Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html): Find and run partner campaigns.
-- [Suede Cold Email](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html): Write B2B cold outreach that gets replies.
-- [Suede Community Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html): Build a community that compounds.
-- [Suede Competitor Profiling](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html): Research competitors from their public surfaces and turn the findings into structured profiles.
-- [Suede Competitors](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html): Write comparison and alternative pages that rank and convert without misrepresenting anyone.
-- [Suede Content Strategy](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html): Decide what to publish and why.
-- [Suede Customer Research](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html): Find out what customers actually think.
-- [Suede Directory Submissions](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html): Work the directory layer deliberately.
-- [Suede Emails](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html): Design lifecycle email that runs itself.
-- [Suede Free Tools](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html): Engineering as marketing.
-- [Suede Image](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html): Create and optimise marketing imagery.
-- [Suede Instagram Growth](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html): Audit an Instagram account from authorized evidence, map views to qualified actions, and create account-specific Reels, carousels, Stories, calendars, and daily approval-ready workflows.
-- [Suede Lead Magnets](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html): Decide what to give away for an email.
-- [Suede Marketing Council](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html): Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.
-- [Suede Marketing Ideas](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html): Get unstuck with a structured idea library rather than a blank page.
-- [Suede Marketing Loops](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html): Turn marketing into a recurring loop an agent runs on a cadence.
-- [Suede Marketing Plan](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html): Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.
-- [Suede Marketing Psychology](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html): Apply behavioural science honestly.
-- [Suede Offers](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html): Construct the thing you actually sell.
-- [Suede Onboarding](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html): Get a new user to first value fast.
-- [Suede Paywalls](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html): Design in-app upgrade moments that convert without resentment.
-- [Suede Pricing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html): Decide what to charge and how to package it.
-- [Suede Product Marketing](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html): Establish the product context every other marketing lane reads from.
-- [Suede Programmatic SEO](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html): Build search pages at scale without building junk.
-- [Suede Prospecting](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html): Build and qualify a target list before you write a word.
-- [Suede Public Relations](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html): Earn coverage without a retainer.
-- [Suede Referrals](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html): Turn customers into a channel.
-- [Suede RevOps](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html): Wire marketing to revenue.
-- [Suede Sales Enablement](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html): Arm the people doing the selling.
-- [Suede Signup](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html): Cut friction out of registration.
-- [Suede SMS](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html): Run SMS without getting blocked or resented.
-- [Suede Social](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html): Run social as a channel rather than a chore.
-- [Suede Video](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html): Plan and produce marketing video.
+- [Suede A/B Testing](https://skills.suedeai.ai/skills/suede-ab-testing.html): Test so the result means something.
+- [Suede Ad Creative](https://skills.suedeai.ai/skills/suede-ad-creative.html): Produce ad creative at volume.
+- [Suede Ads](https://skills.suedeai.ai/skills/suede-ads.html): Run paid acquisition that pays back.
+- [Suede Analytics](https://skills.suedeai.ai/skills/suede-analytics.html): Know whether any of it worked.
+- [Suede ASO](https://skills.suedeai.ai/skills/suede-aso.html): Optimise an App Store or Play listing.
+- [Suede Churn Prevention](https://skills.suedeai.ai/skills/suede-churn-prevention.html): Keep subscribers who are leaving and recover the ones you lose to billing.
+- [Suede Co Marketing](https://skills.suedeai.ai/skills/suede-co-marketing.html): Find and run partner campaigns.
+- [Suede Cold Email](https://skills.suedeai.ai/skills/suede-cold-email.html): Write B2B cold outreach that gets replies.
+- [Suede Community Marketing](https://skills.suedeai.ai/skills/suede-community-marketing.html): Build a community that compounds.
+- [Suede Competitor Profiling](https://skills.suedeai.ai/skills/suede-competitor-profiling.html): Research competitors from their public surfaces and turn the findings into structured profiles.
+- [Suede Competitors](https://skills.suedeai.ai/skills/suede-competitors.html): Write comparison and alternative pages that rank and convert without misrepresenting anyone.
+- [Suede Content Strategy](https://skills.suedeai.ai/skills/suede-content-strategy.html): Decide what to publish and why.
+- [Suede Customer Research](https://skills.suedeai.ai/skills/suede-customer-research.html): Find out what customers actually think.
+- [Suede Directory Submissions](https://skills.suedeai.ai/skills/suede-directory-submissions.html): Work the directory layer deliberately.
+- [Suede Emails](https://skills.suedeai.ai/skills/suede-emails.html): Design lifecycle email that runs itself.
+- [Suede Free Tools](https://skills.suedeai.ai/skills/suede-free-tools.html): Engineering as marketing.
+- [Suede Image](https://skills.suedeai.ai/skills/suede-image.html): Create and optimise marketing imagery.
+- [Suede Instagram Growth](https://skills.suedeai.ai/skills/suede-instagram-growth.html): Audit an Instagram account from authorized evidence, map views to qualified actions, and create account-specific Reels, carousels, Stories, calendars, and daily approval-ready workflows.
+- [Suede Lead Magnets](https://skills.suedeai.ai/skills/suede-lead-magnets.html): Decide what to give away for an email.
+- [Suede Marketing Council](https://skills.suedeai.ai/skills/suede-marketing-council.html): Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.
+- [Suede Marketing Ideas](https://skills.suedeai.ai/skills/suede-marketing-ideas.html): Get unstuck with a structured idea library rather than a blank page.
+- [Suede Marketing Loops](https://skills.suedeai.ai/skills/suede-marketing-loops.html): Turn marketing into a recurring loop an agent runs on a cadence.
+- [Suede Marketing Plan](https://skills.suedeai.ai/skills/suede-marketing-plan.html): Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.
+- [Suede Marketing Psychology](https://skills.suedeai.ai/skills/suede-marketing-psychology.html): Apply behavioural science honestly.
+- [Suede Offers](https://skills.suedeai.ai/skills/suede-offers.html): Construct the thing you actually sell.
+- [Suede Onboarding](https://skills.suedeai.ai/skills/suede-onboarding.html): Get a new user to first value fast.
+- [Suede Paywalls](https://skills.suedeai.ai/skills/suede-paywalls.html): Design in-app upgrade moments that convert without resentment.
+- [Suede Pricing](https://skills.suedeai.ai/skills/suede-pricing.html): Decide what to charge and how to package it.
+- [Suede Product Marketing](https://skills.suedeai.ai/skills/suede-product-marketing.html): Establish the product context every other marketing lane reads from.
+- [Suede Programmatic SEO](https://skills.suedeai.ai/skills/suede-programmatic-seo.html): Build search pages at scale without building junk.
+- [Suede Prospecting](https://skills.suedeai.ai/skills/suede-prospecting.html): Build and qualify a target list before you write a word.
+- [Suede Public Relations](https://skills.suedeai.ai/skills/suede-public-relations.html): Earn coverage without a retainer.
+- [Suede Referrals](https://skills.suedeai.ai/skills/suede-referrals.html): Turn customers into a channel.
+- [Suede RevOps](https://skills.suedeai.ai/skills/suede-revops.html): Wire marketing to revenue.
+- [Suede Sales Enablement](https://skills.suedeai.ai/skills/suede-sales-enablement.html): Arm the people doing the selling.
+- [Suede Signup](https://skills.suedeai.ai/skills/suede-signup.html): Cut friction out of registration.
+- [Suede SMS](https://skills.suedeai.ai/skills/suede-sms.html): Run SMS without getting blocked or resented.
+- [Suede Social](https://skills.suedeai.ai/skills/suede-social.html): Run social as a channel rather than a chore.
+- [Suede Video](https://skills.suedeai.ai/skills/suede-video.html): Plan and produce marketing video.
 
 ## Creator skills (music, rights, campaigns)
 
-- [Suede Rights Passport](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html): Package creative folders into structured transfer material with provenance, credits, and splits.
-- [Suede Release Linter](https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html): Audit release folders for missing metadata, artwork, masters, stems, credits, splits, and provenance gaps.
+- [Suede Rights Passport](https://skills.suedeai.ai/skills/suede-rights-passport.html): Package creative folders into structured transfer material with provenance, credits, and splits.
+- [Suede Release Linter](https://skills.suedeai.ai/skills/suede-release-linter.html): Audit release folders for missing metadata, artwork, masters, stems, credits, splits, and provenance gaps.
 - Suede Campaign in a Box — Turn a song, release, or era into a complete artist campaign: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-campaign-in-a-box/SKILL.md
 - Suede Rights Audit — Find ownership, split, sample, and provenance gaps before packaging: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-rights-audit/SKILL.md
 - Suede Sync Packaging — Package songs for sync pitching with scene-fit angles and clean asset checklists: https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-sync-packaging/SKILL.md

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -7,25 +7,25 @@
   <meta name="description" content="Install all 70 Suede Creator Skills for Claude Code, Codex, and other supported agents. Add the optional MCP for discovery, audits, grading, and QA.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/plugins.html">
+  <link rel="canonical" href="https://skills.suedeai.ai/plugins.html">
   <link rel="icon" href="./assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Install Suede Creator Skills | Claude Code, Codex, and MCP">
   <meta property="og:description" content="Public GitHub skill installs for Claude Code and Codex, plus MCP options for skill discovery, Suedify, design, anti-slop copywriting, visibility grading, Suede SEO/AEO/AI EO audits, and QA checklists.">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/plugins.html">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/plugins.html">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Install Suede Creator Skills | Claude Code, Codex, and MCP">
   <meta name="twitter:description" content="Install public Suede skills for Claude Code and Codex from GitHub and use the bundled MCP for discovery, visibility grading, code grading, SEO/AEO/AI EO copy audits, and QA.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "TechArticle",
-      "@id": "https://jasoncolapietro.github.io/suede-creator-skills/plugins.html#article",
+      "@id": "https://skills.suedeai.ai/plugins.html#article",
       "headline": "Install Suede Creator Skills: Claude Code, Codex, and MCP",
       "description": "Install public Suede skills for Claude Code and Codex from GitHub and use the Suede Skills MCP for Suedify, design, anti-slop copywriting, visibility grading, code grading, Suede SEO/AEO/AI EO copy audits, and QA checklists.",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/plugins.html",
+      "url": "https://skills.suedeai.ai/plugins.html",
       "author": {
         "@type": "Person",
         "name": "Jason Colapietro",

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://jasoncolapietro.github.io/suede-creator-skills/sitemap.xml
+Sitemap: https://skills.suedeai.ai/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,470 +1,470 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/guide.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/guide.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/skills/</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/copy.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/copy.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/plugins.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/plugins.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-workflow-skills.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/johnny-suede-write.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/johnny-suede-design.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-visibility-grader.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ai-eval.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-agent-teams.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-code-grader.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-rights-passport.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-release-linter.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-code.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-code-review.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ci-gate.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-codex-fleet.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/amazon-returns-recovery.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/android-app-factory.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/site-to-ios-app.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/subscription-recovery.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ab-testing.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ad-creative.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ads.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-analytics.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-aso.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-churn-prevention.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-clip-to-guide.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-co-marketing.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-cold-email.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-community-marketing.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-competitor-profiling.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-competitors.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-content-strategy.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-copy.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-customer-research.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-design.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-deslop.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-directory-submissions.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-emails.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-free-tools.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html</loc>
-    <lastmod>2026-08-05</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-full-send.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-image.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-instagram-growth.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-launch-packaging.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-lead-magnets.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-marketing-council.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-marketing-ideas.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-marketing-loops.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-marketing-plan.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-marketing-psychology.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-mcp-qa.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-offers.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-onboarding.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-paywalls.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-pricing.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-product-marketing.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-programmatic-seo.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-prospecting.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-public-relations.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-recommend-next-action.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-referrals.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-revops.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-rights-audit.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-sales-enablement.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-seo-audit.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ship.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-ship-copy.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-signup.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-site-alchemy.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-sms.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-social.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-sync-packaging.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/skills/suede-video.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/blog/</loc>
-    <lastmod>2026-08-04</lastmod>
+    <loc>https://skills.suedeai.ai/blog/</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://jasoncolapietro.github.io/suede-creator-skills/blog/android-recommend-next-action-and-workflows.html</loc>
-    <lastmod>2026-08-01</lastmod>
+    <loc>https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html</loc>
+    <lastmod>2026-08-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Amazon Returns Recovery in Claude Code to find Amazon restocking fees, short refunds, and forgotten subscriptions like Britbox and Starz, then drive Amazon live chat to get them waived, refunded, or canceled.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/amazon-returns-recovery.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Amazon Returns Recovery - Suede Creator Skills">
     <meta property="og:description" content="Use Amazon Returns Recovery in Claude Code to find Amazon restocking fees, short refunds, and forgotten subscriptions like Britbox and Starz, then drive Amazon live chat to get them waived, refunded, or canceled.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/amazon-returns-recovery.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Amazon Returns Recovery - Suede Creator Skills">
     <meta name="twitter:description" content="Use Amazon Returns Recovery in Claude Code to find Amazon restocking fees, short refunds, and forgotten subscriptions like Britbox and Starz, then drive Amazon live chat to get them waived, refunded, or canceled.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html#article",
+        "@id": "https://skills.suedeai.ai/skills/amazon-returns-recovery.html#article",
         "headline": "Amazon Returns Recovery - Suede Creator Skills",
         "description": "Amazon Returns Recovery scans Amazon order and return history and digital subscriptions (Britbox, Starz, Audible, and more) for restocking fees, short refunds, and forgotten charges, confirms findings with the account owner, then drives Amazon live chat to get the money waived, refunded, or the subscription canceled. $448.31 recovered in documented real cases.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/amazon-returns-recovery.html",
+        "url": "https://skills.suedeai.ai/skills/amazon-returns-recovery.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Amazon restocking fee", "Amazon refund dispute", "Amazon returns", "Amazon subscriptions", "Britbox", "Starz", "Audible", "browser automation", "Claude in Chrome", "consumer recovery"],

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Android App Factory in Claude Code or Codex to plan and build a native Android app end to end: keyword, Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, Data Safety, signing, and Play Console release.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/android-app-factory.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Android App Factory - Suede Creator Skills">
     <meta property="og:description" content="Use Android App Factory in Claude Code or Codex to plan and build a native Android app end to end: keyword, Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, Data Safety, signing, and Play Console release.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/android-app-factory.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Android App Factory - Suede Creator Skills">
     <meta name="twitter:description" content="Use Android App Factory in Claude Code or Codex to plan and build a native Android app end to end: keyword, Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, Data Safety, signing, and Play Console release.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html#article",
+        "@id": "https://skills.suedeai.ai/skills/android-app-factory.html#article",
         "headline": "Android App Factory - Suede Creator Skills",
         "description": "Android App Factory plans and builds a native Android app from a one-line idea or target keyword through Kotlin + Jetpack Compose scaffolding, Play Billing monetization, Play Store screenshots and ASO listing copy, Data Safety and content-rating disclosure, signing, and Google Play Console release. Complements site-to-ios-app, the public iOS conversion workflow.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/android-app-factory.html",
+        "url": "https://skills.suedeai.ai/skills/android-app-factory.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Android app development", "Kotlin", "Jetpack Compose", "Play Billing", "Google Play Console", "ASO", "Play Store listing", "Data Safety form"],

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -7,45 +7,45 @@
   <meta name="description" content="Browse all 71 Suede Creator Skills for Claude Code and Codex: Full Send orchestration, agent teams, code review, CI, AI evals, Suedify, Instagram growth, SEO, MCP, iOS, Android, and creator tools.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/">
+  <link rel="canonical" href="https://skills.suedeai.ai/skills/">
   <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills Docs">
   <meta property="og:description" content="Read the public docs for all 70 Suede skills: Full Send orchestration, agent teams, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copy, SEO/AEO/GEO/AI EO, music/IP, and creator rights.">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/skills/">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Creator Skills Docs">
   <meta name="twitter:description" content="Public docs for 71 Claude Code and Codex skills: Full Send orchestration, agent teams, A-F code review, CI ship-gates, AI evals, Suedify, Instagram growth, SEO/AEO/GEO/AI EO, music/IP, and creator workflows.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "CollectionPage",
-      "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/#webpage",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/",
+      "@id": "https://skills.suedeai.ai/skills/#webpage",
+      "url": "https://skills.suedeai.ai/skills/",
       "name": "Suede Creator Skills Docs",
       "description": "Complete public documentation for Suede Creator Skills: Suede Workflow Skills, coordinated agent teams, Codex CLI worker fleets, code review and A-F grading, CI ship-gates, AI evals, Suedify, design, anti-slop copywriting, visual QA, visibility grading, Suede SEO/AEO/GEO/AI EO, artist campaigns, music/IP, and creator utilities.",
       "isPartOf": {
         "@type": "WebSite",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/#website"
+        "@id": "https://skills.suedeai.ai/#website"
       },
       "about": ["Claude Code skills", "Codex skills", "Agent Skills", "Suedify", "website design", "copywriting", "website visibility", "CTA grading", "SEO audit", "AEO", "AI EO", "agent QA", "artist campaigns"],
       "hasPart": [
         {
           "@type": "TechArticle",
           "name": "Suede Workflow Skills docs",
-          "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html"
+          "url": "https://skills.suedeai.ai/skills/suede-workflow-skills.html"
         },
         {
           "@type": "TechArticle",
           "name": "Suede Visibility Grader docs",
-          "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html"
+          "url": "https://skills.suedeai.ai/skills/suede-visibility-grader.html"
         },
         {
           "@type": "TechArticle",
           "name": "Suede AI Eval docs",
-          "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html"
+          "url": "https://skills.suedeai.ai/skills/suede-ai-eval.html"
         },
         {
           "@type": "TechArticle",
@@ -55,12 +55,12 @@
         {
           "@type": "TechArticle",
           "name": "Suede Rights Passport docs",
-          "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html"
+          "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html"
         },
         {
           "@type": "TechArticle",
           "name": "Suede Release Linter docs",
-          "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html"
+          "url": "https://skills.suedeai.ai/skills/suede-release-linter.html"
         }
       ]
     }

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Load Johnny Suede Design for Suede or your own company: Suedify, mobile and product surfaces, product screenshots, UI polish, design-system QA, visual QA, visibility grading, SEO, company voice, and copy.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/johnny-suede-design.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Johnny Suede Design">
     <meta property="og:description" content="The full design mode for Suede or your own company: Suedify, mobile and product surfaces, product screenshots, UI polish, design-system QA, visual QA, SEO, company voice, and copy.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/johnny-suede-design.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Johnny Suede Design">
     <meta name="twitter:description" content="Load one design mode for reference-site restyling, mobile and product surfaces, SEO, company voice, UI polish, visibility grading, and copy.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html#article",
+        "@id": "https://skills.suedeai.ai/skills/johnny-suede-design.html#article",
         "headline": "Johnny Suede Design",
         "description": "Install Johnny Suede Design as the full design mode for Suede or a supplied company: Suedify, mobile and product surfaces, product screenshots, UI polish, design-system QA, visual QA, visibility grading, SEO/AEO/AI EO discoverability, company voice, implementation handoff, and copy.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-design.html",
+        "url": "https://skills.suedeai.ai/skills/johnny-suede-design.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "design systems", "Suedify", "website redesign", "product surfaces", "mobile design", "product screenshots", "copywriting", "Suede SEO", "SEO", "AI EO", "SKILL.md"],

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Load Johnny Suede Write for Suede or your own company: public copy, company voice, product and mobile conversion copy, SEO/AEO/AI EO, CTAs, and anti-slop line editing.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/johnny-suede-write.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Johnny Suede Write">
     <meta property="og:description" content="The full writing mode for Suede or your own company: public copy, product and mobile conversion copy, SEO/AEO/AI EO, CTAs, evidence boundaries, and anti-slop line editing.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/johnny-suede-write.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Johnny Suede Write">
     <meta name="twitter:description" content="Load one writing mode for company voice, copy, mobile and product surfaces, SEO, CTAs, launch copy, and public language.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html#article",
+        "@id": "https://skills.suedeai.ai/skills/johnny-suede-write.html#article",
         "headline": "Johnny Suede Write",
         "description": "Install Johnny Suede Write as the full writing mode for Suede or a supplied company: copy, product and mobile conversion copy, SEO/AEO/AI EO, CTAs, company voice, and anti-slop line editing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/johnny-suede-write.html",
+        "url": "https://skills.suedeai.ai/skills/johnny-suede-write.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "copywriting", "product pages", "mobile copy", "product listing", "Suede SEO", "SEO", "AEO", "AI EO", "CTAs", "founder voice", "SKILL.md"],

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Site to iOS App in Claude Code and Codex to audit, plan, gate, and scaffold website conversions with App Store 4.2 checks.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/site-to-ios-app.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Site to iOS App - Suede Creator Skills">
     <meta property="og:description" content="Use Site to iOS App in Claude Code and Codex to audit, plan, gate, and scaffold website conversions with App Store 4.2 checks.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/site-to-ios-app.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Site to iOS App - Suede Creator Skills">
     <meta name="twitter:description" content="Use Site to iOS App in Claude Code and Codex to audit, plan, gate, and scaffold website conversions with App Store 4.2 checks.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html#article",
+        "@id": "https://skills.suedeai.ai/skills/site-to-ios-app.html#article",
         "headline": "Site to iOS App - Suede Creator Skills",
         "description": "Site to iOS App audits websites, chooses a Capacitor or native strategy, gates App Store 4.2 wrapper risk, plans native value, and blocks release until explicit submission delegation.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/site-to-ios-app.html",
+        "url": "https://skills.suedeai.ai/skills/site-to-ios-app.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "site-to-iOS conversion", "App Store 4.2", "Capacitor", "SwiftUI", "WebView", "native value", "release gate"],

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Subscription Recovery in Claude Code to find and cancel forgotten subscriptions across Netflix, Spotify, gyms, App Store, Google Play, and PayPal, or negotiate a refund through that service's own support.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/subscription-recovery.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Subscription Recovery - Suede Creator Skills">
     <meta property="og:description" content="Use Subscription Recovery in Claude Code to find and cancel forgotten subscriptions across Netflix, Spotify, gyms, App Store, Google Play, and PayPal, or negotiate a refund through that service's own support.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/subscription-recovery.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Subscription Recovery - Suede Creator Skills">
     <meta name="twitter:description" content="Use Subscription Recovery in Claude Code to find and cancel forgotten subscriptions across Netflix, Spotify, gyms, App Store, Google Play, and PayPal, or negotiate a refund through that service's own support.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html#article",
+        "@id": "https://skills.suedeai.ai/skills/subscription-recovery.html#article",
         "headline": "Subscription Recovery - Suede Creator Skills",
         "description": "Subscription Recovery audits recurring charges across App Store, Google Play, PayPal, and direct-bill services like Netflix, Spotify, and gyms, confirms findings with the account owner, then cancels unused subscriptions directly or negotiates a refund through that service's own support. Complements amazon-returns-recovery, which stays scoped to Amazon.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/subscription-recovery.html",
+        "url": "https://skills.suedeai.ai/skills/subscription-recovery.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "subscription cancellation", "recurring charge audit", "Netflix", "Spotify", "App Store subscriptions", "Google Play subscriptions", "PayPal recurring payments", "browser automation", "Claude in Chrome", "consumer recovery"],

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Test so the result means something: hypothesis framing, sample size and significance, test duration, and running an experiment programme rather than one-off guesses.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ab-testing.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ab Testing - Suede Creator Skills">
     <meta property="og:description" content="Test so the result means something: hypothesis framing, sample size and significance, test duration, and running an experiment programme rather than one-off guesses.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ab-testing.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ab Testing - Suede Creator Skills">
     <meta name="twitter:description" content="Test so the result means something: hypothesis framing, sample size and significance, test duration, and running an experiment programme rather than one-off guesses.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ab-testing.html#article",
         "headline": "Suede Ab Testing - Suede Creator Skills",
         "description": "Test so the result means something: hypothesis framing, sample size and significance, test duration, and running an experiment programme rather than one-off guesses.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ab-testing.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ab-testing.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Produce ad creative at volume: headline and primary-text variants, platform specs, static and motion concepts, and a creative testing cadence.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ad-creative.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ad Creative - Suede Creator Skills">
     <meta property="og:description" content="Produce ad creative at volume: headline and primary-text variants, platform specs, static and motion concepts, and a creative testing cadence.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ad-creative.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ad Creative - Suede Creator Skills">
     <meta name="twitter:description" content="Produce ad creative at volume: headline and primary-text variants, platform specs, static and motion concepts, and a creative testing cadence.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ad-creative.html#article",
         "headline": "Suede Ad Creative - Suede Creator Skills",
         "description": "Produce ad creative at volume: headline and primary-text variants, platform specs, static and motion concepts, and a creative testing cadence.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ad-creative.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ad-creative.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Run paid acquisition that pays back: campaign structure, audience targeting, bidding, budget pacing, negative keywords, and knowing when to kill an ad.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ads.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ads - Suede Creator Skills">
     <meta property="og:description" content="Run paid acquisition that pays back: campaign structure, audience targeting, bidding, budget pacing, negative keywords, and knowing when to kill an ad.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ads.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ads - Suede Creator Skills">
     <meta name="twitter:description" content="Run paid acquisition that pays back: campaign structure, audience targeting, bidding, budget pacing, negative keywords, and knowing when to kill an ad.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ads.html#article",
         "headline": "Suede Ads - Suede Creator Skills",
         "description": "Run paid acquisition that pays back: campaign structure, audience targeting, bidding, budget pacing, negative keywords, and knowing when to kill an ad.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ads.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ads.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Agent Teams to wire complex changes into coordinated agent lanes with WIP collision detection, RFC mode, feature-flag strategy, rollback trees, scenario templates, and a handoff that won't close without evidence.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-agent-teams.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Agent Teams">
     <meta property="og:description" content="Coordinate complex changes across agent lanes with quality gates, collision detection, rollback trees, and a signed evidence handoff.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-agent-teams.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Agent Teams">
     <meta name="twitter:description" content="Wire complex changes into coordinated agent lanes with quality gates and a handoff that won't close without evidence.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-agent-teams.html#article",
         "headline": "Suede Agent Teams",
         "description": "Public Codex skill for coordinating complex changes across agent lanes with quality gates, collision detection, rollback trees, and a signed evidence handoff.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-agent-teams.html",
+        "url": "https://skills.suedeai.ai/skills/suede-agent-teams.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede AI Eval to design AI-SPEC artifacts, failure-mode rubrics, prompt and retrieval test cases, acceptance gates, and retroactive eval coverage audits for AI-powered product surfaces.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ai-eval.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede AI Eval">
     <meta property="og:description" content="Turn AI-powered product behavior into measurable specs, failure rubrics, eval cases, acceptance gates, and coverage audits.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ai-eval.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede AI Eval">
     <meta name="twitter:description" content="AI-SPECs, failure-mode rubrics, eval cases, acceptance gates, and coverage audits for AI-powered surfaces.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ai-eval.html#article",
         "headline": "Suede AI Eval",
         "description": "Public Codex skill for AI-SPEC artifacts, failure-mode rubrics, prompt and retrieval test cases, acceptance gates, and retroactive eval coverage audits.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ai-eval.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ai-eval.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Know whether any of it worked: tracking plans, event and conversion instrumentation, UTM discipline, attribution, and auditing what is actually firing.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-analytics.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Analytics - Suede Creator Skills">
     <meta property="og:description" content="Know whether any of it worked: tracking plans, event and conversion instrumentation, UTM discipline, attribution, and auditing what is actually firing.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-analytics.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Analytics - Suede Creator Skills">
     <meta name="twitter:description" content="Know whether any of it worked: tracking plans, event and conversion instrumentation, UTM discipline, attribution, and auditing what is actually firing.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-analytics.html#article",
         "headline": "Suede Analytics - Suede Creator Skills",
         "description": "Know whether any of it worked: tracking plans, event and conversion instrumentation, UTM discipline, attribution, and auditing what is actually firing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-analytics.html",
+        "url": "https://skills.suedeai.ai/skills/suede-analytics.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Optimise an App Store or Play listing: keyword field strategy, title and subtitle, screenshots that convert, and competitor listing teardowns.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-aso.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Aso - Suede Creator Skills">
     <meta property="og:description" content="Optimise an App Store or Play listing: keyword field strategy, title and subtitle, screenshots that convert, and competitor listing teardowns.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-aso.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Aso - Suede Creator Skills">
     <meta name="twitter:description" content="Optimise an App Store or Play listing: keyword field strategy, title and subtitle, screenshots that convert, and competitor listing teardowns.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-aso.html#article",
         "headline": "Suede Aso - Suede Creator Skills",
         "description": "Optimise an App Store or Play listing: keyword field strategy, title and subtitle, screenshots that convert, and competitor listing teardowns.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-aso.html",
+        "url": "https://skills.suedeai.ai/skills/suede-aso.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Campaign in a Box in Claude Code and Codex to package artist rollouts with identity, eras, hooks, stunts, fan rituals, visuals, merch, and calendars.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Campaign in a Box - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Campaign in a Box in Claude Code and Codex to package artist rollouts with identity, eras, hooks, stunts, fan rituals, visuals, merch, and calendars.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Campaign in a Box - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Campaign in a Box in Claude Code and Codex to package artist rollouts with identity, eras, hooks, stunts, fan rituals, visuals, merch, and calendars.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html#article",
         "headline": "Suede Campaign in a Box - Suede Creator Skills",
         "description": "Suede Campaign in a Box packages a song, release, era, catalog moment, show, or drop into an artist campaign. It organizes identity, eras, hooks, stunts, fan rituals, visuals, merch, setlists, catalog revival, collaborator lanes, rollout copy, calendars, and safety gaps.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-campaign-in-a-box.html",
+        "url": "https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills","Claude Code skills","Codex skills","artist campaigns","release rollouts","fan rituals","visualizer treatments","merch objects","campaign safety"],

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Keep subscribers who are leaving and recover the ones you lose to billing: cancel flows, save offers, pause options, dunning for failed payments, and win-back sequences.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-churn-prevention.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Churn Prevention - Suede Creator Skills">
     <meta property="og:description" content="Keep subscribers who are leaving and recover the ones you lose to billing: cancel flows, save offers, pause options, dunning for failed payments, and win-back sequences.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-churn-prevention.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Churn Prevention - Suede Creator Skills">
     <meta name="twitter:description" content="Keep subscribers who are leaving and recover the ones you lose to billing: cancel flows, save offers, pause options, dunning for failed payments, and win-back sequences.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-churn-prevention.html#article",
         "headline": "Suede Churn Prevention - Suede Creator Skills",
         "description": "Keep subscribers who are leaving and recover the ones you lose to billing: cancel flows, save offers, pause options, dunning for failed payments, and win-back sequences.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-churn-prevention.html",
+        "url": "https://skills.suedeai.ai/skills/suede-churn-prevention.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-ci-gate.html
+++ b/docs/skills/suede-ci-gate.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Ship Gate in Claude Code and Codex to wire path-aware CI, ci-success aggregation, lockfile hygiene, and branch protection settings.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ci-gate.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ship Gate - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Ship Gate in Claude Code and Codex to wire path-aware CI, ci-success aggregation, lockfile hygiene, and branch protection settings.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ci-gate.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ship Gate - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Ship Gate in Claude Code and Codex to wire path-aware CI, ci-success aggregation, lockfile hygiene, and branch protection settings.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ci-gate.html#article",
         "headline": "Suede Ship Gate - Suede Creator Skills",
         "description": "Suede Ship Gate detects repo apps, lockfiles, workflows, runtimes, deploy platform, and scripts before generating CI. It uses path-aware jobs, a ci-success aggregator, and exact branch-protection settings.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ci-gate.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ci-gate.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "GitHub Actions", "branch protection", "path-aware CI", "ci-success aggregator", "lockfile hygiene", "runtime detection"],

--- a/docs/skills/suede-clip-to-guide.html
+++ b/docs/skills/suede-clip-to-guide.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Turn a qualifying video moment into a rights-aware short-to-long funnel with an 8/10 gate, exact approval, and dual proof in Full Send or Fleet mode.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-clip-to-guide.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Clip to Guide - Suede Creator Skills">
     <meta property="og:description" content="Turn a qualifying video moment into a rights-aware short-to-long funnel with an 8/10 gate, exact approval, and dual proof in Full Send or Fleet mode.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-clip-to-guide.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Clip to Guide - Suede Creator Skills">
     <meta name="twitter:description" content="Turn a qualifying video moment into a rights-aware short-to-long funnel with an 8/10 gate, exact approval, and dual proof in Full Send or Fleet mode.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-clip-to-guide.html#article",
         "headline": "Suede Clip to Guide - Suede Creator Skills",
         "description": "Turn a qualifying video moment into a rights-aware short-to-long funnel with an 8/10 gate, exact approval, and dual proof in Full Send or Fleet mode.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-clip-to-guide.html",
+        "url": "https://skills.suedeai.ai/skills/suede-clip-to-guide.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Find and run partner campaigns: partner selection, joint offer design, audience overlap, and splitting the work and the credit.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-co-marketing.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Co Marketing - Suede Creator Skills">
     <meta property="og:description" content="Find and run partner campaigns: partner selection, joint offer design, audience overlap, and splitting the work and the credit.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-co-marketing.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Co Marketing - Suede Creator Skills">
     <meta name="twitter:description" content="Find and run partner campaigns: partner selection, joint offer design, audience overlap, and splitting the work and the credit.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-co-marketing.html#article",
         "headline": "Suede Co Marketing - Suede Creator Skills",
         "description": "Find and run partner campaigns: partner selection, joint offer design, audience overlap, and splitting the work and the credit.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-co-marketing.html",
+        "url": "https://skills.suedeai.ai/skills/suede-co-marketing.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Code Grader for a blunt A-F ship verdict: 7 evidence-backed lanes, instant-F triggers, grade caps for auth and payment surfaces, and a required upgrade for every grade below A.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-code-grader.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Code Grader">
     <meta property="og:description" content="A blunt A-F ship verdict on any code change, with evidence-backed lanes, instant-F triggers, and grade caps for auth and payment surfaces.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-code-grader.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Code Grader">
     <meta name="twitter:description" content="Get a direct A-F ship/no-ship grade on a diff, PR, file, or release. Evidence, not a lint score.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-code-grader.html#article",
         "headline": "Suede Code Grader",
         "description": "Public Codex skill for a blunt A-F ship verdict on any code change, with evidence-backed lanes, instant-F triggers, and grade caps for auth and payment surfaces.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-grader.html",
+        "url": "https://skills.suedeai.ai/skills/suede-code-grader.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Code Review for findings-only diff review in Claude Code and Codex, with repo gates, severity-ranked evidence, deploy safety, and ship verdicts.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-code-review.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Code Review - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Code Review for findings-only diff review in Claude Code and Codex, with repo gates, severity-ranked evidence, deploy safety, and ship verdicts.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-code-review.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Code Review - Suede Creator Skills">
     <meta name="twitter:description" content="Findings-only diff review for Claude Code and Codex, with repo gates, severity-ranked evidence, deploy safety, and ship verdicts.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-code-review.html#article",
         "headline": "Suede Code Review - Suede Creator Skills",
         "description": "Suede Code Review documents a findings-only review skill for diffs and PRs. It runs repo gates, checks risk lanes, ranks evidence-backed findings, and ends with deploy safety and a ship gate.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code-review.html",
+        "url": "https://skills.suedeai.ai/skills/suede-code-review.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "findings-only review", "deploy safety", "Commit Dirt Score", "OWASP review", "accessibility review"],

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Suede Code gives Claude Code and Codex an explicit review mode for evidence-backed findings, A-F ship grades, OWASP checks, and deploy safety gates.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-code.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Code - Suede Creator Skills">
     <meta property="og:description" content="Suede Code gives Claude Code and Codex an explicit review mode for evidence-backed findings, A-F ship grades, OWASP checks, and deploy safety gates.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-code.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Code - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Code in Claude Code and Codex for evidence-backed code review, A-F ship grades, OWASP checks, and deploy safety gates.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-code.html#article",
         "headline": "Suede Code - Suede Creator Skills",
         "description": "Suede Code is an explicit review skill for code findings and A-F ship grading. It checks current source, diff context, repo gates, risk lanes, and deploy safety before a ship verdict.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-code.html",
+        "url": "https://skills.suedeai.ai/skills/suede-code.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "A-F ship grade", "OWASP review", "deploy safety gate", "Next.js review", "TypeScript review"],

--- a/docs/skills/suede-codex-fleet.html
+++ b/docs/skills/suede-codex-fleet.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Fable Fleet in Claude Code and Codex to split clear high-volume work into self-contained briefs, spawn CLI workers, and review outputs.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-codex-fleet.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Fable Fleet - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Fable Fleet in Claude Code and Codex to split clear high-volume work into self-contained briefs, spawn CLI workers, and review outputs.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-codex-fleet.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Fable Fleet - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Fable Fleet in Claude Code and Codex to split clear high-volume work into self-contained briefs, spawn CLI workers, and review outputs.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-codex-fleet.html#article",
         "headline": "Suede Fable Fleet - Suede Creator Skills",
         "description": "Suede Fable Fleet helps Claude decompose clear high-volume tasks into self-contained briefs, run parallel Codex CLI workers, and review outputs before anything ships.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-codex-fleet.html",
+        "url": "https://skills.suedeai.ai/skills/suede-codex-fleet.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude orchestrator", "OpenAI Codex CLI", "Codex CLI orchestration", "codex exec", "multi-agent worker fleet", "self-contained briefs", "acceptance criteria", "AGENTS.md"],

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Write B2B cold outreach that gets replies: subject lines, opening lines, body, CTA, personalisation depth, and multi-touch follow-up.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-cold-email.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Cold Email - Suede Creator Skills">
     <meta property="og:description" content="Write B2B cold outreach that gets replies: subject lines, opening lines, body, CTA, personalisation depth, and multi-touch follow-up.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-cold-email.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Cold Email - Suede Creator Skills">
     <meta name="twitter:description" content="Write B2B cold outreach that gets replies: subject lines, opening lines, body, CTA, personalisation depth, and multi-touch follow-up.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-cold-email.html#article",
         "headline": "Suede Cold Email - Suede Creator Skills",
         "description": "Write B2B cold outreach that gets replies: subject lines, opening lines, body, CTA, personalisation depth, and multi-touch follow-up.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-cold-email.html",
+        "url": "https://skills.suedeai.ai/skills/suede-cold-email.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Build a community that compounds: platform choice, seeding, rituals, moderation, and turning members into advocates.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-community-marketing.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Community Marketing - Suede Creator Skills">
     <meta property="og:description" content="Build a community that compounds: platform choice, seeding, rituals, moderation, and turning members into advocates.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-community-marketing.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Community Marketing - Suede Creator Skills">
     <meta name="twitter:description" content="Build a community that compounds: platform choice, seeding, rituals, moderation, and turning members into advocates.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-community-marketing.html#article",
         "headline": "Suede Community Marketing - Suede Creator Skills",
         "description": "Build a community that compounds: platform choice, seeding, rituals, moderation, and turning members into advocates.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-community-marketing.html",
+        "url": "https://skills.suedeai.ai/skills/suede-community-marketing.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Research competitors from their public surfaces and turn the findings into structured profiles: positioning, pricing, messaging, and where they are weak.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-competitor-profiling.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Competitor Profiling - Suede Creator Skills">
     <meta property="og:description" content="Research competitors from their public surfaces and turn the findings into structured profiles: positioning, pricing, messaging, and where they are weak.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-competitor-profiling.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Competitor Profiling - Suede Creator Skills">
     <meta name="twitter:description" content="Research competitors from their public surfaces and turn the findings into structured profiles: positioning, pricing, messaging, and where they are weak.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-competitor-profiling.html#article",
         "headline": "Suede Competitor Profiling - Suede Creator Skills",
         "description": "Research competitors from their public surfaces and turn the findings into structured profiles: positioning, pricing, messaging, and where they are weak.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitor-profiling.html",
+        "url": "https://skills.suedeai.ai/skills/suede-competitor-profiling.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Write comparison and alternative pages that rank and convert without misrepresenting anyone: page formats, claim discipline, and honest framing.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-competitors.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Competitors - Suede Creator Skills">
     <meta property="og:description" content="Write comparison and alternative pages that rank and convert without misrepresenting anyone: page formats, claim discipline, and honest framing.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-competitors.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Competitors - Suede Creator Skills">
     <meta name="twitter:description" content="Write comparison and alternative pages that rank and convert without misrepresenting anyone: page formats, claim discipline, and honest framing.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-competitors.html#article",
         "headline": "Suede Competitors - Suede Creator Skills",
         "description": "Write comparison and alternative pages that rank and convert without misrepresenting anyone: page formats, claim discipline, and honest framing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-competitors.html",
+        "url": "https://skills.suedeai.ai/skills/suede-competitors.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Decide what to publish and why: topic clusters, content pillars, editorial cadence, distribution planning, and what to stop writing.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-content-strategy.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Content Strategy - Suede Creator Skills">
     <meta property="og:description" content="Decide what to publish and why: topic clusters, content pillars, editorial cadence, distribution planning, and what to stop writing.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-content-strategy.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Content Strategy - Suede Creator Skills">
     <meta name="twitter:description" content="Decide what to publish and why: topic clusters, content pillars, editorial cadence, distribution planning, and what to stop writing.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-content-strategy.html#article",
         "headline": "Suede Content Strategy - Suede Creator Skills",
         "description": "Decide what to publish and why: topic clusters, content pillars, editorial cadence, distribution planning, and what to stop writing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-content-strategy.html",
+        "url": "https://skills.suedeai.ai/skills/suede-content-strategy.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Copy in Claude Code and Codex for standalone conversion email, landing page copy, CTAs, microcopy, variants, and anti-slop review.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-copy.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Copy - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Copy in Claude Code and Codex for standalone conversion email, landing page copy, CTAs, microcopy, variants, and anti-slop review.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-copy.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Copy - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Copy in Claude Code and Codex for standalone conversion email, landing page copy, CTAs, microcopy, variants, and anti-slop review.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-copy.html#article",
         "headline": "Suede Copy - Suede Creator Skills",
         "description": "Suede Copy writes standalone conversion email, landing page copy, CTAs, microcopy, and button labels. It uses headline formulas, persuasion frameworks, variants, channel templates, an anti-slop gate, and a scored ship gate.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-copy.html",
+        "url": "https://skills.suedeai.ai/skills/suede-copy.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion copy", "landing page copy", "email copy", "social posts", "CTA writing", "anti-slop review"],

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Find out what customers actually think: interview design, transcript and ticket synthesis, review mining, and turning raw input into personas and jobs.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-customer-research.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Customer Research - Suede Creator Skills">
     <meta property="og:description" content="Find out what customers actually think: interview design, transcript and ticket synthesis, review mining, and turning raw input into personas and jobs.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-customer-research.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Customer Research - Suede Creator Skills">
     <meta name="twitter:description" content="Find out what customers actually think: interview design, transcript and ticket synthesis, review mining, and turning raw input into personas and jobs.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-customer-research.html#article",
         "headline": "Suede Customer Research - Suede Creator Skills",
         "description": "Find out what customers actually think: interview design, transcript and ticket synthesis, review mining, and turning raw input into personas and jobs.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-customer-research.html",
+        "url": "https://skills.suedeai.ai/skills/suede-customer-research.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Design for Claude Code and Codex to guide Suede interface tokens, component polish, dark mode, fluid type, motion sequencing, and visual QA.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-design.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Design - Suede Creator Skills">
     <meta property="og:description" content="Install Suede Design for Claude Code and Codex to guide Suede interface tokens, component polish, dark mode, fluid type, motion sequencing, and visual QA.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-design.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Design - Suede Creator Skills">
     <meta name="twitter:description" content="Install Suede Design for Claude Code and Codex to guide Suede interface tokens, component polish, dark mode, fluid type, motion sequencing, and visual QA.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-design.html#article",
         "headline": "Suede Design - Suede Creator Skills",
         "description": "Suede Design documents design-system, token, component, dark-mode, type, motion, and visual QA guidance for Suede interfaces. Use it for product UI, brand surfaces, landing pages, dashboards, component systems, responsive polish, and comparing mocks with rendered implementation.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-design.html",
+        "url": "https://skills.suedeai.ai/skills/suede-design.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "design system tokens", "component polish", "dark mode tokens", "fluid typography", "motion sequencing", "visual QA"],

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Deslop in Claude Code or Codex to strip AI writing patterns from prose before it ships: a merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-deslop.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Deslop - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Deslop in Claude Code or Codex to strip AI writing patterns from prose before it ships: a merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-deslop.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Deslop - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Deslop in Claude Code or Codex to strip AI writing patterns from prose before it ships: a merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-deslop.html#article",
         "headline": "Suede Deslop - Suede Creator Skills",
         "description": "Suede Deslop strips AI writing patterns from prose before it ships: throat-clearing openers, false agency, formulaic contrasts, passive voice, and metronomic rhythm, all cut against a merged kill list, then scored 1-10 on directness, rhythm, trust, authenticity, and density with a revise line at 35 of 50.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-deslop.html",
+        "url": "https://skills.suedeai.ai/skills/suede-deslop.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "AI writing patterns", "copy editing", "anti-slop", "prose quality"],

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Work the directory layer deliberately: which listings carry dofollow weight, submission order, launch-day sequencing, and verifying the backlink landed.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-directory-submissions.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Directory Submissions - Suede Creator Skills">
     <meta property="og:description" content="Work the directory layer deliberately: which listings carry dofollow weight, submission order, launch-day sequencing, and verifying the backlink landed.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-directory-submissions.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Directory Submissions - Suede Creator Skills">
     <meta name="twitter:description" content="Work the directory layer deliberately: which listings carry dofollow weight, submission order, launch-day sequencing, and verifying the backlink landed.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-directory-submissions.html#article",
         "headline": "Suede Directory Submissions - Suede Creator Skills",
         "description": "Work the directory layer deliberately: which listings carry dofollow weight, submission order, launch-day sequencing, and verifying the backlink landed.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-directory-submissions.html",
+        "url": "https://skills.suedeai.ai/skills/suede-directory-submissions.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Design lifecycle email that runs itself: welcome and onboarding sequences, nurture, re-engagement, trigger design, and cadence that does not burn the list.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-emails.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Emails - Suede Creator Skills">
     <meta property="og:description" content="Design lifecycle email that runs itself: welcome and onboarding sequences, nurture, re-engagement, trigger design, and cadence that does not burn the list.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-emails.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Emails - Suede Creator Skills">
     <meta name="twitter:description" content="Design lifecycle email that runs itself: welcome and onboarding sequences, nurture, re-engagement, trigger design, and cadence that does not burn the list.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-emails.html#article",
         "headline": "Suede Emails - Suede Creator Skills",
         "description": "Design lifecycle email that runs itself: welcome and onboarding sequences, nurture, re-engagement, trigger design, and cadence that does not burn the list.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-emails.html",
+        "url": "https://skills.suedeai.ai/skills/suede-emails.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Engineering as marketing: pick a free tool worth building, scope it honestly, and design it so the output pulls people toward the paid product.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-free-tools.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Free Tools - Suede Creator Skills">
     <meta property="og:description" content="Engineering as marketing: pick a free tool worth building, scope it honestly, and design it so the output pulls people toward the paid product.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-free-tools.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Free Tools - Suede Creator Skills">
     <meta name="twitter:description" content="Engineering as marketing: pick a free tool worth building, scope it honestly, and design it so the output pulls people toward the paid product.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-free-tools.html#article",
         "headline": "Suede Free Tools - Suede Creator Skills",
         "description": "Engineering as marketing: pick a free tool worth building, scope it honestly, and design it so the output pulls people toward the paid product.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-free-tools.html",
+        "url": "https://skills.suedeai.ai/skills/suede-free-tools.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-full-send.html
+++ b/docs/skills/suede-full-send.html
@@ -7,27 +7,27 @@
   <meta name="description" content="Use Suede Full Send for broad, authorized outcomes that need one controller, useful non-colliding lanes, adversarial review, and an evidence-backed finish.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html">
+  <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-full-send.html">
   <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Suede Full Send | Outcome-Bound Agent Orchestration">
   <meta property="og:description" content="One controller. Maximum useful non-colliding lanes. Adversarial review and proof for broad, authorized outcomes.">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-full-send.html">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta property="og:image:alt" content="Suede Creator Skills: 71 open-source Agent Skills">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Full Send">
   <meta name="twitter:description" content="Route broad, authorized outcomes through one controller, useful lanes, adversarial review, and proof.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:image:alt" content="Suede Creator Skills: 71 open-source Agent Skills">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html#article",
+    "@id": "https://skills.suedeai.ai/skills/suede-full-send.html#article",
     "headline": "Suede Full Send",
     "description": "An open-source Agent Skill for routing broad, authorized outcome-bound work through one controller, useful non-colliding lanes, adversarial review, and an evidence-backed handoff.",
-    "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-full-send.html",
+    "url": "https://skills.suedeai.ai/skills/suede-full-send.html",
     "datePublished": "2026-07-25",
     "dateModified": "2026-07-25",
     "author": {

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Create and optimise marketing imagery: prompt craft for AI generation, hero and social graphics, product mockups, and export and compression discipline.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-image.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Image - Suede Creator Skills">
     <meta property="og:description" content="Create and optimise marketing imagery: prompt craft for AI generation, hero and social graphics, product mockups, and export and compression discipline.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-image.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Image - Suede Creator Skills">
     <meta name="twitter:description" content="Create and optimise marketing imagery: prompt craft for AI generation, hero and social graphics, product mockups, and export and compression discipline.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-image.html#article",
         "headline": "Suede Image - Suede Creator Skills",
         "description": "Create and optimise marketing imagery: prompt craft for AI generation, hero and social graphics, product mockups, and export and compression discipline.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-image.html",
+        "url": "https://skills.suedeai.ai/skills/suede-image.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-instagram-growth.html
+++ b/docs/skills/suede-instagram-growth.html
@@ -7,28 +7,28 @@
   <meta name="description" content="Audit an Instagram account from authorized evidence, map views to qualified action, and produce account-specific Reels, carousels, Stories, calendars, and daily workflows.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-  <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html">
+  <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-instagram-growth.html">
   <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="article">
   <meta property="og:title" content="Suede Instagram Growth - Suede Creator Skills">
   <meta property="og:description" content="Account evidence in. Instagram tests, content packages, conversion maps, and approval gates out.">
-  <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html">
-  <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-instagram-growth.html">
+  <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Suede Instagram Growth - Suede Creator Skills">
   <meta name="twitter:description" content="An evidence-backed Instagram operating system for audits, Reels, carousels, Stories, conversion, and daily workflows.">
-  <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+  <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
     "headline": "Suede Instagram Growth",
     "description": "A public Agent Skill for Instagram account audits, conversion mapping, account-specific content production, and approval-gated daily workflows.",
-    "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-instagram-growth.html",
+    "url": "https://skills.suedeai.ai/skills/suede-instagram-growth.html",
     "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://suedeai.ai/founder"},
     "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
     "license": "https://opensource.org/licenses/MIT",
-    "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+    "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
   }
   </script>
   <style>

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Launch Packaging in Claude Code and Codex to package public releases, verify live URLs, test install commands, and keep local paths out of docs.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-launch-packaging.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Launch Packaging - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Launch Packaging in Claude Code and Codex to package public releases, verify live URLs, test install commands, and keep local paths out of docs.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-launch-packaging.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Launch Packaging - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Launch Packaging in Claude Code and Codex to package public releases, verify live URLs, test install commands, and keep local paths out of docs.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-launch-packaging.html#article",
         "headline": "Suede Launch Packaging - Suede Creator Skills",
         "description": "Suede Launch Packaging helps package Suede work for launch and verify public install paths. It checks live URLs, proof links, install commands, copy gates, and handoff notes.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-launch-packaging.html",
+        "url": "https://skills.suedeai.ai/skills/suede-launch-packaging.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "launch packaging", "install verification", "GitHub Pages updates", "README launches", "MCP setup", "public install support"],

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Decide what to give away for an email: format selection, depth, gating rules, delivery, and the sequence that follows the download.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-lead-magnets.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Lead Magnets - Suede Creator Skills">
     <meta property="og:description" content="Decide what to give away for an email: format selection, depth, gating rules, delivery, and the sequence that follows the download.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-lead-magnets.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Lead Magnets - Suede Creator Skills">
     <meta name="twitter:description" content="Decide what to give away for an email: format selection, depth, gating rules, delivery, and the sequence that follows the download.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-lead-magnets.html#article",
         "headline": "Suede Lead Magnets - Suede Creator Skills",
         "description": "Decide what to give away for an email: format selection, depth, gating rules, delivery, and the sequence that follows the download.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-lead-magnets.html",
+        "url": "https://skills.suedeai.ai/skills/suede-lead-magnets.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-marketing-council.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Marketing Council - Suede Creator Skills">
     <meta property="og:description" content="Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-marketing-council.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Marketing Council - Suede Creator Skills">
     <meta name="twitter:description" content="Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-marketing-council.html#article",
         "headline": "Suede Marketing Council - Suede Creator Skills",
         "description": "Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-council.html",
+        "url": "https://skills.suedeai.ai/skills/suede-marketing-council.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Get unstuck with a structured idea library rather than a blank page: channel-by-channel tactics scored for effort, cost, and fit.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-marketing-ideas.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Marketing Ideas - Suede Creator Skills">
     <meta property="og:description" content="Get unstuck with a structured idea library rather than a blank page: channel-by-channel tactics scored for effort, cost, and fit.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-marketing-ideas.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Marketing Ideas - Suede Creator Skills">
     <meta name="twitter:description" content="Get unstuck with a structured idea library rather than a blank page: channel-by-channel tactics scored for effort, cost, and fit.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-marketing-ideas.html#article",
         "headline": "Suede Marketing Ideas - Suede Creator Skills",
         "description": "Get unstuck with a structured idea library rather than a blank page: channel-by-channel tactics scored for effort, cost, and fit.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-ideas.html",
+        "url": "https://skills.suedeai.ai/skills/suede-marketing-ideas.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Turn marketing into a recurring loop an agent runs on a cadence: ad-fatigue checks, content refresh, churn watch, ranking-drop alerts, and weekly reviews.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-marketing-loops.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Marketing Loops - Suede Creator Skills">
     <meta property="og:description" content="Turn marketing into a recurring loop an agent runs on a cadence: ad-fatigue checks, content refresh, churn watch, ranking-drop alerts, and weekly reviews.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-marketing-loops.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Marketing Loops - Suede Creator Skills">
     <meta name="twitter:description" content="Turn marketing into a recurring loop an agent runs on a cadence: ad-fatigue checks, content refresh, churn watch, ranking-drop alerts, and weekly reviews.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-marketing-loops.html#article",
         "headline": "Suede Marketing Loops - Suede Creator Skills",
         "description": "Turn marketing into a recurring loop an agent runs on a cadence: ad-fatigue checks, content refresh, churn watch, ranking-drop alerts, and weekly reviews.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-loops.html",
+        "url": "https://skills.suedeai.ai/skills/suede-marketing-loops.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-marketing-plan.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Marketing Plan - Suede Creator Skills">
     <meta property="og:description" content="Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-marketing-plan.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Marketing Plan - Suede Creator Skills">
     <meta name="twitter:description" content="Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-marketing-plan.html#article",
         "headline": "Suede Marketing Plan - Suede Creator Skills",
         "description": "Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-plan.html",
+        "url": "https://skills.suedeai.ai/skills/suede-marketing-plan.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Apply behavioural science honestly: anchoring, social proof, loss aversion, framing, and the mental models behind why people actually buy.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-marketing-psychology.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Marketing Psychology - Suede Creator Skills">
     <meta property="og:description" content="Apply behavioural science honestly: anchoring, social proof, loss aversion, framing, and the mental models behind why people actually buy.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-marketing-psychology.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Marketing Psychology - Suede Creator Skills">
     <meta name="twitter:description" content="Apply behavioural science honestly: anchoring, social proof, loss aversion, framing, and the mental models behind why people actually buy.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-marketing-psychology.html#article",
         "headline": "Suede Marketing Psychology - Suede Creator Skills",
         "description": "Apply behavioural science honestly: anchoring, social proof, loss aversion, framing, and the mental models behind why people actually buy.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-marketing-psychology.html",
+        "url": "https://skills.suedeai.ai/skills/suede-marketing-psychology.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede MCP QA to test live Suede Skills MCP servers, catalogs, JSON-RPC paths, install output, and docs alignment in Claude Code and Codex.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-mcp-qa.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede MCP QA - Suede Creator Skills">
     <meta property="og:description" content="Use Suede MCP QA to test live Suede Skills MCP servers, catalogs, JSON-RPC paths, install output, and docs alignment in Claude Code and Codex.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-mcp-qa.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede MCP QA - Suede Creator Skills">
     <meta name="twitter:description" content="Test live Suede Skills MCP servers, catalogs, JSON-RPC paths, install output, and docs alignment in Claude Code and Codex.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-mcp-qa.html#article",
         "headline": "Suede MCP QA - Suede Creator Skills",
         "description": "Suede MCP QA checks a live Suede Skills MCP server against its source, catalog, skill folders, tools, resources, prompts, install output, JSON-RPC errors, public-safe content, and docs alignment.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-mcp-qa.html",
+        "url": "https://skills.suedeai.ai/skills/suede-mcp-qa.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "MCP quality assurance", "Suede Skills MCP", "JSON-RPC testing", "Catalog alignment", "Install output checks", "Docs alignment"],

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Construct the thing you actually sell: value framing, bonus stacking, guarantee and risk-reversal design, honest scarcity, naming, and payment structure.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-offers.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Offers - Suede Creator Skills">
     <meta property="og:description" content="Construct the thing you actually sell: value framing, bonus stacking, guarantee and risk-reversal design, honest scarcity, naming, and payment structure.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-offers.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Offers - Suede Creator Skills">
     <meta name="twitter:description" content="Construct the thing you actually sell: value framing, bonus stacking, guarantee and risk-reversal design, honest scarcity, naming, and payment structure.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-offers.html#article",
         "headline": "Suede Offers - Suede Creator Skills",
         "description": "Construct the thing you actually sell: value framing, bonus stacking, guarantee and risk-reversal design, honest scarcity, naming, and payment structure.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-offers.html",
+        "url": "https://skills.suedeai.ai/skills/suede-offers.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Get a new user to first value fast: activation milestones, first-run sequencing, empty states, setup checklists, and the aha moment worth instrumenting.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-onboarding.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Onboarding - Suede Creator Skills">
     <meta property="og:description" content="Get a new user to first value fast: activation milestones, first-run sequencing, empty states, setup checklists, and the aha moment worth instrumenting.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-onboarding.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Onboarding - Suede Creator Skills">
     <meta name="twitter:description" content="Get a new user to first value fast: activation milestones, first-run sequencing, empty states, setup checklists, and the aha moment worth instrumenting.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-onboarding.html#article",
         "headline": "Suede Onboarding - Suede Creator Skills",
         "description": "Get a new user to first value fast: activation milestones, first-run sequencing, empty states, setup checklists, and the aha moment worth instrumenting.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-onboarding.html",
+        "url": "https://skills.suedeai.ai/skills/suede-onboarding.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Design in-app upgrade moments that convert without resentment: paywall screens, feature gates, trial-expiry states, and free-to-paid prompts.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-paywalls.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Paywalls - Suede Creator Skills">
     <meta property="og:description" content="Design in-app upgrade moments that convert without resentment: paywall screens, feature gates, trial-expiry states, and free-to-paid prompts.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-paywalls.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Paywalls - Suede Creator Skills">
     <meta name="twitter:description" content="Design in-app upgrade moments that convert without resentment: paywall screens, feature gates, trial-expiry states, and free-to-paid prompts.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-paywalls.html#article",
         "headline": "Suede Paywalls - Suede Creator Skills",
         "description": "Design in-app upgrade moments that convert without resentment: paywall screens, feature gates, trial-expiry states, and free-to-paid prompts.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-paywalls.html",
+        "url": "https://skills.suedeai.ai/skills/suede-paywalls.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Decide what to charge and how to package it: tiers, freemium versus free trial, value metric, willingness-to-pay research, and price increases without churning the base.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-pricing.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Pricing - Suede Creator Skills">
     <meta property="og:description" content="Decide what to charge and how to package it: tiers, freemium versus free trial, value metric, willingness-to-pay research, and price increases without churning the base.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-pricing.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Pricing - Suede Creator Skills">
     <meta name="twitter:description" content="Decide what to charge and how to package it: tiers, freemium versus free trial, value metric, willingness-to-pay research, and price increases without churning the base.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-pricing.html#article",
         "headline": "Suede Pricing - Suede Creator Skills",
         "description": "Decide what to charge and how to package it: tiers, freemium versus free trial, value metric, willingness-to-pay research, and price increases without churning the base.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-pricing.html",
+        "url": "https://skills.suedeai.ai/skills/suede-pricing.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Establish the product context every other marketing lane reads from: what it is, who it is for, the positioning, and the proof.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-product-marketing.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Product Marketing - Suede Creator Skills">
     <meta property="og:description" content="Establish the product context every other marketing lane reads from: what it is, who it is for, the positioning, and the proof.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-product-marketing.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Product Marketing - Suede Creator Skills">
     <meta name="twitter:description" content="Establish the product context every other marketing lane reads from: what it is, who it is for, the positioning, and the proof.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-product-marketing.html#article",
         "headline": "Suede Product Marketing - Suede Creator Skills",
         "description": "Establish the product context every other marketing lane reads from: what it is, who it is for, the positioning, and the proof.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-product-marketing.html",
+        "url": "https://skills.suedeai.ai/skills/suede-product-marketing.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Build search pages at scale without building junk: template design, data sourcing, index-worthiness thresholds, and internal linking that holds up.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-programmatic-seo.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Programmatic Seo - Suede Creator Skills">
     <meta property="og:description" content="Build search pages at scale without building junk: template design, data sourcing, index-worthiness thresholds, and internal linking that holds up.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-programmatic-seo.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Programmatic Seo - Suede Creator Skills">
     <meta name="twitter:description" content="Build search pages at scale without building junk: template design, data sourcing, index-worthiness thresholds, and internal linking that holds up.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-programmatic-seo.html#article",
         "headline": "Suede Programmatic Seo - Suede Creator Skills",
         "description": "Build search pages at scale without building junk: template design, data sourcing, index-worthiness thresholds, and internal linking that holds up.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-programmatic-seo.html",
+        "url": "https://skills.suedeai.ai/skills/suede-programmatic-seo.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Build and qualify a target list before you write a word: ICP fit, sourcing, enrichment, disqualification, and where the first customers actually are.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-prospecting.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Prospecting - Suede Creator Skills">
     <meta property="og:description" content="Build and qualify a target list before you write a word: ICP fit, sourcing, enrichment, disqualification, and where the first customers actually are.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-prospecting.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Prospecting - Suede Creator Skills">
     <meta name="twitter:description" content="Build and qualify a target list before you write a word: ICP fit, sourcing, enrichment, disqualification, and where the first customers actually are.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-prospecting.html#article",
         "headline": "Suede Prospecting - Suede Creator Skills",
         "description": "Build and qualify a target list before you write a word: ICP fit, sourcing, enrichment, disqualification, and where the first customers actually are.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-prospecting.html",
+        "url": "https://skills.suedeai.ai/skills/suede-prospecting.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Earn coverage without a retainer: media lists, journalist pitching, newsjacking a live story, press kits, and responding to reporter requests.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-public-relations.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Public Relations - Suede Creator Skills">
     <meta property="og:description" content="Earn coverage without a retainer: media lists, journalist pitching, newsjacking a live story, press kits, and responding to reporter requests.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-public-relations.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Public Relations - Suede Creator Skills">
     <meta name="twitter:description" content="Earn coverage without a retainer: media lists, journalist pitching, newsjacking a live story, press kits, and responding to reporter requests.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-public-relations.html#article",
         "headline": "Suede Public Relations - Suede Creator Skills",
         "description": "Earn coverage without a retainer: media lists, journalist pitching, newsjacking a live story, press kits, and responding to reporter requests.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-public-relations.html",
+        "url": "https://skills.suedeai.ai/skills/suede-public-relations.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Recommend Next Action in Claude Code or Codex to score candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then get one recommendation packaged as a short runnable prompt.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-recommend-next-action.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Recommend Next Action - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Recommend Next Action in Claude Code or Codex to score candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then get one recommendation packaged as a short runnable prompt.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-recommend-next-action.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Recommend Next Action - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Recommend Next Action in Claude Code or Codex to score candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then get one recommendation packaged as a short runnable prompt.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-recommend-next-action.html#article",
         "headline": "Suede Recommend Next Action - Suede Creator Skills",
         "description": "Suede Recommend Next Action reads current repo, terminal, plan, or handoff state, scores 2-4 candidate moves against goal alignment, unblocking, evidence, urgency, and leverage, and returns one recommended action plus a short, self-contained copy/paste prompt, expanding into a full operator prompt or granular steps only on request.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-recommend-next-action.html",
+        "url": "https://skills.suedeai.ai/skills/suede-recommend-next-action.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "next action recommendation", "prompt engineering", "agent orchestration", "decision scoring"],

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Turn customers into a channel: referral mechanics, incentive design that does not attract fraud, affiliate structure, and viral loop math.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-referrals.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Referrals - Suede Creator Skills">
     <meta property="og:description" content="Turn customers into a channel: referral mechanics, incentive design that does not attract fraud, affiliate structure, and viral loop math.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-referrals.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Referrals - Suede Creator Skills">
     <meta name="twitter:description" content="Turn customers into a channel: referral mechanics, incentive design that does not attract fraud, affiliate structure, and viral loop math.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-referrals.html#article",
         "headline": "Suede Referrals - Suede Creator Skills",
         "description": "Turn customers into a channel: referral mechanics, incentive design that does not attract fraud, affiliate structure, and viral loop math.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-referrals.html",
+        "url": "https://skills.suedeai.ai/skills/suede-referrals.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Docs for the Release Metadata Linter: audit release metadata, artwork, masters, lyrics, stems, credits, splits, samples, and downstream readiness.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-release-linter.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Release Metadata Linter Skill">
     <meta property="og:description" content="Audit music release folders for metadata, artwork, masters, lyrics, stems, credits, splits, sample status, provenance, and downstream readiness.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/release-linter-preview.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-release-linter.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/release-linter-preview.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Release Metadata Linter Skill">
     <meta name="twitter:description" content="Release-readiness linting docs for Suede Creator Skills.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/release-linter-preview.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/release-linter-preview.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-release-linter.html#article",
         "headline": "Release Metadata Linter Skill",
         "description": "Audit music release folders for missing metadata, artwork, masters, lyrics, stems, credits, split totals, sample status, provenance, release history, and downstream readiness gaps.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-release-linter.html",
+        "url": "https://skills.suedeai.ai/skills/suede-release-linter.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Wire marketing to revenue: lead scoring and routing, MQL and SQL definitions, pipeline stages, CRM hygiene, and the marketing-to-sales handoff.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-revops.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Revops - Suede Creator Skills">
     <meta property="og:description" content="Wire marketing to revenue: lead scoring and routing, MQL and SQL definitions, pipeline stages, CRM hygiene, and the marketing-to-sales handoff.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-revops.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Revops - Suede Creator Skills">
     <meta name="twitter:description" content="Wire marketing to revenue: lead scoring and routing, MQL and SQL definitions, pipeline stages, CRM hygiene, and the marketing-to-sales handoff.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-revops.html#article",
         "headline": "Suede Revops - Suede Creator Skills",
         "description": "Wire marketing to revenue: lead scoring and routing, MQL and SQL definitions, pipeline stages, CRM hygiene, and the marketing-to-sales handoff.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-revops.html",
+        "url": "https://skills.suedeai.ai/skills/suede-revops.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Run Suede Rights Audit in Claude Code and Codex to organize ownership, split, sample, provenance, license, and routing gaps before packaging.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-rights-audit.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Rights Audit - Suede Creator Skills">
     <meta property="og:description" content="Run Suede Rights Audit in Claude Code and Codex to organize ownership, split, sample, provenance, license, and routing gaps before packaging.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-rights-audit.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Rights Audit - Suede Creator Skills">
     <meta name="twitter:description" content="Run Suede Rights Audit in Claude Code and Codex to organize ownership, split, sample, provenance, license, and routing gaps before packaging.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-rights-audit.html#article",
         "headline": "Suede Rights Audit - Suede Creator Skills",
         "description": "Suede Rights Audit organizes confirmed, inferred, unconfirmed, disputed, unknown, and not-applicable evidence for creator rights gaps. It supports rights-gap audits, provenance maps, licensing-discussion readiness, and royalty-routing readiness without clearing rights.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-audit.html",
+        "url": "https://skills.suedeai.ai/skills/suede-rights-audit.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "rights gap audit", "provenance mapping", "licensing readiness", "royalty routing readiness", "creator intake", "evidence tables"],

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Create validated music-rights packages with separate works, recordings, releases, parties, identifiers, scoped claims, licenses, consent, provenance, and privacy controls.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-rights-passport.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Creator Rights Package Builder">
     <meta property="og:description" content="Create local transfer packages for music rights, provenance, splits, licenses, and agent commerce readiness.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/rights-passport-preview.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-rights-passport.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/rights-passport-preview.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Creator Rights Package Builder">
     <meta name="twitter:description" content="Music rights transfer package docs for Suede Creator Skills.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/rights-passport-preview.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/rights-passport-preview.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-rights-passport.html#article",
         "headline": "Creator Rights Package Builder",
         "description": "Create validated local music-rights packages with normalized works, recordings, releases, parties, identifiers, claims, licenses, consent, provenance, and privacy controls.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-rights-passport.html",
+        "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Arm the people doing the selling: pitch decks, one-pagers, objection handling, demo scripts, battle cards, and deal-level ROI framing.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-sales-enablement.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Sales Enablement - Suede Creator Skills">
     <meta property="og:description" content="Arm the people doing the selling: pitch decks, one-pagers, objection handling, demo scripts, battle cards, and deal-level ROI framing.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-sales-enablement.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Sales Enablement - Suede Creator Skills">
     <meta name="twitter:description" content="Arm the people doing the selling: pitch decks, one-pagers, objection handling, demo scripts, battle cards, and deal-level ROI framing.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-sales-enablement.html#article",
         "headline": "Suede Sales Enablement - Suede Creator Skills",
         "description": "Arm the people doing the selling: pitch decks, one-pagers, objection handling, demo scripts, battle cards, and deal-level ROI framing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sales-enablement.html",
+        "url": "https://skills.suedeai.ai/skills/suede-sales-enablement.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede SEO Audit for Claude Code and Codex: audit public pages across technical access, metadata, schema, AI EO, copy, E-E-A-T, and topic clusters.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-seo-audit.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede SEO Audit - Suede Creator Skills">
     <meta property="og:description" content="Install Suede SEO Audit for Claude Code and Codex: audit public pages across technical access, metadata, schema, AI EO, copy, E-E-A-T, and topic clusters.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-seo-audit.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede SEO Audit - Suede Creator Skills">
     <meta name="twitter:description" content="Install Suede SEO Audit for Claude Code and Codex: run nine-lane SEO, AEO, and AI EO audits with exact rewrites, lane grades, and a ship gate.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-seo-audit.html#article",
         "headline": "Suede SEO Audit - Suede Creator Skills",
         "description": "Suede SEO Audit is a nine-lane SEO, AEO, and AI EO audit skill for public pages. It checks live page source, crawl access, metadata, structure, schema, AI citation readiness, copy quality, E-E-A-T, topic clusters, exact rewrites, lane grades, and a ship gate.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-seo-audit.html",
+        "url": "https://skills.suedeai.ai/skills/suede-seo-audit.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "SEO audit", "AEO audit", "AI EO audit", "schema validation", "metadata audit", "topic clusters"],

--- a/docs/skills/suede-ship-copy.html
+++ b/docs/skills/suede-ship-copy.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Ship Copy in Claude Code and Codex to run one high-stakes piece of writing through a research-heavy agent graph that audits every agent-generated claim and never audits what you supplied.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ship-copy.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ship Copy - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Ship Copy in Claude Code and Codex to run one high-stakes piece of writing through a research-heavy agent graph that audits every agent-generated claim and never audits what you supplied.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ship-copy.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ship Copy - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Ship Copy in Claude Code and Codex to run one high-stakes piece of writing through a research-heavy agent graph that audits every agent-generated claim and never audits what you supplied.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ship-copy.html#article",
         "headline": "Suede Ship - Suede Creator Skills",
         "description": "Suede Ship Copy is the copy side of the canonical Suede DAG: intake with a verbatim capture of the currently published text, five blind research lenses, an audit of every agent-generated claim against its source, three independent angles, a section map where each section owns one message, disjoint section writers, four-lens review, adversarial refutation, a deslop pass, a graphic spec, the channel package, and a publish-readiness gate. Facts the requester supplies are given and are never audited. It writes a draft and reads the live surface without ever publishing.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship-copy.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ship-copy.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "multi-agent orchestration", "directed acyclic graph", "agent fan-out", "adversarial verification", "git worktree isolation", "critical path"],

--- a/docs/skills/suede-ship.html
+++ b/docs/skills/suede-ship.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Use Suede Ship in Claude Code and Codex to run a nontrivial change through a research-heavy agent graph that halts on hazards and gates on real tests.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-ship.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Ship - Suede Creator Skills">
     <meta property="og:description" content="Use Suede Ship in Claude Code and Codex to run a nontrivial change through a research-heavy agent graph that halts on hazards and gates on real tests.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-ship.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Ship - Suede Creator Skills">
     <meta name="twitter:description" content="Use Suede Ship in Claude Code and Codex to run a nontrivial change through a research-heavy agent graph that halts on hazards and gates on real tests.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-ship.html#article",
         "headline": "Suede Ship - Suede Creator Skills",
         "description": "Suede Ship is the canonical Suede shipping DAG: scout, multi-lens research, gap critic, lane plan with explicit file ownership, disjoint parallel build, dual-lens review, adversarial refute, integration gate, and release verification. It halts on a blocking hazard or a lane collision, and reads production without ever deploying.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-ship.html",
+        "url": "https://skills.suedeai.ai/skills/suede-ship.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "multi-agent orchestration", "directed acyclic graph", "agent fan-out", "adversarial verification", "git worktree isolation", "critical path"],

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Cut friction out of registration: field-by-field audit, social versus email tradeoffs, progressive profiling, and recovering abandoned signups.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-signup.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Signup - Suede Creator Skills">
     <meta property="og:description" content="Cut friction out of registration: field-by-field audit, social versus email tradeoffs, progressive profiling, and recovering abandoned signups.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-signup.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Signup - Suede Creator Skills">
     <meta name="twitter:description" content="Cut friction out of registration: field-by-field audit, social versus email tradeoffs, progressive profiling, and recovering abandoned signups.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-signup.html#article",
         "headline": "Suede Signup - Suede Creator Skills",
         "description": "Cut friction out of registration: field-by-field audit, social versus email tradeoffs, progressive profiling, and recovering abandoned signups.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-signup.html",
+        "url": "https://skills.suedeai.ai/skills/suede-signup.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Site Alchemy for Claude Code and Codex to run funnel analysis, friction audits, conversion math, mobile CRO rules, and page QA.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-site-alchemy.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Site Alchemy - Suede Creator Skills">
     <meta property="og:description" content="Install Suede Site Alchemy for Claude Code and Codex to run funnel analysis, friction audits, conversion math, mobile CRO rules, and page QA.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-site-alchemy.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Site Alchemy - Suede Creator Skills">
     <meta name="twitter:description" content="Install Suede Site Alchemy for Claude Code and Codex to run funnel analysis, friction audits, conversion math, mobile CRO rules, and page QA.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-site-alchemy.html#article",
         "headline": "Suede Site Alchemy - Suede Creator Skills",
         "description": "Suede Site Alchemy documents a skill for conversion-focused page work. It covers funnel analysis, friction audits, conversion math, A/B hypotheses, social proof architecture, pricing psychology, mobile CRO rules, and ship-gate checks.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-site-alchemy.html",
+        "url": "https://skills.suedeai.ai/skills/suede-site-alchemy.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion rate optimization", "funnel analysis", "friction audit", "conversion math", "mobile CRO", "landing page QA"],

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Run SMS without getting blocked or resented: consent and compliance, message design, timing, cadence limits, and when SMS beats email.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-sms.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Sms - Suede Creator Skills">
     <meta property="og:description" content="Run SMS without getting blocked or resented: consent and compliance, message design, timing, cadence limits, and when SMS beats email.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-sms.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Sms - Suede Creator Skills">
     <meta name="twitter:description" content="Run SMS without getting blocked or resented: consent and compliance, message design, timing, cadence limits, and when SMS beats email.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-sms.html#article",
         "headline": "Suede Sms - Suede Creator Skills",
         "description": "Run SMS without getting blocked or resented: consent and compliance, message design, timing, cadence limits, and when SMS beats email.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sms.html",
+        "url": "https://skills.suedeai.ai/skills/suede-sms.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Run social as a channel rather than a chore: platform strategy, content formats that travel, posting cadence, engagement, and listening.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-social.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Social - Suede Creator Skills">
     <meta property="og:description" content="Run social as a channel rather than a chore: platform strategy, content formats that travel, posting cadence, engagement, and listening.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-social.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Social - Suede Creator Skills">
     <meta name="twitter:description" content="Run social as a channel rather than a chore: platform strategy, content formats that travel, posting cadence, engagement, and listening.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-social.html#article",
         "headline": "Suede Social - Suede Creator Skills",
         "description": "Run social as a channel rather than a chore: platform strategy, content formats that travel, posting cadence, engagement, and listening.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-social.html",
+        "url": "https://skills.suedeai.ai/skills/suede-social.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Prepare sync review packages in Claude Code and Codex with scene-fit angles, asset checklists, lyric flags, rights status, and next review steps.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-sync-packaging.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Sync Packaging - Suede Creator Skills">
     <meta property="og:description" content="Prepare sync review packages in Claude Code and Codex with scene-fit angles, asset checklists, lyric flags, rights status, and next review steps.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-sync-packaging.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Sync Packaging - Suede Creator Skills">
     <meta name="twitter:description" content="Prepare sync review packages in Claude Code and Codex with scene-fit angles, asset checklists, lyric flags, rights status, and next review steps.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-sync-packaging.html#article",
         "headline": "Suede Sync Packaging - Suede Creator Skills",
         "description": "Suede Sync Packaging prepares sync review packages for tracks. It organizes scene-fit angles, asset checklists, lyric flags, confirmed rights facts, clearance questions, one-sheet copy, pitch email copy when gates pass, and next review steps.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-sync-packaging.html",
+        "url": "https://skills.suedeai.ai/skills/suede-sync-packaging.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "sync pitching", "music supervisor requests", "sync one-sheets", "asset checklists", "lyric flags", "rights status"],

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -7,29 +7,29 @@
     <meta name="description" content="Plan and produce marketing video: format selection, hook structure, short-form pacing, scripting, and repurposing one shoot into many cuts.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-video.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Video - Suede Creator Skills">
     <meta property="og:description" content="Plan and produce marketing video: format selection, hook structure, short-form pacing, scripting, and repurposing one shoot into many cuts.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-video.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Video - Suede Creator Skills">
     <meta name="twitter:description" content="Plan and produce marketing video: format selection, hook structure, short-form pacing, scripting, and repurposing one shoot into many cuts.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-video.html#article",
         "headline": "Suede Video - Suede Creator Skills",
         "description": "Plan and produce marketing video: format selection, hook structure, short-form pacing, scripting, and repurposing one shoot into many cuts.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-video.html",
+        "url": "https://skills.suedeai.ai/skills/suede-video.html",
         "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
-        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://jasoncolapietro.github.io/suede-creator-skills/"}
+        "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}
       }
     </script>
     <style>

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Visibility Grader for A-F website visibility, CTA, proof, AI readability, design signal, and Google and Gemini result surfaces.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-visibility-grader.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Visibility Grader">
     <meta property="og:description" content="A-F website visibility and CTA grading for public pages, GitHub Pages sites, docs, launch pages, campaign pages, AI readability, and design signal.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-visibility-grader.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Visibility Grader">
     <meta name="twitter:description" content="Grade a public website A-F for findability, CTA pull, proof, AI readability, and design signal.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-visibility-grader.html#article",
         "headline": "Suede Visibility Grader",
         "description": "Public Codex skill for A-F website visibility, CTA pull, proof, AI readability, design signal, and Google and Gemini result surfaces.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-visibility-grader.html",
+        "url": "https://skills.suedeai.ai/skills/suede-visibility-grader.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -7,25 +7,25 @@
     <meta name="description" content="Install Suede Workflow Skills. One skill routes the agent across all 71 skills: Full Send, code review, SEO, copy, design, AI evals, Instagram growth, MCP QA, iOS, Android, and creator workflows.">
     <meta name="author" content="Jason Colapietro">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
-    <link rel="canonical" href="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html">
+    <link rel="canonical" href="https://skills.suedeai.ai/skills/suede-workflow-skills.html">
     <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
     <meta property="og:type" content="article">
     <meta property="og:title" content="Suede Workflow Skills">
     <meta property="og:description" content="Public Suede umbrella skill for 71 installable skills: Full Send, code review, SEO, copy, design, AI evals, Instagram growth, MCP QA, iOS and Android app shipping, agent teams, and creator workflows.">
-    <meta property="og:url" content="https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html">
-    <meta property="og:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta property="og:url" content="https://skills.suedeai.ai/skills/suede-workflow-skills.html">
+    <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Suede Workflow Skills">
     <meta name="twitter:description" content="Install the umbrella workflow skill for 71 public Johnny Suede, Full Send, code, design, SEO, AI eval, Instagram growth, MCP QA, iOS, Android, and creator workflows.">
-    <meta name="twitter:image" content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image-v2.png">
+    <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "TechArticle",
-        "@id": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html#article",
+        "@id": "https://skills.suedeai.ai/skills/suede-workflow-skills.html#article",
         "headline": "Suede Workflow Skills",
         "description": "Install Suede Workflow Skills as the umbrella entry point for 71 public Suede skill folders across Full Send outcome routing, copy, design, code review, SEO, AI evals, Instagram growth, MCP QA, iOS and Android app shipping, agent teams, and creator workflows.",
-        "url": "https://jasoncolapietro.github.io/suede-creator-skills/skills/suede-workflow-skills.html",
+        "url": "https://skills.suedeai.ai/skills/suede-workflow-skills.html",
         "author": {
           "@type": "Person",
           "name": "Jason Colapietro",

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -2,13 +2,13 @@
   "name": "Suede Skills MCP",
   "version": "0.10.0",
   "updated": "2026-08-04",
-  "homepage": "https://jasoncolapietro.github.io/suede-creator-skills/",
+  "homepage": "https://skills.suedeai.ai/",
   "repository": "https://github.com/JasonColapietro/suede-creator-skills",
   "summary": "Local MCP access to an open-source Suede skill pack: decisive full-send routing, full-stack design and writing modes, reference-site restyling, SEO/AEO/AI EO, visibility grading, AI eval design, one-pass code review+grade, any-repo CI ship-gate, agent-team orchestration, Codex CLI worker-fleet orchestration, install and launch packaging, MCP QA, artist campaign tools, and creator rights utilities.",
   "publicLinks": [
     {
       "label": "GitHub Pages site",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/",
+      "url": "https://skills.suedeai.ai/",
       "description": "Public landing page for Suede Creator Skills, install paths, docs, skill catalog, and open-source project links."
     },
     {
@@ -18,12 +18,12 @@
     },
     {
       "label": "Copy bank",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/copy.html",
+      "url": "https://skills.suedeai.ai/copy.html",
       "description": "Public copy bank for GitHub, docs, CTA, SEO/AEO/AI EO, FAQ, social, and safety copy."
     },
     {
       "label": "Public installs and MCP",
-      "url": "https://jasoncolapietro.github.io/suede-creator-skills/plugins.html",
+      "url": "https://skills.suedeai.ai/plugins.html",
       "description": "Public GitHub skill install commands and Suede Skills MCP guidance."
     },
     {

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -19,7 +19,7 @@ const docsRoot = path.join(repoRoot, "docs");
 const sitemapPath = path.join(docsRoot, "sitemap.xml");
 const checkOnly = process.argv.includes("--check");
 
-const BASE_URL = "https://jasoncolapietro.github.io/suede-creator-skills";
+const BASE_URL = "https://skills.suedeai.ai";
 
 function ownsGitHistory() {
   const result = spawnSync(

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1223,9 +1223,9 @@ for (const check of countChecks) {
     const COMPLETENESS = /\b(complete documentation of every skill|documentation of every skill|every skill|all \d+ skills)\b/i;
     for (const entry of llmsText.split("\n").filter((line) => line.trim().startsWith("- ["))) {
       if (!COMPLETENESS.test(entry)) continue;
-      const linked = entry.match(/\]\((https:\/\/jasoncolapietro\.github\.io\/suede-creator-skills\/[^)]*)\)/)?.[1];
+      const linked = entry.match(/\]\((https:\/\/skills\.suedeai\.ai\/[^)]*)\)/)?.[1];
       if (!linked) continue;
-      const rel = linked.slice("https://jasoncolapietro.github.io/suede-creator-skills/".length) || "index.html";
+      const rel = linked.slice("https://skills.suedeai.ai/".length) || "index.html";
       const target = path.join(repoRoot, "docs", rel.endsWith("/") ? `${rel}index.html` : rel);
       if (!fs.existsSync(target)) continue;
       const pageText = readText(target);
@@ -1234,7 +1234,7 @@ for (const check of countChecks) {
         fail.push(`docs/llms.txt claims completeness for ${rel} but that page omits ${absent.length} of ${skillNames.length} skills`);
       }
     }
-    const siteBase = "https://jasoncolapietro.github.io/suede-creator-skills/";
+    const siteBase = "https://skills.suedeai.ai/";
     const blobBase = "https://github.com/JasonColapietro/suede-creator-skills/blob/main/";
     for (const rawUrl of llmsText.match(/https:\/\/[^\s)\]]+/g) || []) {
       const url = rawUrl.replace(/[.,)]+$/, "");

--- a/tests/test_homepage_quality.py
+++ b/tests/test_homepage_quality.py
@@ -47,7 +47,7 @@ class HomepageQualityTests(unittest.TestCase):
 
     def test_social_card_describes_the_current_product(self):
         self.assertIn("assets/og-image-v2.png", HOME)
-        self.assertNotIn('content="https://jasoncolapietro.github.io/suede-creator-skills/assets/og-image.png"', HOME)
+        self.assertNotIn('content="https://skills.suedeai.ai/assets/og-image.png"', HOME)
         self.assertIn('property="og:image:width" content="1200"', HOME)
         self.assertIn('property="og:image:height" content="630"', HOME)
         self.assertIn('name="twitter:image:alt"', HOME)


### PR DESCRIPTION
> **DO NOT MERGE until `dig +short skills.suedeai.ai` returns a GitHub Pages target.**
> Merging early publishes canonical tags pointing at a hostname that does not resolve, which is worse than the status quo.

## Blocker

`skills.suedeai.ai` does not exist yet. Confirmed against the authoritative nameserver, so this is not resolver caching:

```
dig @ns27.domaincontrol.com skills.suedeai.ai CNAME  →  SOA only (no record)
dig @ns27.domaincontrol.com suedeai.ai A             →  76.76.21.21 (apex resolves)
```

`suedeai.ai` is on GoDaddy (`ns27`/`ns28.domaincontrol.com`), not Vercel, so the record is manual:

| Type | Name | Value |
|---|---|---|
| CNAME | `skills` | `jasoncolapietro.github.io` |

## Why

`github.io` is on the [Public Suffix List](https://publicsuffix.org/), so authority earned by this site — 148 stars' worth of links and citations — accrues to GitHub, not to Suede.

## What changed

The site is a **project page** served from the `/suede-creator-skills/` subpath. A custom domain serves it from the **root**. That relocation is safe here because every internal link in `docs/` is relative (`../`, `./`) — there are **zero root-absolute hrefs** — so only absolute URLs needed rewriting, and that reduced to a single prefix swap across 92 files.

- `docs/CNAME` → `skills.suedeai.ai`
- `canonical` + `og:url` on the homepage, all 71 skill pages, blog, and docs pages
- `docs/sitemap.xml` regenerated (78 URLs) + `docs/robots.txt` Sitemap line
- `scripts/generate-sitemap.mjs` `BASE_URL`, the validator's `siteBase`, and the one **escaped-regex** copy of the old origin that a literal find-replace cannot reach
- `tests/test_homepage_quality.py`, README, `CITATION.cff`, `llms.txt`, plugin manifests, `mcp/catalog.json`

`github.com/JasonColapietro/...` repository links are deliberately unchanged.

**No `twitter:url` exists on any page** — Twitter cards read `og:url`, which is updated.

## Verification

- `npm run ci` exits 0 — 29 tests, no warnings, `Validated 71 skills against 71 catalog entries`.
- The sitemap freshness gate inside the validator passes against the regenerated file.
- Test-merged against `codex/homepage-ship-log-policy-gates-20260803` (#44): **auto-merges cleanly, zero conflicts.** No rebase or sequencing needed in either direction.

## Cutover, once DNS resolves

1. Merge this PR.
2. Set the custom domain in Pages settings; enable Enforce HTTPS after the cert provisions.
3. `gh api -X PATCH repos/JasonColapietro/suede-creator-skills -f homepage=https://skills.suedeai.ai`
4. Confirm the new origin serves 200 with the new canonical, and that the old `github.io` URL 301s rather than 404s (GitHub issues that redirect automatically for project pages).