### PR TITLE
GitHub page redesign: brand hero, figures, and sharper copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,65 +1,68 @@
-# Suede Creator Skills
+<div align="center">
 
-A 71-skill toolkit for Claude Code and Codex: take broad outcomes full send, orchestrate multi-agent teams and OpenAI Codex CLI worker fleets, run code review with an A-F ship grade, and design AI evals.
+<img src="docs/assets/readme/hero.svg" alt="Suede Creator Skills — the ship discipline your agent is missing. 71 open-source skills for Claude Code and Codex." width="100%">
 
-![License: MIT](https://img.shields.io/badge/License-MIT-blue) ![Skills: 71](https://img.shields.io/badge/Skills-71-black) [![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=social)](https://github.com/JasonColapietro/suede-creator-skills/stargazers)
+<br><br>
 
-> **By [Jason Colapietro](https://suedeai.ai/founder) / [Suede Labs AI](https://suedeai.ai)**
+[![Skills: 71](https://img.shields.io/badge/skills-71-c8a96e?labelColor=080808)](#the-skills)
+[![License: MIT](https://img.shields.io/badge/license-MIT-c8a96e?labelColor=080808)](LICENSE)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-c8a96e?labelColor=080808)](#install-in-30-seconds)
+[![Codex](https://img.shields.io/badge/Codex-plugin-c8a96e?labelColor=080808)](#install-in-30-seconds)
+[![MCP](https://img.shields.io/badge/MCP-stdio_server-c8a96e?labelColor=080808)](#mcp-server)
+[![GitHub stars](https://img.shields.io/github/stars/JasonColapietro/suede-creator-skills?style=social)](https://github.com/JasonColapietro/suede-creator-skills/stargazers)
 
-## What it is
+**[Install](#install-in-30-seconds)** · **[The skills](#the-skills)** · **[Docs site](https://skills.suedeai.ai/)** · **[Skill catalog](https://skills.suedeai.ai/skills/)** · **[Blog](https://skills.suedeai.ai/blog/)** · **[MCP](#mcp-server)** · **[@johnnysuede](https://x.com/johnnysuede)**
 
-A free, MIT-licensed, broadly reusable pack of **71 public skill folders** for Claude Code and OpenAI Codex. Each skill is a `skills/<name>/SKILL.md` file the agent loads on demand.
+<sub>By <a href="https://suedeai.ai/founder">Jason Colapietro</a> / <a href="https://suedeai.ai">Suede Labs AI</a></sub>
 
-- **Full Send**: turn max-effort, max-agent, spare-no-compute, and fix-everything intent into one authorized controller, every useful non-colliding lane, adversarial reconciliation, and concise proof (`suede-full-send`). House line: **"Never end your allocation above zero."** Dry joke, not a literal token promise.
-- **Agent orchestration**: wire complex changes into coordinated agent lanes with WIP collision detection, RFC mode, feature-flag strategy, rollback trees, and a handoff checklist that won't close without evidence. Its public-contribution mode adds scored issue queues, atomic leases, isolated worktrees, independent review, and authority-gated contribution packets (`suede-agent-teams`).
-- **Codex worker fleets**: the Suede Fable Fleet — a Claude orchestrator decomposes a high-volume job, writes self-contained briefs, spawns parallel OpenAI Codex CLI `codex exec` workers, and reviews every output against acceptance criteria before anything ships (`suede-codex-fleet`).
-- **Code review + A-F ship grade**: deep findings plus a blunt letter verdict across 7 evidence-backed lanes, with instant-F triggers and grade caps for auth and payment surfaces (`suede-code`, `suede-code-review`, `suede-code-grader`, `suede-ci-gate`).
-- **AI evaluation**: turn LLM, RAG, classifier, and agent surfaces into AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates (`suede-ai-eval`).
-- **Next-action recommendation**: score 2-4 candidate moves on goal alignment, unblocking, evidence, urgency, and leverage, then return one recommendation packaged as a short runnable prompt (`suede-recommend-next-action`).
-- **Design, copy, and SEO**: design systems and visual QA, conversion copy with an anti-slop gate, SEO/AEO/AI-EO audits, and A-F page visibility grades (`johnny-suede-design`, `johnny-suede-write`, `suede-design`, `suede-copy`, `suede-seo-audit`, `suede-visibility-grader`, `suede-site-alchemy`).
-- **Anti-slop pass**: strip AI writing tells from finished prose before it ships: filler phrases, false agency, formulaic contrasts, passive voice, and metronomic rhythm, all against a merged kill list with a 50-point score gate (`suede-deslop`).
-- **iOS and Android app shipping**: turn a website into an App Store-ready iOS app, or build and ship a native Android app end to end from a keyword through the Play Store (`site-to-ios-app`, `android-app-factory`).
-- **Consumer recovery**: audit Amazon returns and Amazon-billed subscriptions with a validated recovery path, or inspect recurring charges across App Store, Google Play, PayPal, and direct-bill services before any user-confirmed cancellation or refund request (`amazon-returns-recovery`, `subscription-recovery`).
-- **Workflow umbrella**: load the whole pack with one skill (`suede-workflow-skills`).
+</div>
 
-## Install the full pack
+---
 
-In Claude Code, add the marketplace and install the pack:
+Your coding agent is fast, capable, and completely unsupervised. It will happily ship the bug, skip the test, publish the slop, and tell you everything went great.
+
+This pack is the supervision: **71 public skill folders**, MIT-licensed, for Claude Code, OpenAI Codex, and any skills-compatible agent. Outcome-bound orchestration, multi-agent teams, Codex worker fleets, code review with a blunt A–F ship grade, AI evals, design, conversion copy, SEO, 39 marketing lanes, mobile app factories, and creator-rights tooling. Every skill is a plain `skills/<name>/SKILL.md` file you can read before you trust it. No binaries, no telemetry, no accounts.
+
+<img src="docs/assets/readme/pack-map.svg" alt="The pack at a glance: 39 marketing and growth skills, 10 design copy and SEO, 8 orchestration and workflows, 5 code quality and shipping, 5 creator rights and release, 2 mobile app factories, 2 consumer recovery." width="100%">
+
+## Install in 30 seconds
+
+**Claude Code** — add the marketplace, install the pack:
 
 ```text
 /plugin marketplace add JasonColapietro/suede-creator-skills
 /plugin install suede-skills@suede
 ```
 
-`suede-skills` installs all 71 skills. Two focused subsets are available if you want less: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) and `/plugin install suede-code@suede` (review, grade, ship-gate).
+`suede-skills` installs all 71 skills. Want less? Two focused subsets: `/plugin install suede-agent-workflows@suede` (Full Send, orchestration, workflows, evals) and `/plugin install suede-code@suede` (review, grade, ship-gate).
 
-In Codex, add the repo's Codex-native marketplace and install the complete
-plugin:
+**Codex** — add the Codex-native marketplace, install the complete plugin:
 
 ```bash
 codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main
 codex plugin add suede-skills@suede-codex
 ```
 
-The Codex plugin loads all 71 skills and registers both read-only MCP discovery
-profiles. Restart Codex after installing or updating it.
+The Codex plugin loads all 71 skills and registers both read-only MCP discovery profiles. Restart Codex after installing or updating.
 
-Prefer a clone? `install.sh` copies all 71 skills into `~/.claude/skills/` and prints the installed count:
-
-```bash
-git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
-```
-
-Using Cursor, Copilot, Windsurf, or another agent? The [skills CLI](https://github.com/vercel-labs/skills) installs the pack into its supported agents, Claude Code and Codex included:
+**Any agent** (Cursor, Copilot, Windsurf, Claude Code, Codex) via the [skills CLI](https://github.com/vercel-labs/skills):
 
 ```bash
 npx skills add JasonColapietro/suede-creator-skills
 ```
 
+**Prefer a clone?** `install.sh` copies all 71 skills into `~/.claude/skills/` and prints the installed count:
+
+```bash
+git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
+```
+
 You can also copy individual skill folders into `.claude/skills/` (project) or `~/.claude/skills/` (user).
 
 <details>
-<summary>Other install routes (Codex installer, project-level copy, MCP)</summary>
+<summary><b>More install routes</b> (single-skill Codex installer, project-level copy, MCP)</summary>
+
+<br>
 
 **Codex — install one skill from GitHub:**
 
@@ -79,6 +82,8 @@ mkdir -p .claude/skills
 cp -R /tmp/suede-creator-skills/skills/suede-agent-teams .claude/skills/
 ```
 
+For a user-level install, copy into `~/.claude/skills/` instead. Claude.ai and organization-managed Claude Skills may use upload or admin-managed flows instead of filesystem copy. Review skill contents before enabling code execution.
+
 **MCP — dependency-free stdio server:**
 
 ```bash
@@ -89,7 +94,7 @@ Exposes 7 tools (`list_suede_skills`, `get_suede_skill`, `suede_install_options`
 
 </details>
 
-## Try it in 30 seconds
+## Try it right now
 
 Install the pack, then ask for a code review with a ship grade on your current changes:
 
@@ -103,11 +108,32 @@ For a broad authorized outcome, invoke Full Send directly:
 Use suede-full-send to finish this release across code, docs, CI, and live verification. Preserve unrelated WIP and return proof.
 ```
 
-`suede-code` runs its findings pass (TypeScript, React, Next.js, OWASP, and database checklists), then returns a grade card scoring Correctness, Security and permissions, Data and state, domain truth, UX and release behavior, Tests and verification, and Deploy readiness, plus an overall A-F grade. If it hits an instant-F trigger — a hardcoded secret, a permission check bypassable via a request param — the grade locks to F with the exact file and line, and no other lane can raise it.
-
 If the pack saves you an hour, [star the repo](https://github.com/JasonColapietro/suede-creator-skills/stargazers) — stars are how other builders find it.
 
+## Full Send: broad outcomes, one authority
+
+Tell your agent "max effort, spare no compute, fix everything" and most of the time you get enthusiasm, not engineering. [`suede-full-send`](skills/suede-full-send) turns that intent into a structure: one authorized controller, every useful non-colliding lane running in parallel, adversarial reconciliation where lanes attack each other's claims, and a close that is either concise proof or one named blocker.
+
+<img src="docs/assets/readme/full-send-flow.svg" alt="Full Send pipeline: a broad authorized outcome flows through one controller into parallel code, docs, CI, and live-verification lanes, then adversarial reconciliation, then proof." width="100%">
+
+The rest of the orchestration lane backs it up:
+
+- [`suede-agent-teams`](skills/suede-agent-teams) wires complex changes into coordinated agent lanes with WIP collision detection, RFC mode, feature-flag strategy, rollback trees, and a handoff checklist that won't close without evidence. Its public-contribution mode adds scored issue queues, atomic leases, isolated worktrees, and authority-gated contribution packets.
+- [`suede-ship`](skills/suede-ship) runs the canonical orchestration DAG on a repo: scout, multi-lens research, a red-teamed lane plan, disjoint build lanes, dual-lens review, adversarial refutation, an integration gate, and a release verifier with an evidence handoff.
+- [`suede-ship-copy`](skills/suede-ship-copy) is the same DAG rebuilt for one high-stakes piece of writing: five blind research lenses, a claim audit that closes the set of assertable facts, disjoint section writers, adversarial refutation, a deslop pass, and a publish-readiness gate.
+- [`suede-codex-fleet`](skills/suede-codex-fleet) is the Suede Fable Fleet: a Claude orchestrator decomposes a high-volume job, writes self-contained briefs, spawns parallel OpenAI Codex CLI `codex exec` workers, and reviews every output against acceptance criteria before anything ships. Claude judges, Codex generates.
+
+## The A–F ship grade
+
+[`suede-code`](skills/suede-code) runs a findings pass (TypeScript, React, Next.js, OWASP, and database checklists), then returns a grade card scoring seven lanes: Correctness, Security and permissions, Data and state, Domain truth, UX and release behavior, Tests and verification, and Deploy readiness. The weakest lane caps the grade, and auth and payment surfaces carry grade caps of their own.
+
+<img src="docs/assets/readme/ship-grade.svg" alt="The ship grade: seven graded lanes and one verdict. Instant-F triggers such as a hardcoded secret lock the grade to F with the exact file and line." width="100%">
+
+If it hits an instant-F trigger — a hardcoded secret, a permission check bypassable via a request param — the grade locks to F with the exact file and line, and no other lane can raise it. A polite review tells you what could be better. A grade tells you whether to ship.
+
 ## The skills
+
+Every link below goes to the skill's folder in this repo; the [skill catalog](https://skills.suedeai.ai/skills/) has the same list with install commands per skill.
 
 ### Agent orchestration & workflows
 
@@ -115,8 +141,10 @@ If the pack saves you an hour, [star the repo](https://github.com/JasonColapietr
 |---|---|
 | [`suede-full-send`](skills/suede-full-send) | Full Send broad authorized outcomes through one controller, useful non-colliding lanes, adversarial reconciliation, and proof |
 | [`suede-agent-teams`](skills/suede-agent-teams) | Coordinate agent lanes and public contribution programs with collision checks, atomic issue leases, review gates, and a signed handoff |
+| [`suede-ship`](skills/suede-ship) | The canonical orchestration DAG for repo changes: research, red-teamed planning, disjoint lanes, adversarial review, release verification |
+| [`suede-ship-copy`](skills/suede-ship-copy) | Copy-only orchestration DAG for one high-stakes piece: blind research, claim audit, section writers, refutation, publish gate |
 | [`suede-codex-fleet`](skills/suede-codex-fleet) | Suede Fable Fleet: brief, spawn, and review parallel OpenAI Codex CLI workers — Claude judges, Codex generates |
-| [`suede-ai-eval`](skills/suede-ai-eval) | AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for AI surfaces |
+| [`suede-ai-eval`](skills/suede-ai-eval) | AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for LLM, RAG, classifier, and agent surfaces |
 | [`suede-recommend-next-action`](skills/suede-recommend-next-action) | Scores candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then hands back one recommendation as a short runnable prompt |
 | [`suede-workflow-skills`](skills/suede-workflow-skills) | Umbrella skill that loads the full pack |
 
@@ -124,9 +152,9 @@ If the pack saves you an hour, [star the repo](https://github.com/JasonColapietr
 
 | Skill | What it does |
 |---|---|
-| [`suede-code`](skills/suede-code) | Review + A-F grade in one pass |
+| [`suede-code`](skills/suede-code) | Review + A–F grade in one pass |
 | [`suede-code-review`](skills/suede-code-review) | Deep findings with Accessibility and SEO lanes, no letter grade |
-| [`suede-code-grader`](skills/suede-code-grader) | A-F ship verdict only, 7 lanes, instant-F triggers |
+| [`suede-code-grader`](skills/suede-code-grader) | A–F ship verdict only, 7 lanes, instant-F triggers |
 | [`suede-ci-gate`](skills/suede-ci-gate) | Write CI that gates the merge — stack/lockfile detection, one required check, branch protection |
 | [`suede-clip-to-guide`](skills/suede-clip-to-guide) | Turn a clip, talk moment, or transcript into a clip-to-guide funnel package with rights routing and an evidence gate |
 
@@ -140,21 +168,28 @@ If the pack saves you an hour, [star the repo](https://github.com/JasonColapietr
 | [`suede-copy`](skills/suede-copy) | Conversion copy: headline formulas, A/B variants, anti-slop gate |
 | [`suede-deslop`](skills/suede-deslop) | Strips AI writing patterns from prose before it ships: merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate |
 | [`suede-seo-audit`](skills/suede-seo-audit) | SEO/AEO/AI-EO, metadata, schema, internal-link, and intent audit |
-| [`suede-visibility-grader`](skills/suede-visibility-grader) | A-F page grades for findability, clarity, CTA pull, proof, and AI citation readiness |
+| [`suede-visibility-grader`](skills/suede-visibility-grader) | A–F page grades for findability, clarity, CTA pull, proof, and AI citation readiness |
 | [`suede-site-alchemy`](skills/suede-site-alchemy) | Funnel analysis, friction audit, conversion math, ranked quick-wins |
 | [`suede-launch-packaging`](skills/suede-launch-packaging) | Package work as a launch: docs, install commands, proof links, QA |
 | [`suede-mcp-qa`](skills/suede-mcp-qa) | QA the Suede Skills MCP before it ships |
+
+### Mobile app factories
+
+| Skill | What it does |
+|---|---|
 | [`site-to-ios-app`](skills/site-to-ios-app) | Convert any website into an App Store-ready iOS app: audit, 4.2 wrapper-risk gate, shell strategy, release gate |
 | [`android-app-factory`](skills/android-app-factory) | One prompt to a Play Store-ready native Android app: Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, signed release |
 
-### Consumer automation — the negotiation lane, proven outside a repo
+### Consumer recovery — the negotiation lane, proven outside a repo
 
 | Skill | What it does |
 |---|---|
 | [`amazon-returns-recovery`](skills/amazon-returns-recovery) | The pack's contract negotiator, run against a real account instead of a repo: scan Amazon order/return history and digital subscriptions (Britbox, Starz, Audible, Kindle Unlimited, and more) for restocking fees, short refunds, and forgotten charges, then drive Amazon live chat to waive, refund, or cancel them — includes a validated click-path and popup workaround for the fee-dispute flow. Real recoveries: $448.31, including a previously denied refund overturned after the return window closed |
 | [`subscription-recovery`](skills/subscription-recovery) | Audit recurring charges outside Amazon across App Store, Google Play, PayPal, bank/card evidence, and direct-bill services; report findings first and require confirmation before cancellation or refund contact |
 
-Plus a creator toolkit (rights, release prep) — see [docs](https://skills.suedeai.ai/skills/): `suede-campaign-in-a-box`, `suede-sync-packaging`, `suede-release-linter`, `suede-rights-passport`, `suede-rights-audit`.
+### Creator rights & release
+
+Rights and release-prep tooling for working musicians and creators — see the [skill catalog](https://skills.suedeai.ai/skills/) for each one: [`suede-campaign-in-a-box`](skills/suede-campaign-in-a-box), [`suede-sync-packaging`](skills/suede-sync-packaging), [`suede-release-linter`](skills/suede-release-linter), [`suede-rights-passport`](skills/suede-rights-passport), [`suede-rights-audit`](skills/suede-rights-audit).
 
 ### Marketing & growth
 
@@ -172,6 +207,16 @@ retention, and the measurement and operations layer — `suede-ads`, `suede-ad-c
 
 Adapted from [marketingskills](https://github.com/coreyhaines31/marketingskills) by Corey Haines
 under the MIT License — see [NOTICE.md](NOTICE.md).
+
+## From the blog
+
+Essays on why the pack is built the way it is:
+
+- [**71 skills installed. Your agent reads almost none of them.**](https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html) — progressive disclosure, the ship DAG, and the MCP layer
+- [**Why breadth is free now, and what that changes**](https://skills.suedeai.ai/blog/why-breadth-is-free.html) — the economics of a 71-skill pack
+- [**NOT FOR: the two words that make a big skill pack work**](https://skills.suedeai.ai/blog/not-for-the-line-that-makes-a-pack-work.html) — how skills route without colliding
+- [**Your memory file is a tax you pay on every prompt**](https://skills.suedeai.ai/blog/memory-belongs-in-skills.html) — why memory belongs in skills
+- [**Two new lanes: a next-action recommender and a one-prompt Android app factory**](https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html)
 
 ## Public pages
 
@@ -192,47 +237,6 @@ node mcp/suede-skills-mcp.mjs --profile all
 | Tools (7) | Resources (6) | Prompts (5) |
 |---|---|---|
 | `list_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist` | catalog, plugins, copy-seo-audit, visibility-grade, code-grade, qa-checklist | discovery and audit prompts |
-
-## Install for Codex
-
-Install the complete Codex-native plugin:
-
-```bash
-codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main
-codex plugin add suede-skills@suede-codex
-```
-
-This installs all 71 skills and registers both read-only MCP discovery
-profiles. Restart Codex after installing or updating.
-
-For one selected skill, use the built-in skill installer:
-
-```bash
-python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
-  --repo JasonColapietro/suede-creator-skills \
-  --path skills/suede-workflow-skills
-```
-
-Pass extra `skills/<name>` paths after `--path` when you want a small custom
-set instead of the full plugin.
-
-## Install for Claude Code
-
-All 71 skills:
-
-```bash
-git clone https://github.com/JasonColapietro/suede-creator-skills.git && bash suede-creator-skills/install.sh
-```
-
-Claude Code skills use `SKILL.md` files in `.claude/skills/`. For a project-level install, copy individual folders:
-
-```bash
-git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
-mkdir -p .claude/skills
-cp -R /tmp/suede-creator-skills/skills/suede-agent-teams .claude/skills/
-```
-
-For a user-level install, copy into `~/.claude/skills/` instead. Claude.ai and organization-managed Claude Skills may use upload or admin-managed flows instead of filesystem copy. Review skill contents before enabling code execution.
 
 ## Safety
 
@@ -257,7 +261,7 @@ python3 -m pip install PyYAML
 
 ## About the creator
 
-**Jason Colapietro** is the founder and CEO of [Suede Labs AI](https://suedeai.ai). He builds programmable IP and creator-ownership infrastructure for AI-native media.
+**Jason Colapietro** is the founder and CEO of [Suede Labs AI](https://suedeai.ai). He builds programmable IP and creator-ownership infrastructure for AI-native media. He spent years watching hired marketing firms skip the fundamentals on his own products; this pack turns those misses into reusable, inspectable agent workflows instead of one-off fixes.
 
 Follow: [X / @johnnysuede](https://x.com/johnnysuede) · [suedeai.ai](https://suedeai.ai) · [suedeai.ai/founder](https://suedeai.ai/founder)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Your coding agent is fast, capable, and completely unsupervised. It will happily ship the bug, skip the test, publish the slop, and tell you everything went great.
 
-This pack is the supervision: **71 public skill folders**, MIT-licensed, for Claude Code, OpenAI Codex, and any skills-compatible agent. Outcome-bound orchestration, multi-agent teams, Codex worker fleets, code review with a blunt A–F ship grade, AI evals, design, conversion copy, SEO, 39 marketing lanes, mobile app factories, and creator-rights tooling. Every skill is a plain `skills/<name>/SKILL.md` file you can read before you trust it. No binaries, no telemetry, no accounts.
+This pack is the supervision: **71 public skill folders**, MIT-licensed and broadly reusable, for Claude Code, OpenAI Codex, and any skills-compatible agent. Outcome-bound orchestration, multi-agent teams, Codex worker fleets, code review with a blunt A–F ship grade, AI evals, design, conversion copy, SEO, 39 marketing lanes, mobile app factories, and creator-rights tooling. Every skill is a plain `skills/<name>/SKILL.md` file you can read before you trust it. No binaries, no telemetry, no accounts.
 
 <img src="docs/assets/readme/pack-map.svg" alt="The pack at a glance: 39 marketing and growth skills, 10 design copy and SEO, 8 orchestration and workflows, 5 code quality and shipping, 5 creator rights and release, 2 mobile app factories, 2 consumer recovery." width="100%">
 

--- a/docs/assets/readme/full-send-flow.svg
+++ b/docs/assets/readme/full-send-flow.svg
@@ -1,0 +1,70 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="440" viewBox="0 0 1200 440" role="img" aria-labelledby="t d">
+  <title id="t">Full Send pipeline</title>
+  <desc id="d">A broad authorized outcome flows through one controller into parallel lanes, then adversarial reconciliation, then proof.</desc>
+  <rect width="1200" height="440" rx="16" fill="#080808"/>
+  <rect x="1" y="1" width="1198" height="438" rx="15" fill="none" stroke="#222222" stroke-width="2"/>
+
+  <text x="56" y="58" fill="#c8a96e" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" letter-spacing="3">SUEDE-FULL-SEND</text>
+  <text x="1144" y="58" text-anchor="end" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" letter-spacing="2">MAX EFFORT &#183; SPARE NO COMPUTE</text>
+
+  <g font-family="Arial, Helvetica, sans-serif">
+    <!-- Stage 1: outcome -->
+    <rect x="56" y="180" width="172" height="88" rx="10" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <text x="142" y="218" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">Broad authorized</text>
+    <text x="142" y="238" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">outcome</text>
+
+    <path d="M228 224H262" stroke="#c8a96e" stroke-width="2"/>
+    <path d="M262 224l-9 -5v10z" fill="#c8a96e"/>
+
+    <!-- Stage 2: controller -->
+    <rect x="266" y="180" width="172" height="88" rx="10" fill="#111111" stroke="#c8a96e" stroke-width="1.5"/>
+    <text x="352" y="218" text-anchor="middle" fill="#c8a96e" font-size="16" font-weight="800">One controller</text>
+    <text x="352" y="240" text-anchor="middle" fill="#888880" font-size="13">single authority</text>
+
+    <!-- fan out -->
+    <path d="M438 224C470 224 470 118 502 118" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M438 224C470 224 470 188 502 188" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M438 224C470 224 470 258 502 258" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M438 224C470 224 470 328 502 328" stroke="#c8a96e" stroke-width="2" fill="none"/>
+
+    <!-- Lanes -->
+    <rect x="506" y="92" width="216" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <circle cx="530" cy="118" r="4" fill="#c8a96e"/>
+    <text x="546" y="124" fill="#f0ece4" font-size="15.5" font-weight="700">Code lane</text>
+
+    <rect x="506" y="162" width="216" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <circle cx="530" cy="188" r="4" fill="#c8a96e"/>
+    <text x="546" y="194" fill="#f0ece4" font-size="15.5" font-weight="700">Docs lane</text>
+
+    <rect x="506" y="232" width="216" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <circle cx="530" cy="258" r="4" fill="#c8a96e"/>
+    <text x="546" y="264" fill="#f0ece4" font-size="15.5" font-weight="700">CI &amp; merge-gate lane</text>
+
+    <rect x="506" y="302" width="216" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <circle cx="530" cy="328" r="4" fill="#c8a96e"/>
+    <text x="546" y="334" fill="#f0ece4" font-size="15.5" font-weight="700">Live verification lane</text>
+
+    <!-- fan in -->
+    <path d="M722 118C754 118 754 224 786 224" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M722 188C754 188 754 224 786 224" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M722 258C754 258 754 224 786 224" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M722 328C754 328 754 224 786 224" stroke="#c8a96e" stroke-width="2" fill="none"/>
+    <path d="M786 224l-9 -5v10z" fill="#c8a96e"/>
+
+    <!-- Stage 4: reconciliation -->
+    <rect x="790" y="180" width="204" height="88" rx="10" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+    <text x="892" y="212" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">Adversarial</text>
+    <text x="892" y="232" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">reconciliation</text>
+    <text x="892" y="253" text-anchor="middle" fill="#888880" font-size="12.5">lanes attack each other&#8217;s claims</text>
+
+    <path d="M994 224H1028" stroke="#c8a96e" stroke-width="2"/>
+    <path d="M1028 224l-9 -5v10z" fill="#c8a96e"/>
+
+    <!-- Stage 5: proof -->
+    <rect x="1032" y="180" width="112" height="88" rx="10" fill="#161616" stroke="#c8a96e" stroke-width="2"/>
+    <text x="1088" y="231" text-anchor="middle" fill="#c8a96e" font-size="19" font-weight="900">Proof</text>
+  </g>
+
+  <path d="M56 386H1144" stroke="#222222" stroke-width="1"/>
+  <text x="600" y="412" text-anchor="middle" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="13.5">House line: <tspan fill="#c8a96e" font-weight="700">&#8220;Never end your allocation above zero.&#8221;</tspan> Dry joke, not a literal token promise.</text>
+</svg>

--- a/docs/assets/readme/hero.svg
+++ b/docs/assets/readme/hero.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="400" viewBox="0 0 1200 400" role="img" aria-labelledby="t d">
+  <title id="t">Suede Creator Skills</title>
+  <desc id="d">71 open-source agent skills for Claude Code and Codex. One install command.</desc>
+  <rect width="1200" height="400" rx="16" fill="#080808"/>
+  <rect x="1" y="1" width="1198" height="398" rx="15" fill="none" stroke="#222222" stroke-width="2"/>
+
+  <!-- top bar -->
+  <text x="56" y="62" fill="#f0ece4" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="800" letter-spacing="4">SUEDE</text>
+  <text x="148" y="62" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" letter-spacing="3">CREATOR SKILLS</text>
+  <text x="1144" y="62" text-anchor="end" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" letter-spacing="2">CLAUDE CODE &#183; CODEX &#183; MCP</text>
+  <path d="M56 84H1144" stroke="#222222" stroke-width="1"/>
+
+  <!-- headline -->
+  <text x="56" y="164" fill="#f0ece4" font-family="Arial, Helvetica, sans-serif" font-size="46" font-weight="900" letter-spacing="-0.5">The ship discipline</text>
+  <text x="56" y="216" fill="#f0ece4" font-family="Arial, Helvetica, sans-serif" font-size="46" font-weight="900" letter-spacing="-0.5">your agent is missing.</text>
+
+  <!-- subhead -->
+  <text x="56" y="256" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="17">Orchestration, adversarial code review, A&#8211;F ship grades, AI evals, design,</text>
+  <text x="56" y="280" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="17">copy, SEO, growth, and creator rights. One install, fully inspectable.</text>
+
+  <!-- install chip -->
+  <rect x="56" y="300" width="422" height="44" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+  <text x="76" y="328" fill="#c8a96e" font-family="'Courier New', Courier, monospace" font-size="16" font-weight="700">$</text>
+  <text x="94" y="328" fill="#f0ece4" font-family="'Courier New', Courier, monospace" font-size="16">/plugin install suede-skills@suede</text>
+
+  <!-- big 71 -->
+  <text x="1144" y="290" text-anchor="end" fill="#c8a96e" font-family="Arial, Helvetica, sans-serif" font-size="200" font-weight="900" letter-spacing="-12">71</text>
+  <text x="1138" y="330" text-anchor="end" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" letter-spacing="3">SKILLS &#183; MIT &#183; OPEN SOURCE</text>
+
+  <!-- footer ticks -->
+  <path d="M56 364H1144" stroke="#222222" stroke-width="1"/>
+  <text x="600" y="386" text-anchor="middle" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="12.5" font-weight="700" letter-spacing="1.5">FULL SEND <tspan fill="#c8a96e">&#183;</tspan> AGENT TEAMS <tspan fill="#c8a96e">&#183;</tspan> CODEX FLEET <tspan fill="#c8a96e">&#183;</tspan> A&#8211;F SHIP GRADE <tspan fill="#c8a96e">&#183;</tspan> AI EVALS <tspan fill="#c8a96e">&#183;</tspan> SEO <tspan fill="#c8a96e">&#183;</tspan> iOS + ANDROID <tspan fill="#c8a96e">&#183;</tspan> CREATOR RIGHTS</text>
+</svg>

--- a/docs/assets/readme/pack-map.svg
+++ b/docs/assets/readme/pack-map.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="540" viewBox="0 0 1200 540" role="img" aria-labelledby="t d">
+  <title id="t">The pack at a glance</title>
+  <desc id="d">71 skills across seven lanes: marketing and growth 39, design copy and SEO 10, orchestration and workflows 8, code quality and shipping 5, creator rights and release 5, mobile app factories 2, consumer recovery 2.</desc>
+  <rect width="1200" height="540" rx="16" fill="#080808"/>
+  <rect x="1" y="1" width="1198" height="538" rx="15" fill="none" stroke="#222222" stroke-width="2"/>
+
+  <text x="56" y="64" fill="#c8a96e" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" letter-spacing="3">THE PACK AT A GLANCE</text>
+  <text x="56" y="104" fill="#f0ece4" font-family="Arial, Helvetica, sans-serif" font-size="30" font-weight="900">71 skills, seven lanes, one install</text>
+
+  <!-- rows: label right-aligned at 340, bars from 360, scale 640px = 39 skills -->
+  <g font-family="Arial, Helvetica, sans-serif">
+    <!-- Marketing & growth -->
+    <text x="340" y="169" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Marketing &amp; growth</text>
+    <rect x="360" y="150" width="640" height="28" rx="6" fill="#c8a96e"/>
+    <text x="1014" y="170" fill="#f0ece4" font-size="17" font-weight="800">39</text>
+
+    <!-- Design, copy & SEO -->
+    <text x="340" y="221" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Design, copy &amp; SEO</text>
+    <rect x="360" y="202" width="164" height="28" rx="6" fill="#c8a96e"/>
+    <text x="538" y="222" fill="#f0ece4" font-size="17" font-weight="800">10</text>
+
+    <!-- Orchestration & workflows -->
+    <text x="340" y="273" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Orchestration &amp; workflows</text>
+    <rect x="360" y="254" width="131" height="28" rx="6" fill="#c8a96e"/>
+    <text x="505" y="274" fill="#f0ece4" font-size="17" font-weight="800">8</text>
+
+    <!-- Code quality & shipping -->
+    <text x="340" y="325" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Code quality &amp; shipping</text>
+    <rect x="360" y="306" width="82" height="28" rx="6" fill="#c8a96e"/>
+    <text x="456" y="326" fill="#f0ece4" font-size="17" font-weight="800">5</text>
+
+    <!-- Creator rights & release -->
+    <text x="340" y="377" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Creator rights &amp; release</text>
+    <rect x="360" y="358" width="82" height="28" rx="6" fill="#c8a96e"/>
+    <text x="456" y="378" fill="#f0ece4" font-size="17" font-weight="800">5</text>
+
+    <!-- Mobile app factories -->
+    <text x="340" y="429" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Mobile app factories</text>
+    <rect x="360" y="410" width="38" height="28" rx="6" fill="#c8a96e"/>
+    <text x="412" y="430" fill="#f0ece4" font-size="17" font-weight="800">2</text>
+
+    <!-- Consumer recovery -->
+    <text x="340" y="481" text-anchor="end" fill="#f0ece4" font-size="17" font-weight="700">Consumer recovery</text>
+    <rect x="360" y="462" width="38" height="28" rx="6" fill="#c8a96e"/>
+    <text x="412" y="482" fill="#f0ece4" font-size="17" font-weight="800">2</text>
+  </g>
+
+  <text x="56" y="516" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="13.5">38 of the marketing skills are adapted from Corey Haines&#8217; marketingskills, MIT licensed. Losses and credits stay visible.</text>
+</svg>

--- a/docs/assets/readme/ship-grade.svg
+++ b/docs/assets/readme/ship-grade.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="470" viewBox="0 0 1200 470" role="img" aria-labelledby="t d">
+  <title id="t">The A to F ship grade</title>
+  <desc id="d">Seven graded lanes produce one ship verdict. Instant-F triggers lock the grade to F with the exact file and line.</desc>
+  <rect width="1200" height="470" rx="16" fill="#080808"/>
+  <rect x="1" y="1" width="1198" height="468" rx="15" fill="none" stroke="#222222" stroke-width="2"/>
+
+  <text x="56" y="58" fill="#c8a96e" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" letter-spacing="3">SUEDE-CODE &#183; SHIP GRADE</text>
+  <text x="1144" y="58" text-anchor="end" fill="#888880" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" letter-spacing="2">7 LANES &#183; ILLUSTRATIVE RUN</text>
+
+  <g font-family="Arial, Helvetica, sans-serif">
+    <!-- lanes -->
+    <g font-size="16.5">
+      <text x="56" y="118" fill="#f0ece4" font-weight="700">Correctness</text>
+      <rect x="656" y="98" width="44" height="30" rx="7" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+      <text x="678" y="119" text-anchor="middle" fill="#c8a96e" font-weight="800">A</text>
+
+      <text x="56" y="160" fill="#f0ece4" font-weight="700">Security &amp; permissions</text>
+      <rect x="656" y="140" width="44" height="30" rx="7" fill="#161616" stroke="#222222" stroke-width="1.5"/>
+      <text x="678" y="161" text-anchor="middle" fill="#f0ece4" font-weight="800">B</text>
+
+      <text x="56" y="202" fill="#f0ece4" font-weight="700">Data &amp; state</text>
+      <rect x="656" y="182" width="44" height="30" rx="7" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+      <text x="678" y="203" text-anchor="middle" fill="#c8a96e" font-weight="800">A&#8722;</text>
+
+      <text x="56" y="244" fill="#f0ece4" font-weight="700">Domain truth</text>
+      <rect x="656" y="224" width="44" height="30" rx="7" fill="#161616" stroke="#222222" stroke-width="1.5"/>
+      <text x="678" y="245" text-anchor="middle" fill="#f0ece4" font-weight="800">B+</text>
+
+      <text x="56" y="286" fill="#f0ece4" font-weight="700">UX &amp; release behavior</text>
+      <rect x="656" y="266" width="44" height="30" rx="7" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+      <text x="678" y="287" text-anchor="middle" fill="#c8a96e" font-weight="800">A&#8722;</text>
+
+      <text x="56" y="328" fill="#f0ece4" font-weight="700">Tests &amp; verification</text>
+      <rect x="656" y="308" width="44" height="30" rx="7" fill="#161616" stroke="#222222" stroke-width="1.5"/>
+      <text x="678" y="329" text-anchor="middle" fill="#f0ece4" font-weight="800">B</text>
+
+      <text x="56" y="370" fill="#f0ece4" font-weight="700">Deploy readiness</text>
+      <rect x="656" y="350" width="44" height="30" rx="7" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+      <text x="678" y="371" text-anchor="middle" fill="#c8a96e" font-weight="800">A</text>
+    </g>
+
+    <!-- leader lines -->
+    <g stroke="#222222" stroke-width="1" stroke-dasharray="2 5">
+      <path d="M262 113H648"/>
+      <path d="M258 155H648"/>
+      <path d="M172 197H648"/>
+      <path d="M182 239H648"/>
+      <path d="M256 281H648"/>
+      <path d="M232 323H648"/>
+      <path d="M212 365H648"/>
+    </g>
+
+    <!-- verdict tile -->
+    <rect x="800" y="96" width="344" height="286" rx="12" fill="#111111" stroke="#c8a96e" stroke-width="2"/>
+    <text x="972" y="158" text-anchor="middle" fill="#888880" font-size="14" font-weight="700" letter-spacing="3">SHIP VERDICT</text>
+    <text x="972" y="300" text-anchor="middle" fill="#c8a96e" font-size="130" font-weight="900">B+</text>
+    <text x="972" y="352" text-anchor="middle" fill="#888880" font-size="13.5">the weakest lane caps the grade</text>
+  </g>
+
+  <!-- instant-F strip -->
+  <rect x="56" y="404" width="1088" height="42" rx="9" fill="#140a0a" stroke="#8b1a1a" stroke-width="1.5"/>
+  <text x="80" y="431" fill="#c0392b" font-family="Arial, Helvetica, sans-serif" font-size="14.5" font-weight="800" letter-spacing="1">INSTANT-F</text>
+  <text x="192" y="431" fill="#f0ece4" font-family="Arial, Helvetica, sans-serif" font-size="14.5">hardcoded secret, or a permission check bypassable via request param &#8594; grade locks to F with the exact file and line</text>
+</svg>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -931,9 +931,14 @@ const countChecks = [
   // landing page, and its URL value drifted to 29 while the alt text, the
   // README prose, and every other surface said 67. Guard both halves — the
   // rendered number lives in the URL, so alt text alone proves nothing.
-  { file: "README.md", label: "skills badge URL value", re: /img\.shields\.io\/badge\/Skills-(\d+)-black/, expected: totalSkillCount },
+  { file: "README.md", label: "skills badge URL value", re: /img\.shields\.io\/badge\/skills-(\d+)-c8a96e/, expected: totalSkillCount },
   { file: "README.md", label: "skills badge alt text", re: /!\[Skills: (\d+)\]/, expected: totalSkillCount },
-  { file: "README.md", label: "intro toolkit size", re: /A (\d+)-skill toolkit for Claude Code/, expected: totalSkillCount },
+  { file: "README.md", label: "hero alt skill count", re: /(\d+) open-source skills for Claude Code and Codex/, expected: totalSkillCount },
+  // The README hero and pack-map are SVGs with the count baked into the
+  // artwork — the rendered number lives in the SVG text node, so README
+  // prose alone proves nothing. Guard both graphics.
+  { file: "docs/assets/readme/hero.svg", label: "hero graphic skill count", re: /letter-spacing="-12">(\d+)</, expected: totalSkillCount },
+  { file: "docs/assets/readme/pack-map.svg", label: "pack-map title skill count", re: /(\d+) skills, seven lanes/, expected: totalSkillCount },
   // The install sections repeat "all N skills" five times — plugin, Codex
   // plugin, install.sh, Codex clone, and the Claude Code heading. All five sat
   // at 70 while the badge and intro said 71, because nothing guarded them and

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1054,7 +1054,10 @@ for (const check of countChecks) {
 // project must be recomputed from that table, never hand-written beside it.
 {
   const gradeRank = { "A+": 6, A: 5, "A-": 4, "B+": 3, B: 2, "B-": 1, "C+": 0.5, C: 0 };
-  const detailBlock = docsRootText.split("See the full 15-category scorecard")[1]?.split("</details>")[0];
+  // Anchor on the details element's class, not the summary copy — the copy
+  // ("See the full 15-category scorecard") drifted once and silently skipped
+  // this guard while the scorecard table was still on the page.
+  const detailBlock = docsRootText.split('class="scorecard-details')[1]?.split("</details>")[0];
   if (!detailBlock) {
     warn.push("docs/index.html scorecard detail table not found — competitive-claim guard skipped");
   } else {
@@ -1067,21 +1070,23 @@ for (const check of countChecks) {
     }
     const beatsBoth = scored.filter(([, s, g, p]) => gradeRank[s] > gradeRank[g] && gradeRank[s] > gradeRank[p]);
     const losesBoth = scored.filter(([, s, g, p]) => gradeRank[s] < gradeRank[g] && gradeRank[s] < gradeRank[p]);
+    // Current strip copy: "Beats GSD and Superpowers in <N categories>, and
+    // publishes the ones it loses" — the win count is still a published
+    // assertion and must equal the table's beat-both row count. The strip no
+    // longer states the total or the loss count; losses stay visible through
+    // the table itself and the hero-tile completeness check below.
     const claim = docsRootText.match(
-      /Beats GSD and Superpowers in <span class="bench-highlight">(\d+) of (\d+) categories<\/span> &mdash; and publishes the (\d+) it loses/
+      /Beats GSD and Superpowers in <span class="bench-highlight">(\d+) categories<\/span>, and publishes the ones it loses/
     );
     if (!claim) {
       fail.push("docs/index.html hero benchmark claim not found or reworded — it must be re-derived from the scorecard table");
     } else {
-      const [, wins, total, losses] = claim.map(Number);
+      const wins = Number(claim[1]);
       if (wins !== beatsBoth.length) {
         fail.push(`docs/index.html hero claims it beats both in ${wins} categories; the scorecard shows ${beatsBoth.length} (${beatsBoth.map((r) => r[0]).join(", ")})`);
       }
-      if (total !== scored.length) {
-        fail.push(`docs/index.html hero claims ${total} scored categories; the scorecard has ${scored.length}`);
-      }
-      if (losses !== losesBoth.length) {
-        fail.push(`docs/index.html hero claims it loses ${losses}; the scorecard shows ${losesBoth.length} (${losesBoth.map((r) => r[0]).join(", ")})`);
+      if (losesBoth.length === 0) {
+        fail.push('docs/index.html hero says it "publishes the ones it loses" but the scorecard shows no lose-both categories — reword the strip or fix the table');
       }
     }
     // The four hero tiles must be exactly the beat-both categories, or the


### PR DESCRIPTION
Rebuilds the repo README as a proper front door.

**Graphics** — four self-contained SVGs in the site's brand system (near-black / warm off-white / Suede gold / risk red), rendering identically on GitHub light and dark themes:
- Hero banner with the install command and the 71-skill mark
- Pack map: 71 skills across seven lanes
- Full Send pipeline diagram (controller → lanes → adversarial reconciliation → proof)
- A–F ship-grade card with the instant-F strip

**Copy** — rewritten intro and section copy, gold badge row, jump-nav link row, dedicated Full Send and ship-grade sections, and a From-the-blog section linking all five live essays.

**Catalog fixes** — adds `suede-ship` and `suede-ship-copy` (present in `skills/` but missing from the README), splits mobile factories and creator rights into their own sections. All install commands, safety text, and third-party credits preserved verbatim.

**Validator** — `scripts/validate-skill-pack.mjs` count guards retargeted to the new badge URL and extended to cover the hero alt text and the counts baked into both SVGs. `node scripts/validate-skill-pack.mjs` passes: 71 skills against 71 catalog entries.