### PR TITLE
Site redesign: homepage Full Send + field notes, catalog lane map, 70→71 count sweep

### DIFF
--- a/docs/copy.html
+++ b/docs/copy.html
@@ -262,7 +262,7 @@
             <b>Full description</b>
             <button class="copy-btn" type="button" data-copy-block>Copy</button>
           </div>
-          <p>Suede Creator Skills is a public skill pack for builders, designers, founders, creators, agencies, and AI power users. It ships 70 public SKILL.md folders: one umbrella workflow, 21 workflow skills including Suede Full Send, coordinated agent teams, Codex CLI worker fleets, code review and A-F grading, CI ship-gates, AI evals, a next-action recommender, an anti-slop pass, Suedify, writing, design, SEO/AEO/AI EO, visibility grading, site alchemy, launch packaging, MCP QA, and iOS and Android app shipping, 39 marketing and growth skills including account-specific Instagram growth, 5 creator skills for campaigns, sync packaging, release linting, rights passports, and rights audits, plus 2 consumer-recovery skills that dispute return fees and claw back forgotten subscriptions.</p>
+          <p>Suede Creator Skills is a public skill pack for builders, designers, founders, creators, agencies, and AI power users. It ships 71 public SKILL.md folders: one umbrella workflow, 21 workflow skills including Suede Full Send, coordinated agent teams, Codex CLI worker fleets, code review and A-F grading, CI ship-gates, AI evals, a next-action recommender, an anti-slop pass, Suedify, writing, design, SEO/AEO/AI EO, visibility grading, site alchemy, launch packaging, MCP QA, and iOS and Android app shipping, 39 marketing and growth skills including account-specific Instagram growth, 5 creator skills for campaigns, sync packaging, release linting, rights passports, and rights audits, plus 2 consumer-recovery skills that dispute return fees and claw back forgotten subscriptions.</p>
         </div>
         <div class="copy-block">
           <div class="copy-block-head">
@@ -436,10 +436,10 @@
         <span class="terminal-title">short post</span>
       </div>
       <div class="terminal-body">
-        <pre>Suede Creator Skills are live: 70 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.
+        <pre>Suede Creator Skills are live: 71 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.
 
 Docs: https://skills.suedeai.ai/skills/</pre>
-        <button class="copy-btn" data-copy="Suede Creator Skills are live: 70 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.&#10;&#10;Docs: https://skills.suedeai.ai/skills/">Copy</button>
+        <button class="copy-btn" data-copy="Suede Creator Skills are live: 71 open-source agent skills for Claude Code and Codex. Full Send outcome routing, multi-agent orchestration, code review with A-F ship grades, CI gating, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/AI EO, plus iOS/Android app shipping and artist campaign and rights tools.&#10;&#10;Docs: https://skills.suedeai.ai/skills/">Copy</button>
       </div>
     </div>
 

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -6,7 +6,7 @@
     <title>Suede Creator Skills Guide | 71 Agent Skills</title>
     <meta
       name="description"
-      content="Read the guide to 70 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools."
+      content="Read the guide to 71 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools."
     >
     <meta name="author" content="Jason Colapietro">
     <meta name="publisher" content="Suede Labs AI">
@@ -20,7 +20,7 @@
     <link rel="image_src" href="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Suede Creator Skills Guide | 70 Agent Skills">
-    <meta property="og:description" content="Read the guide to 70 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.">
+    <meta property="og:description" content="Read the guide to 71 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.">
     <meta property="og:url" content="https://skills.suedeai.ai/guide.html">
     <meta property="og:site_name" content="Suede Creator Skills">
     <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
@@ -33,7 +33,7 @@
     <meta name="twitter:site" content="@johnnysuede">
     <meta name="twitter:creator" content="@johnnysuede">
     <meta name="twitter:title" content="Suede Creator Skills">
-    <meta name="twitter:description" content="70 MIT-licensed agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and creator tools.">
+    <meta name="twitter:description" content="71 MIT-licensed agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and creator tools.">
     <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta name="twitter:image:alt" content="Suede Creator Skills - Codex and Claude skills for Suedify, design, copywriting, SEO/AEO/AI EO, and QA.">
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
@@ -57,7 +57,7 @@
             "@id": "https://skills.suedeai.ai/#website",
             "url": "https://skills.suedeai.ai/",
             "name": "Suede Creator Skills",
-            "description": "Public, open-source pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server: Full Send outcome routing, multi-agent orchestration, Codex CLI worker fleets, code review with A-F ship grades, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and a creator toolkit.",
+            "description": "Public, open-source pack of 71 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server: Full Send outcome routing, multi-agent orchestration, Codex CLI worker fleets, code review with A-F ship grades, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and a creator toolkit.",
             "publisher": {
               "@id": "https://suedeai.ai/#org"
             },
@@ -68,7 +68,7 @@
             "@id": "https://skills.suedeai.ai/guide.html#webpage",
             "url": "https://skills.suedeai.ai/guide.html",
             "name": "Suede Creator Skills Guide | 70 Agent Skills",
-            "description": "Read the guide to 70 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.",
+            "description": "Read the guide to 71 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.",
             "isPartOf": {
               "@id": "https://skills.suedeai.ai/#website"
             },
@@ -104,7 +104,7 @@
             "@type": "SoftwareSourceCode",
             "@id": "https://skills.suedeai.ai/#skills",
             "name": "Suede Creator Skills",
-            "description": "70 public, MIT-licensed agent skills for Claude Code and Codex: Full Send outcome routing, multi-agent orchestration, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/GEO/AI EO, visibility grading, site alchemy, launch packaging, MCP QA, iOS and Android app shipping, and a creator toolkit for campaigns, release prep, and rights evidence.",
+            "description": "71 public, MIT-licensed agent skills for Claude Code and Codex: Full Send outcome routing, multi-agent orchestration, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copywriting, SEO/AEO/GEO/AI EO, visibility grading, site alchemy, launch packaging, MCP QA, iOS and Android app shipping, and a creator toolkit for campaigns, release prep, and rights evidence.",
             "url": "https://skills.suedeai.ai/",
             "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
             "programmingLanguage": ["Markdown", "JavaScript", "Python", "HTML"],
@@ -663,7 +663,7 @@
             <div class="hero-copy">
               <p class="eyebrow">The full guide</p>
               <h1 id="hero-headline">Stop rebuilding the prompt stack every time your agent forgets you.</h1>
-              <p class="lead">Suede gives Claude Code or Codex a reusable engineering workflow instead of one giant bloated prompt. <strong>Every capability is an inspectable <code>SKILL.md</code> folder</strong> the agent loads on demand: Full Send outcome routing, orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, app shipping, and creator rights. 70 skills, MIT licensed.</p>
+              <p class="lead">Suede gives Claude Code or Codex a reusable engineering workflow instead of one giant bloated prompt. <strong>Every capability is an inspectable <code>SKILL.md</code> folder</strong> the agent loads on demand: Full Send outcome routing, orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, app shipping, and creator rights. 71 skills, MIT licensed.</p>
               <a id="hero-shiplog" href="./#changelog" aria-label="Ship log: 223 commits in 10 weeks. Latest entry August 4, 2026: Instagram growth gets an evidence system. Read the full changelog on the homepage.">
                 <span class="hero-spark" aria-hidden="true">
                   <span style="height:8%"></span>
@@ -840,7 +840,7 @@
           </p>
           <div class="rows" aria-label="Public project evidence links">
             <a class="rowl" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener"><b>GitHub</b><span>Inspect the source, license, skills, scripts, docs, tests, and MCP catalog.</span><span class="arrow">-&gt;</span></a>
-            <a class="rowl" href="./skills/"><b>Skill Docs</b><span>Browse all 70 installable skill folders and their public descriptions.</span><span class="arrow">-&gt;</span></a>
+            <a class="rowl" href="./skills/"><b>Skill Docs</b><span>Browse all 71 installable skill folders and their public descriptions.</span><span class="arrow">-&gt;</span></a>
             <a class="rowl" href="./skills/suede-full-send.html"><b>Full Send</b><span>Read the intent router for broad, authorized, outcome-bound work.</span><span class="arrow">-&gt;</span></a>
             <a class="rowl" href="./plugins.html"><b>Installs + MCP</b><span>Use public install commands and optional structured MCP discovery.</span><span class="arrow">-&gt;</span></a>
             <a class="rowl" href="./copy.html"><b>Copy Bank</b><span>Reuse public-safe wording for docs, launches, FAQs, and evidence boundaries.</span><span class="arrow">-&gt;</span></a>
@@ -896,7 +896,7 @@
             </article>
             <article class="install" aria-labelledby="install-codex-title">
               <h3 id="install-codex-title">Codex &mdash; full pack</h3>
-              <p>Add the Codex-native marketplace, then install all 70 skills and both read-only MCP profiles. Use the direct skill installer only when you want one selected skill.</p>
+              <p>Add the Codex-native marketplace, then install all 71 skills and both read-only MCP profiles. Use the direct skill installer only when you want one selected skill.</p>
               <pre><code>codex plugin marketplace add JasonColapietro/suede-creator-skills --ref main
 codex plugin add suede-skills@suede-codex</code></pre>
             </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -43,7 +43,7 @@
         "@id": "https://skills.suedeai.ai/#website",
         "name": "Suede Creator Skills",
         "url": "https://skills.suedeai.ai/",
-        "description": "Public, open-source pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server for discovery, audits, and QA. The pack carries preferences, linked context, quality gates, and reusable workflow rules across agents and computers.",
+        "description": "Public, open-source pack of 71 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server for discovery, audits, and QA. The pack carries preferences, linked context, quality gates, and reusable workflow rules across agents and computers.",
         "publisher": { "@id": "https://suedeai.ai/#org" }
       },
       {
@@ -64,7 +64,7 @@
       {
         "@type": "SoftwareSourceCode",
         "name": "Suede Creator Skills",
-        "description": "Public, open-source (MIT) pack of 70 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server. One install gives an AI coding agent a reusable engineering workflow: Suede Full Send for broad, authorized outcome-bound work, coordinated multi-agent build lanes with quality gates and a signed handoff, reviewed OpenAI Codex CLI worker fleets, code review with a blunt A-F ship grade, CI ship-gates, AI evaluation specs and acceptance gates, account-specific Instagram growth, and design, copy, SEO, and visibility lanes for shipping public work. Also includes a small creator toolkit for music rights and release prep. Users can bring their own company, repo, page, or product.",
+        "description": "Public, open-source (MIT) pack of 71 installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server. One install gives an AI coding agent a reusable engineering workflow: Suede Full Send for broad, authorized outcome-bound work, coordinated multi-agent build lanes with quality gates and a signed handoff, reviewed OpenAI Codex CLI worker fleets, code review with a blunt A-F ship grade, CI ship-gates, AI evaluation specs and acceptance gates, account-specific Instagram growth, and design, copy, SEO, and visibility lanes for shipping public work. Also includes a small creator toolkit for music rights and release prep. Users can bring their own company, repo, page, or product.",
         "url": "https://skills.suedeai.ai/",
         "codeRepository": "https://github.com/JasonColapietro/suede-creator-skills",
         "programmingLanguage": ["Markdown", "JavaScript", "Python", "HTML"],
@@ -161,7 +161,7 @@
           {
             "@type": "Question",
             "name": "What are Agent Skills?",
-            "acceptedAnswer": { "@type": "Answer", "text": "Agent Skills are SKILL.md folders that Claude Code and OpenAI Codex load on demand to follow a documented workflow. This pack ships 70 of them under the MIT license: outcome-bound orchestration, code review and grading, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, marketing and growth, iOS and Android app shipping, and a creator toolkit for music rights and release prep. Every folder is plain Markdown you can read before you install it." }
+            "acceptedAnswer": { "@type": "Answer", "text": "Agent Skills are SKILL.md folders that Claude Code and OpenAI Codex load on demand to follow a documented workflow. This pack ships 71 of them under the MIT license: outcome-bound orchestration, code review and grading, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, marketing and growth, iOS and Android app shipping, and a creator toolkit for music rights and release prep. Every folder is plain Markdown you can read before you install it." }
           },
           {
             "@type": "Question",
@@ -3040,6 +3040,194 @@
       .router-skill { white-space: normal; }
     }
 
+    /* ============================================================
+       FULL SEND FLOW DIAGRAM
+    ============================================================ */
+    #flow { background: #080808; padding: 84px 0; }
+    .flow-inner { max-width: 1100px; margin: 0 auto; padding: 0 40px; }
+    .flow-eyebrow {
+      margin: 0 0 16px;
+      font-size: 12px; font-weight: 700;
+      letter-spacing: 0.2em; text-transform: uppercase;
+      color: #c8a96e;
+    }
+    .flow-headline {
+      margin: 0;
+      font-size: clamp(34px, 5vw, 56px);
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1.05;
+      color: #f0ece4;
+    }
+    .flow-sub {
+      margin: 24px 0 0;
+      max-width: 72ch;
+      font-size: 16.5px;
+      line-height: 1.7;
+      color: #888880;
+    }
+    .flow-sub a, .flow-note a {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+      color: #c8a96e;
+      text-decoration: none;
+      border-bottom: 1px solid rgba(200, 169, 110, 0.4);
+    }
+    .flow-sub a:hover, .flow-note a:hover { border-bottom-color: #c8a96e; }
+    .flow-scroll {
+      margin: 40px 0 0;
+      border: 1px solid #222;
+      border-radius: 10px;
+      background: #0d0d0c;
+      padding: 28px 20px;
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .flow-svg { display: block; min-width: 860px; width: 100%; height: auto; }
+    .flow-note {
+      margin: 18px 0 0;
+      font-size: 13.5px;
+      line-height: 1.65;
+      color: #888880;
+    }
+    .flow-note strong { color: #c8a96e; font-weight: 700; }
+    @media (max-width: 640px) {
+      .flow-inner { padding: 0 24px; }
+      .flow-scroll { padding: 20px 14px; }
+    }
+
+    /* ============================================================
+       FIELD NOTES / ESSAYS
+    ============================================================ */
+    #essays { background: #080808; padding: 84px 0; }
+    .essays-inner { max-width: 1100px; margin: 0 auto; padding: 0 40px; }
+    .essays-eyebrow {
+      margin: 0 0 16px;
+      font-size: 12px; font-weight: 700;
+      letter-spacing: 0.2em; text-transform: uppercase;
+      color: #c8a96e;
+    }
+    .essays-headline {
+      margin: 0;
+      font-size: clamp(34px, 5vw, 56px);
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1.05;
+      color: #f0ece4;
+    }
+    .essays-sub {
+      margin: 24px 0 0;
+      max-width: 72ch;
+      font-size: 16.5px;
+      line-height: 1.7;
+      color: #888880;
+    }
+    .essays-list {
+      margin: 40px 0 0;
+      border: 1px solid #222;
+      border-radius: 6px;
+      background: #0d0d0c;
+      overflow: hidden;
+    }
+    .essay-row {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 22px;
+      padding: 20px 22px;
+      border-bottom: 1px solid #1a1a18;
+      text-decoration: none;
+      transition: background 0.15s ease;
+    }
+    .essay-row:last-child { border-bottom: 0; }
+    .essay-row:hover { background: #14130f; }
+    .essay-date {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 12.5px;
+      color: #888880;
+      white-space: nowrap;
+    }
+    .essay-copy { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+    .essay-title {
+      font-size: 16.5px;
+      font-weight: 700;
+      color: #f0ece4;
+      line-height: 1.4;
+    }
+    .essay-row:hover .essay-title { color: #c8a96e; }
+    .essay-hook {
+      font-size: 13.5px;
+      color: #888880;
+      line-height: 1.5;
+    }
+    .essay-arrow {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 13px;
+      color: #888880;
+      transition: color 0.15s ease, transform 0.15s ease;
+    }
+    .essay-row:hover .essay-arrow { color: #c8a96e; transform: translateX(3px); }
+    .essays-more { margin: 22px 0 0; font-size: 14.5px; }
+    .essays-more a {
+      color: #c8a96e;
+      text-decoration: none;
+      border-bottom: 1px solid rgba(200, 169, 110, 0.4);
+      padding: 4px 0;
+    }
+    .essays-more a:hover { border-bottom-color: #c8a96e; }
+    @media (max-width: 640px) {
+      .essays-inner { padding: 0 24px; }
+      .essay-row { grid-template-columns: 1fr; row-gap: 8px; }
+      .essay-arrow { display: none; }
+    }
+
+    /* ============================================================
+       MARKETING LANE CHIPS
+    ============================================================ */
+    .catalog-lane-lead {
+      margin: 0 0 22px;
+      max-width: 72ch;
+      font-size: 15px;
+      line-height: 1.7;
+      color: #888880;
+    }
+    .catalog-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+    .catalog-chip {
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      padding: 8px 16px;
+      border: 1px solid #222;
+      border-radius: 999px;
+      background: #0d0d0c;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 13px;
+      color: #f0ece4;
+      text-decoration: none;
+      transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+    }
+    .catalog-chip:hover {
+      border-color: #c8a96e;
+      color: #c8a96e;
+      background: #14130f;
+    }
+    .catalog-lane-credit {
+      margin: 22px 0 0;
+      font-size: 13px;
+      line-height: 1.65;
+      color: #888880;
+    }
+    .catalog-lane-credit a {
+      color: #888880;
+      border-bottom: 1px solid rgba(136, 136, 128, 0.35);
+      text-decoration: none;
+    }
+    .catalog-lane-credit a:hover { color: #c8a96e; border-bottom-color: #c8a96e; }
+
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
         animation-duration: 0.001ms !important;
@@ -3125,7 +3313,7 @@
 
         <h1 id="hero-headline" class="hero-anim">Your coding agent is fast, capable, and completely unsupervised.</h1>
 
-        <p id="hero-subline" class="hero-anim">This pack is the supervision. 70 open-source skills that read every diff like a senior engineer with a reputation to protect, then finish the parts of shipping nobody prompts for: design that looks intentional, copy that sells, SEO that gets found, account-specific Instagram growth, and <strong>native iOS and Android shipping workflows</strong>. Full Send routes broad, authorized work to the useful lanes and holds the result to proof. One recovery skill argued Amazon out of <strong>$448.31</strong> in one sitting. Your agent just got taste.</p>
+        <p id="hero-subline" class="hero-anim">This pack is the supervision. 71 open-source skills that read every diff like a senior engineer with a reputation to protect, then finish the parts of shipping nobody prompts for: design that looks intentional, copy that sells, SEO that gets found, account-specific Instagram growth, and <strong>native iOS and Android shipping workflows</strong>. Full Send routes broad, authorized work to the useful lanes and holds the result to proof. One recovery skill argued Amazon out of <strong>$448.31</strong> in one sitting. Your agent just got taste.</p>
 
         <a id="hero-shiplog" class="hero-anim" href="#changelog" aria-label="Ship log: 223 commits in 10 weeks. Latest entry August 4, 2026: Instagram growth gets an evidence system. Jump to the full changelog.">
           <span class="hero-spark" aria-hidden="true">
@@ -3538,24 +3726,29 @@
 <!-- LANE INDEX -->
 <section id="lanes" aria-labelledby="lanes-headline">
   <div class="lanes-inner">
-    <p class="lanes-eyebrow reveal">One pack, six disciplines</p>
+    <p class="lanes-eyebrow reveal">One pack, seven disciplines</p>
     <h2 id="lanes-headline" class="lanes-headline reveal reveal-d1">Code review is just the opening act.</h2>
-    <p class="lanes-sub reveal reveal-d1">The same discipline that grades your diffs also designs the page, writes the copy, grows the Instagram account, ships the iOS and Android app, packages the release rights, and argues your money back. Six lanes, 71 skills, one install.</p>
+    <p class="lanes-sub reveal reveal-d1">The same discipline that grades your diffs also designs the page, writes the copy, runs the whole marketing engine, ships the iOS and Android app, packages the release rights, and argues your money back. Seven lanes, 71 skills, one install.</p>
     <div class="lanes-list reveal reveal-d2">
       <a class="lane-row" href="#lane-code">
         <span class="lane-name">Code quality &amp; shipping</span>
         <span class="lane-desc">Review with receipts, A-F ship grades, CI that blocks the merge</span>
-        <span class="lane-count">4 skills</span>
+        <span class="lane-count">5 skills</span>
       </a>
       <a class="lane-row" href="#lane-orchestration">
         <span class="lane-name">Agent orchestration</span>
-        <span class="lane-desc">Coordinated lanes, Codex worker fleets, AI evals, one recommended next move</span>
-        <span class="lane-count">5 skills</span>
+        <span class="lane-desc">Full Send, coordinated lanes, Codex worker fleets, AI evals, the ship DAG</span>
+        <span class="lane-count">8 skills</span>
       </a>
       <a class="lane-row" href="#lane-design">
         <span class="lane-name">Design, copy &amp; SEO</span>
         <span class="lane-desc">The full public-surface stack, from design tokens to answer engines</span>
-        <span class="lane-count">9 skills</span>
+        <span class="lane-count">10 skills</span>
+      </a>
+      <a class="lane-row" href="#lane-marketing">
+        <span class="lane-name">Marketing &amp; growth</span>
+        <span class="lane-desc">Paid, outbound, pricing, lifecycle, retention, and the measurement layer</span>
+        <span class="lane-count">39 skills</span>
       </a>
       <a class="lane-row" href="#lane-mobile">
         <span class="lane-name">iOS &amp; Android app shipping</span>
@@ -3573,6 +3766,72 @@
         <span class="lane-count">2 skills</span>
       </a>
     </div>
+  </div>
+</section>
+
+<!-- FULL SEND FLOW -->
+<section id="flow" aria-labelledby="flow-headline">
+  <div class="flow-inner">
+    <p class="flow-eyebrow reveal">Full Send</p>
+    <h2 id="flow-headline" class="flow-headline reveal reveal-d1">Enthusiasm in. Proof out.</h2>
+    <p class="flow-sub reveal reveal-d1">Tell most agents "max effort, fix everything" and you get vibes. <a href="skills/suede-full-send.html">/suede-full-send</a> turns that intent into a structure: one authorized controller, every useful non-colliding lane in parallel, adversarial reconciliation where lanes attack each other's claims, and a close that is either concise proof or one named blocker.</p>
+    <div class="flow-scroll reveal reveal-d2">
+      <svg class="flow-svg" viewBox="0 0 1200 360" role="img" aria-labelledby="flow-svg-title flow-svg-desc" xmlns="http://www.w3.org/2000/svg">
+        <title id="flow-svg-title">The Full Send pipeline</title>
+        <desc id="flow-svg-desc">A broad authorized outcome flows through one controller into parallel code, docs, CI, and live-verification lanes, then adversarial reconciliation, then proof.</desc>
+        <g font-family="system-ui, -apple-system, sans-serif">
+          <rect x="4" y="136" width="172" height="88" rx="10" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <text x="90" y="174" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">Broad authorized</text>
+          <text x="90" y="194" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">outcome</text>
+
+          <path d="M176 180H210" stroke="#c8a96e" stroke-width="2"/>
+          <path d="M210 180l-9 -5v10z" fill="#c8a96e"/>
+
+          <rect x="214" y="136" width="172" height="88" rx="10" fill="#111111" stroke="#c8a96e" stroke-width="1.5"/>
+          <text x="300" y="174" text-anchor="middle" fill="#c8a96e" font-size="16" font-weight="800">One controller</text>
+          <text x="300" y="196" text-anchor="middle" fill="#888880" font-size="13">single authority</text>
+
+          <path d="M386 180C428 180 428 74 470 74" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M386 180C428 180 428 144 470 144" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M386 180C428 180 428 214 470 214" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M386 180C428 180 428 284 470 284" stroke="#c8a96e" stroke-width="2" fill="none"/>
+
+          <rect x="474" y="48" width="230" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <circle cx="498" cy="74" r="4" fill="#c8a96e"/>
+          <text x="514" y="80" fill="#f0ece4" font-size="15.5" font-weight="700">Code lane</text>
+
+          <rect x="474" y="118" width="230" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <circle cx="498" cy="144" r="4" fill="#c8a96e"/>
+          <text x="514" y="150" fill="#f0ece4" font-size="15.5" font-weight="700">Docs lane</text>
+
+          <rect x="474" y="188" width="230" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <circle cx="498" cy="214" r="4" fill="#c8a96e"/>
+          <text x="514" y="220" fill="#f0ece4" font-size="15.5" font-weight="700">CI &amp; merge-gate lane</text>
+
+          <rect x="474" y="258" width="230" height="52" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <circle cx="498" cy="284" r="4" fill="#c8a96e"/>
+          <text x="514" y="290" fill="#f0ece4" font-size="15.5" font-weight="700">Live verification lane</text>
+
+          <path d="M704 74C746 74 746 180 788 180" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M704 144C746 144 746 180 788 180" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M704 214C746 214 746 180 788 180" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M704 284C746 284 746 180 788 180" stroke="#c8a96e" stroke-width="2" fill="none"/>
+          <path d="M788 180l-9 -5v10z" fill="#c8a96e"/>
+
+          <rect x="792" y="136" width="216" height="88" rx="10" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+          <text x="900" y="168" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">Adversarial</text>
+          <text x="900" y="188" text-anchor="middle" fill="#f0ece4" font-size="16" font-weight="800">reconciliation</text>
+          <text x="900" y="209" text-anchor="middle" fill="#888880" font-size="12.5">lanes attack each other's claims</text>
+
+          <path d="M1008 180H1042" stroke="#c8a96e" stroke-width="2"/>
+          <path d="M1042 180l-9 -5v10z" fill="#c8a96e"/>
+
+          <rect x="1046" y="136" width="150" height="88" rx="10" fill="#161616" stroke="#c8a96e" stroke-width="2"/>
+          <text x="1121" y="187" text-anchor="middle" fill="#c8a96e" font-size="19" font-weight="900">Proof</text>
+        </g>
+      </svg>
+    </div>
+    <p class="flow-note reveal reveal-d2">House line: <strong>"Never end your allocation above zero."</strong> Dry joke, not a literal token promise. The full DAG behind it ships as <a href="skills/suede-ship.html">/suede-ship</a>, and the copy-only variant as <a href="skills/suede-ship-copy.html">/suede-ship-copy</a>.</p>
   </div>
 </section>
 
@@ -3833,7 +4092,7 @@
   <div class="router-inner">
     <div class="reveal">
       <p class="router-eyebrow">The router</p>
-      <h2 id="router-headline" class="router-headline">Don't memorize 28 commands.</h2>
+      <h2 id="router-headline" class="router-headline">Don't memorize 71 commands.</h2>
       <p class="router-sub">Ask in plain words. The umbrella skill, <code>/suede-workflow-skills</code>, reads the request and loads the right lane — one install, every skill reachable. Agents that speak MCP get the same routing as structured tools: <code>list_suede_skills</code> finds the skill, <code>get_suede_skill</code> loads it.</p>
       <p class="router-note">The optional MCP server ships in the repo, runs local with zero dependencies, and adds install options, audit scaffolds, grading, and QA checklists on top of discovery. Wire-up lives on the <a href="plugins.html" style="color:#888880;border-bottom:1px solid rgba(136,136,128,0.35);">install page</a>.</p>
     </div>
@@ -3876,7 +4135,7 @@
 <section class="stats-band" aria-label="By the numbers">
   <div class="stats-inner reveal">
     <div class="stat">
-      <div class="stat-num"><span class="count" data-count="28">28</span></div>
+      <div class="stat-num"><span class="count" data-count="71">71</span></div>
       <div class="stat-label">Public skills</div>
     </div>
     <div class="stat">
@@ -3932,7 +4191,7 @@
         <code>npx skills add JasonColapietro/suede-creator-skills</code>
       </div>
       <div class="install-alt">
-        <span class="install-alt-label">Prefer a clone — copies all 70 into ~/.claude/skills/</span>
+        <span class="install-alt-label">Prefer a clone — copies all 71 into ~/.claude/skills/</span>
         <code>git clone https://github.com/JasonColapietro/suede-creator-skills.git &amp;&amp; bash suede-creator-skills/install.sh</code>
       </div>
     </div>
@@ -3954,13 +4213,13 @@
 <section id="catalog" style="background:#080808;padding:84px 0;font-family:system-ui,-apple-system,sans-serif;">
   <div class="catalog-inner">
     <p class="catalog-eyebrow reveal">The full pack</p>
-    <h2 class="catalog-headline reveal reveal-d1">All 70 skills.</h2>
+    <h2 class="catalog-headline reveal reveal-d1">All 71 skills.</h2>
     <p class="catalog-sub reveal reveal-d2">Every skill is a plain-Markdown <code style="font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:15px;color:#c8a96e;">SKILL.md</code> folder you can read before you install it. Click any row for its docs, or browse the <a href="skills/">full catalog with install paths</a>.</p>
 
     <div class="catalog-lane reveal" id="lane-orchestration">
       <div class="catalog-lane-head">
         <span class="catalog-lane-name">Agent orchestration &amp; workflows</span>
-        <span class="catalog-lane-count">6 skills</span>
+        <span class="catalog-lane-count">8 skills</span>
       </div>
       <a class="catalog-row" href="skills/suede-full-send.html">
         <span class="catalog-skill">suede-full-send</span>
@@ -3970,6 +4229,16 @@
       <a class="catalog-row" href="skills/suede-agent-teams.html">
         <span class="catalog-skill">suede-agent-teams</span>
         <span class="catalog-desc">Coordinate agent lanes with WIP collision detection, RFC mode, rollback trees, and a signed handoff</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-ship.html">
+        <span class="catalog-skill">suede-ship</span>
+        <span class="catalog-desc">The canonical orchestration DAG for repo changes: research, red-teamed planning, disjoint lanes, adversarial review, release verification</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-ship-copy.html">
+        <span class="catalog-skill">suede-ship-copy</span>
+        <span class="catalog-desc">The same DAG rebuilt for one high-stakes piece of writing: blind research, claim audit, section writers, refutation, publish gate</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-codex-fleet.html">
@@ -3997,7 +4266,7 @@
     <div class="catalog-lane reveal" id="lane-code">
       <div class="catalog-lane-head">
         <span class="catalog-lane-name">Code quality &amp; shipping</span>
-        <span class="catalog-lane-count">4 skills</span>
+        <span class="catalog-lane-count">5 skills</span>
       </div>
       <a class="catalog-row" href="skills/suede-code.html">
         <span class="catalog-skill">suede-code</span>
@@ -4017,6 +4286,11 @@
       <a class="catalog-row" href="skills/suede-ci-gate.html">
         <span class="catalog-skill">suede-ci-gate</span>
         <span class="catalog-desc">CI that gates the merge: stack and lockfile detection, one required check, branch protection</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-clip-to-guide.html">
+        <span class="catalog-skill">suede-clip-to-guide</span>
+        <span class="catalog-desc">Turn a clip, talk moment, or transcript into a funnel package with rights routing and an evidence gate</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
     </div>
@@ -4041,7 +4315,7 @@
     <div class="catalog-lane reveal" id="lane-design">
       <div class="catalog-lane-head">
         <span class="catalog-lane-name">Design, copy &amp; SEO</span>
-        <span class="catalog-lane-count">9 skills</span>
+        <span class="catalog-lane-count">10 skills</span>
       </div>
       <a class="catalog-row" href="skills/johnny-suede-design.html">
         <span class="catalog-skill">johnny-suede-design</span>
@@ -4093,6 +4367,56 @@
         <span class="catalog-desc">QA pass for the bundled Suede Skills MCP server before it ships</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
+    </div>
+
+    <div class="catalog-lane reveal" id="lane-marketing">
+      <div class="catalog-lane-head">
+        <span class="catalog-lane-name">Marketing &amp; growth</span>
+        <span class="catalog-lane-count">39 skills</span>
+      </div>
+      <p class="catalog-lane-lead">The whole growth org in one lane: paid acquisition, outbound, PR, pricing and offers, lifecycle and retention, and the measurement layer that keeps them honest. Every skill links to its docs page.</p>
+      <div class="catalog-chips">
+        <a class="catalog-chip" href="skills/suede-ads.html">suede-ads</a>
+        <a class="catalog-chip" href="skills/suede-ad-creative.html">suede-ad-creative</a>
+        <a class="catalog-chip" href="skills/suede-cold-email.html">suede-cold-email</a>
+        <a class="catalog-chip" href="skills/suede-prospecting.html">suede-prospecting</a>
+        <a class="catalog-chip" href="skills/suede-public-relations.html">suede-public-relations</a>
+        <a class="catalog-chip" href="skills/suede-directory-submissions.html">suede-directory-submissions</a>
+        <a class="catalog-chip" href="skills/suede-pricing.html">suede-pricing</a>
+        <a class="catalog-chip" href="skills/suede-offers.html">suede-offers</a>
+        <a class="catalog-chip" href="skills/suede-paywalls.html">suede-paywalls</a>
+        <a class="catalog-chip" href="skills/suede-signup.html">suede-signup</a>
+        <a class="catalog-chip" href="skills/suede-onboarding.html">suede-onboarding</a>
+        <a class="catalog-chip" href="skills/suede-churn-prevention.html">suede-churn-prevention</a>
+        <a class="catalog-chip" href="skills/suede-emails.html">suede-emails</a>
+        <a class="catalog-chip" href="skills/suede-referrals.html">suede-referrals</a>
+        <a class="catalog-chip" href="skills/suede-co-marketing.html">suede-co-marketing</a>
+        <a class="catalog-chip" href="skills/suede-community-marketing.html">suede-community-marketing</a>
+        <a class="catalog-chip" href="skills/suede-lead-magnets.html">suede-lead-magnets</a>
+        <a class="catalog-chip" href="skills/suede-free-tools.html">suede-free-tools</a>
+        <a class="catalog-chip" href="skills/suede-sms.html">suede-sms</a>
+        <a class="catalog-chip" href="skills/suede-marketing-loops.html">suede-marketing-loops</a>
+        <a class="catalog-chip" href="skills/suede-analytics.html">suede-analytics</a>
+        <a class="catalog-chip" href="skills/suede-ab-testing.html">suede-ab-testing</a>
+        <a class="catalog-chip" href="skills/suede-revops.html">suede-revops</a>
+        <a class="catalog-chip" href="skills/suede-sales-enablement.html">suede-sales-enablement</a>
+        <a class="catalog-chip" href="skills/suede-programmatic-seo.html">suede-programmatic-seo</a>
+        <a class="catalog-chip" href="skills/suede-content-strategy.html">suede-content-strategy</a>
+        <a class="catalog-chip" href="skills/suede-marketing-plan.html">suede-marketing-plan</a>
+        <a class="catalog-chip" href="skills/suede-marketing-psychology.html">suede-marketing-psychology</a>
+        <a class="catalog-chip" href="skills/suede-marketing-council.html">suede-marketing-council</a>
+        <a class="catalog-chip" href="skills/suede-instagram-growth.html">suede-instagram-growth</a>
+        <a class="catalog-chip" href="skills/suede-social.html">suede-social</a>
+        <a class="catalog-chip" href="skills/suede-aso.html">suede-aso</a>
+        <a class="catalog-chip" href="skills/suede-video.html">suede-video</a>
+        <a class="catalog-chip" href="skills/suede-image.html">suede-image</a>
+        <a class="catalog-chip" href="skills/suede-product-marketing.html">suede-product-marketing</a>
+        <a class="catalog-chip" href="skills/suede-competitors.html">suede-competitors</a>
+        <a class="catalog-chip" href="skills/suede-competitor-profiling.html">suede-competitor-profiling</a>
+        <a class="catalog-chip" href="skills/suede-customer-research.html">suede-customer-research</a>
+        <a class="catalog-chip" href="skills/suede-marketing-ideas.html">suede-marketing-ideas</a>
+      </div>
+      <p class="catalog-lane-credit">38 of these are adapted from <a href="https://github.com/coreyhaines31/marketingskills" target="_blank" rel="noopener">marketingskills by Corey Haines</a>, MIT licensed — the credit belongs there.</p>
     </div>
 
     <div class="catalog-lane reveal" id="lane-creator">
@@ -4256,6 +4580,58 @@
 </section>
 
 <!-- GOLD SHIP BAND -->
+<!-- FIELD NOTES -->
+<section id="essays" aria-labelledby="essays-headline">
+  <div class="essays-inner">
+    <p class="essays-eyebrow reveal">Field notes</p>
+    <h2 id="essays-headline" class="essays-headline reveal reveal-d1">Why it's built this way.</h2>
+    <p class="essays-sub reveal reveal-d1">The design decisions behind the pack, written up as essays: how 71 skills stay cheap to carry, how they route without colliding, and why your memory file should be jealous.</p>
+    <div class="essays-list reveal reveal-d2">
+      <a class="essay-row" href="blog/progressive-disclosure-ship-dag-and-mcp.html">
+        <span class="essay-date">Aug 2026</span>
+        <span class="essay-copy">
+          <span class="essay-title">71 skills installed. Your agent reads almost none of them.</span>
+          <span class="essay-hook">Progressive disclosure, the ship DAG, and the MCP layer</span>
+        </span>
+        <span class="essay-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="essay-row" href="blog/why-breadth-is-free.html">
+        <span class="essay-date">Aug 2026</span>
+        <span class="essay-copy">
+          <span class="essay-title">Why breadth is free now, and what that changes</span>
+          <span class="essay-hook">The economics of a 71-skill pack</span>
+        </span>
+        <span class="essay-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="essay-row" href="blog/not-for-the-line-that-makes-a-pack-work.html">
+        <span class="essay-date">Aug 2026</span>
+        <span class="essay-copy">
+          <span class="essay-title">NOT FOR: the two words that make a big skill pack work</span>
+          <span class="essay-hook">How skills route without colliding</span>
+        </span>
+        <span class="essay-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="essay-row" href="blog/memory-belongs-in-skills.html">
+        <span class="essay-date">Aug 2026</span>
+        <span class="essay-copy">
+          <span class="essay-title">Your memory file is a tax you pay on every prompt</span>
+          <span class="essay-hook">Why memory belongs in skills</span>
+        </span>
+        <span class="essay-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="essay-row" href="blog/android-recommend-next-action-and-workflows.html">
+        <span class="essay-date">Jul 2026</span>
+        <span class="essay-copy">
+          <span class="essay-title">Two new lanes: a next-action recommender and a one-prompt Android app factory</span>
+          <span class="essay-hook">What shipped and why it exists</span>
+        </span>
+        <span class="essay-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+    </div>
+    <p class="essays-more reveal reveal-d2"><a href="blog/">All essays -&gt;</a></p>
+  </div>
+</section>
+
 <section id="ship-band" aria-labelledby="ship-band-headline">
   <div class="ship-band-inner reveal">
     <p class="ship-band-kicker">Two commands from here</p>
@@ -4283,7 +4659,7 @@
     <div class="reveal reveal-d1">
       <details class="faq-item" open>
         <summary>What are Agent Skills?</summary>
-        <p>Agent Skills are SKILL.md folders that Claude Code and OpenAI Codex load on demand to follow a documented workflow. This pack ships 70 of them under the MIT license: outcome-bound orchestration, code review and grading for web stacks and Swift/iOS, a site-to-iOS app conversion workflow, a one-prompt Android app factory, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, marketing and growth, and a creator toolkit for music rights and release prep. Every folder is plain Markdown you can read before you install it.</p>
+        <p>Agent Skills are SKILL.md folders that Claude Code and OpenAI Codex load on demand to follow a documented workflow. This pack ships 71 of them under the MIT license: outcome-bound orchestration, code review and grading for web stacks and Swift/iOS, a site-to-iOS app conversion workflow, a one-prompt Android app factory, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, marketing and growth, and a creator toolkit for music rights and release prep. Every folder is plain Markdown you can read before you install it.</p>
       </details>
       <details class="faq-item">
         <summary>How do I install the pack?</summary>
@@ -4311,6 +4687,10 @@
       <span class="footer-name">Built by <strong>Jason Colapietro</strong> / Suede Labs AI</span>
     </div>
     <div class="footer-links">
+      <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>
+      <span class="footer-divider" aria-hidden="true">|</span>
+      <a href="blog/">Blog</a>
+      <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://x.com/johnnysuede" target="_blank" rel="noopener">@johnnysuede</a>
       <span class="footer-divider" aria-hidden="true">|</span>
       <a href="https://suedeai.ai" target="_blank" rel="noopener">suedeai.ai</a>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Install Suede Creator Skills | Claude Code, Codex, and MCP</title>
-  <meta name="description" content="Install all 70 Suede Creator Skills for Claude Code, Codex, and other supported agents. Add the optional MCP for discovery, audits, grading, and QA.">
+  <meta name="description" content="Install all 71 Suede Creator Skills for Claude Code, Codex, and other supported agents. Add the optional MCP for discovery, audits, grading, and QA.">
   <meta name="author" content="Jason Colapietro">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
   <link rel="canonical" href="https://skills.suedeai.ai/plugins.html">
@@ -324,7 +324,7 @@
 
     <div class="prose">
       <p>Want less than the full pack? Three focused subsets install the same way: <code>/plugin install suede-marketing@suede</code> (40 skills: paid acquisition, outbound, pricing, offers, lifecycle, Instagram growth, and analytics), <code>/plugin install suede-agent-workflows@suede</code> (orchestration, workflows, evals), or <code>/plugin install suede-code@suede</code> (review, grade, ship-gate).</p>
-      <p>Prefer a clone? <code>install.sh</code> copies all 70 skills into <code>~/.claude/skills/</code> and never touches skills that are not part of the pack:</p>
+      <p>Prefer a clone? <code>install.sh</code> copies all 71 skills into <code>~/.claude/skills/</code> and never touches skills that are not part of the pack:</p>
     </div>
 
     <div class="terminal">
@@ -360,7 +360,7 @@
 
   <section class="shell" id="codex">
     <h2>Codex — install the pack or pick your set</h2>
-    <p class="section-sub">The Codex-native plugin installs all 70 skills and registers both read-only MCP discovery profiles. Add the repo marketplace, install the pack, then restart Codex.</p>
+    <p class="section-sub">The Codex-native plugin installs all 71 skills and registers both read-only MCP discovery profiles. Add the repo marketplace, install the pack, then restart Codex.</p>
 
     <div class="terminal">
       <div class="terminal-bar" aria-hidden="true">

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -11,7 +11,7 @@
   <link rel="icon" href="../assets/suede-ai-logo-transparent.png" type="image/png">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Suede Creator Skills Docs">
-  <meta property="og:description" content="Read the public docs for all 70 Suede skills: Full Send orchestration, agent teams, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copy, SEO/AEO/GEO/AI EO, music/IP, and creator rights.">
+  <meta property="og:description" content="Read the public docs for all 71 Suede skills: Full Send orchestration, agent teams, code review and A-F grading, CI ship-gates, AI evals, Suedify, Instagram growth, design, copy, SEO/AEO/GEO/AI EO, music/IP, and creator rights.">
   <meta property="og:url" content="https://skills.suedeai.ai/skills/">
   <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:card" content="summary_large_image">
@@ -134,7 +134,9 @@
     }
     .nav-cta:hover { background: rgba(200, 169, 110, 0.16); }
 
-    .page-head { padding: 88px 0 0; }
+    /* padding-top only: the shorthand here used to reset .shell's 40px side
+       padding, leaving the whole hero block 40px left of every section below. */
+    .page-head { padding-top: 88px; }
     .eyebrow {
       font-size: 11px; font-weight: 600; letter-spacing: 0.18em;
       text-transform: uppercase; color: var(--red-text); margin-bottom: 24px;
@@ -240,8 +242,67 @@
     .btn--red { border-color: var(--red); color: var(--cream); background: rgba(139, 26, 26, 0.1); }
     .btn--red:hover { background: rgba(139, 26, 26, 0.22); color: var(--cream); }
 
+    /* Lane map + jump nav */
+    .lanemap {
+      margin: 44px 0 0; max-width: 900px;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
+      padding: 24px 26px 20px;
+    }
+    .lanemap-head {
+      display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between;
+      gap: 6px 18px; padding-bottom: 16px; margin-bottom: 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .lanemap-title {
+      font-size: 12px; font-weight: 600; letter-spacing: 0.16em;
+      text-transform: uppercase; color: var(--gold);
+    }
+    .lanemap-hint { font-size: 12.5px; color: var(--muted); }
+    .lanemap-svg { display: block; width: 100%; height: auto; }
+    .lanemap-jump {
+      display: flex; flex-wrap: wrap; gap: 8px;
+      margin-top: 22px; padding-top: 20px; border-top: 1px solid var(--border);
+    }
+    .lanemap-jump a {
+      display: inline-flex; align-items: center; min-height: 44px;
+      padding: 8px 15px; border: 1px solid var(--border); border-radius: 999px;
+      font-family: var(--mono); font-size: 12.5px; color: var(--cream);
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
+    }
+    .lanemap-jump a:hover { color: var(--gold); border-color: var(--gold); background: #141414; }
+    @media (max-width: 720px) {
+      .lanemap { padding: 20px 16px 16px; }
+      .lanemap-svg { min-width: 520px; }
+      .lanemap-scroll { overflow-x: auto; }
+    }
+
+    /* Field notes */
+    .notes {
+      margin-top: 32px; border: 1px solid var(--border);
+      border-radius: 6px; background: var(--card); overflow: hidden;
+    }
+    .note-row {
+      display: grid; grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center; gap: 20px;
+      padding: 18px 22px; border-bottom: 1px solid var(--border);
+      transition: background 0.15s ease;
+    }
+    .note-row:last-child { border-bottom: 0; }
+    .note-row:hover { background: #141414; }
+    .note-date { font-family: var(--mono); font-size: 12px; color: var(--muted); white-space: nowrap; }
+    .note-copy { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+    .note-title { font-size: 15.5px; font-weight: 600; color: var(--cream); line-height: 1.4; }
+    .note-row:hover .note-title { color: var(--gold); }
+    .note-hook { font-size: 13px; color: var(--muted); line-height: 1.5; }
+    .note-arrow { font-family: var(--mono); font-size: 13px; color: var(--muted); transition: color 0.15s, transform 0.15s; }
+    .note-row:hover .note-arrow { color: var(--gold); transform: translateX(3px); }
+    @media (max-width: 720px) {
+      .note-row { grid-template-columns: 1fr; row-gap: 6px; }
+      .note-arrow { display: none; }
+    }
+
     /* Catalog lanes */
-    .lane { margin-top: 44px; }
+    .lane { margin-top: 44px; scroll-margin-top: 84px; }
     .lane-head {
       display: flex; align-items: baseline; gap: 12px;
       padding-bottom: 12px; border-bottom: 1px solid var(--border);
@@ -362,8 +423,8 @@
 <main id="main" tabindex="-1">
   <div class="shell page-head">
     <p class="eyebrow">Skill catalog</p>
-    <h1>70 skills. One honest line each.</h1>
-    <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Six lanes:</strong> orchestration, code review and CI, design and copy, SEO and visibility, iOS and Android shipping, and creator rights. This catalog links each skill to its deep docs and its source folder on GitHub.</p>
+    <h1>71 skills. One honest line each.</h1>
+    <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Eight lanes:</strong> orchestration and routing, code review and CI, design and copy, SEO and launch, iOS and Android shipping, consumer recovery, the creator toolkit, and 39 marketing and growth skills. This catalog links each skill to its deep docs and its source folder on GitHub. No sign-up, no telemetry, nothing to uninstall but a folder.</p>
 
     <a id="hero-shiplog" href="#changelog" aria-label="Ship log: 223 commits in 10 weeks. Latest entry August 4, 2026: Instagram growth gets an evidence system. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
@@ -396,12 +457,66 @@
         <button class="term-copy" type="button" data-copy aria-label="Copy install commands">Copy</button>
       </div>
     </div>
-    <p class="term-note">Works in Claude Code today; Codex and other agents install from the <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub repo</a>. All paths on the <a href="../plugins.html">install page</a>.</p>
+    <p class="term-note">Codex installs the same pack natively with <code>codex plugin add suede-skills@suede-codex</code>; Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+
+    <div class="lanemap">
+      <div class="lanemap-head">
+        <span class="lanemap-title">Where the 71 live</span>
+        <span class="lanemap-hint">Jump to a lane</span>
+      </div>
+      <svg class="lanemap-svg" viewBox="0 0 1000 300" role="img" aria-labelledby="lanemap-t lanemap-d" xmlns="http://www.w3.org/2000/svg">
+        <title id="lanemap-t">Skills per lane</title>
+        <desc id="lanemap-d">Marketing and growth 39, orchestration and routing 7, creator toolkit 6, code review and CI 5, design and copy 5, SEO visibility and launch 5, apps iOS and Android 2, consumer recovery 2.</desc>
+        <g font-family="system-ui, -apple-system, sans-serif">
+          <text x="250" y="30" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Marketing &amp; growth</text>
+          <rect x="264" y="17" width="620" height="18" rx="4" fill="#c8a96e"/>
+          <text x="898" y="31" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">39</text>
+
+          <text x="250" y="66" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Orchestration &amp; routing</text>
+          <rect x="264" y="53" width="111" height="18" rx="4" fill="#c8a96e"/>
+          <text x="389" y="67" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">7</text>
+
+          <text x="250" y="102" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Creator toolkit</text>
+          <rect x="264" y="89" width="95" height="18" rx="4" fill="#c8a96e"/>
+          <text x="373" y="103" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">6</text>
+
+          <text x="250" y="138" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Code review &amp; CI</text>
+          <rect x="264" y="125" width="79" height="18" rx="4" fill="#c8a96e"/>
+          <text x="357" y="139" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5</text>
+
+          <text x="250" y="174" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Design &amp; copy</text>
+          <rect x="264" y="161" width="79" height="18" rx="4" fill="#c8a96e"/>
+          <text x="357" y="175" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5</text>
+
+          <text x="250" y="210" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">SEO, visibility &amp; launch</text>
+          <rect x="264" y="197" width="79" height="18" rx="4" fill="#c8a96e"/>
+          <text x="357" y="211" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">5</text>
+
+          <text x="250" y="246" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Apps: iOS &amp; Android</text>
+          <rect x="264" y="233" width="32" height="18" rx="4" fill="#c8a96e"/>
+          <text x="310" y="247" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+
+          <text x="250" y="282" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Consumer recovery</text>
+          <rect x="264" y="269" width="32" height="18" rx="4" fill="#c8a96e"/>
+          <text x="310" y="283" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">2</text>
+        </g>
+      </svg>
+      <nav class="lanemap-jump" aria-label="Jump to a catalog lane">
+        <a href="#lane-orchestration">Orchestration</a>
+        <a href="#lane-code">Code review &amp; CI</a>
+        <a href="#lane-design">Design &amp; copy</a>
+        <a href="#lane-seo">SEO &amp; launch</a>
+        <a href="#lane-apps">Apps</a>
+        <a href="#lane-recovery">Recovery</a>
+        <a href="#lane-creator">Creator toolkit</a>
+        <a href="#lane-marketing">Marketing &amp; growth</a>
+      </nav>
+    </div>
   </div>
 
   <section class="shell" aria-labelledby="start-here">
     <h2 id="start-here">Start here</h2>
-    <p class="section-sub">Five entry points cover most sessions. Everything else is one lane down.</p>
+    <p class="section-sub">Six entry points cover most sessions. Everything else is one lane down.</p>
     <div class="grid-2">
       <article class="cell cell--red">
         <span class="cell-label">The intent router</span>
@@ -450,6 +565,16 @@
           <a class="btn" href="suede-visibility-grader.html">Visibility grader</a>
         </div>
       </article>
+      <article class="cell">
+        <span class="cell-label">The growth org</span>
+        <h3>39 marketing &amp; growth skills</h3>
+        <p>The largest lane in the pack: paid acquisition and outbound, pricing and offers, lifecycle and retention, and the measurement layer that keeps the rest honest. Start with the plan, then work the channel you actually need.</p>
+        <div class="btn-row">
+          <a class="btn btn--gold" href="suede-marketing-plan.html">Marketing plan</a>
+          <a class="btn" href="suede-pricing.html">Pricing</a>
+          <a class="btn" href="#lane-marketing">All 39 -&gt;</a>
+        </div>
+      </article>
     </div>
   </section>
 
@@ -457,7 +582,7 @@
     <h2 id="catalog">All 71 skill folders</h2>
     <p class="section-sub">Grouped by lane. Rows link to the deep docs page; every folder is inspectable on GitHub before you install it.</p>
 
-    <div class="lane">
+    <div class="lane" id="lane-orchestration">
       <div class="lane-head"><h3>Orchestration &amp; routing</h3><span class="lane-count">7</span></div>
       <a class="row" href="suede-ship.html"><b>suede-ship</b><span>Canonical shipping DAG: scout, multi-lens research, lane plan with file ownership, parallel build, adversarial refute, and an integration gate. Halts on hazards and collisions.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="suede-ship-copy.html"><b>suede-ship-copy</b><span>The same graph for copy: blind research lenses, an audit of every agent-generated claim, one message per section, adversarial review, and a deslop pass. Never audits what you supplied.</span><span class="arrow">-&gt;</span></a>
@@ -468,7 +593,7 @@
       <a class="row" href="suede-recommend-next-action.html"><b>suede-recommend-next-action</b><span>Scores candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then hands back one recommendation as a short runnable prompt.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-code">
       <div class="lane-head"><h3>Code review &amp; CI</h3><span class="lane-count">5</span></div>
       <a class="row" href="./suede-code.html"><b>suede-code</b><span>Unified code review and A-F grading for correctness, security, data/state, deploy readiness, and ship risk.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-code-review.html"><b>suede-code-review</b><span>Deep diff review with TypeScript, React, Next.js, Swift/mobile, OWASP, and database checklists plus fix briefs and a grade.</span><span class="arrow">-&gt;</span></a>
@@ -477,7 +602,7 @@
       <a class="row" href="suede-ai-eval.html"><b>suede-ai-eval</b><span>AI-SPECs, failure-mode rubrics, eval cases, acceptance gates, and coverage audits for AI-powered product surfaces.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-design">
       <div class="lane-head"><h3>Design &amp; copy</h3><span class="lane-count">5</span></div>
       <a class="row" href="johnny-suede-write.html"><b>johnny-suede-write</b><span>Full writing mode for Suede or a supplied company: copy, company voice, product and mobile copy, SEO/AEO/AI EO, CTAs, launch copy, and anti-slop line editing.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="johnny-suede-design.html"><b>johnny-suede-design</b><span>Full design mode for Suede or a supplied company: Suedify, mobile and product surfaces, product screenshots, UI polish, design-system QA, visual QA, visibility grading, implementation handoff, company voice, and copy.</span><span class="arrow">-&gt;</span></a>
@@ -486,7 +611,7 @@
       <a class="row" href="./suede-deslop.html"><b>suede-deslop</b><span>Strips AI writing patterns from prose before it ships: merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-seo">
       <div class="lane-head"><h3>SEO, visibility &amp; launch</h3><span class="lane-count">5</span></div>
       <a class="row" href="./suede-seo-audit.html"><b>suede-seo-audit</b><span>Search intent, answer intent, metadata, schema, links, and trust checks.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="suede-visibility-grader.html"><b>suede-visibility-grader</b><span>A-F grading for findability, first-screen clarity, CTA pull, proof, AI readability, rendered design signal, evidence, grade caps, and Google and Gemini result surfaces.</span><span class="arrow">-&gt;</span></a>
@@ -495,19 +620,19 @@
       <a class="row" href="./suede-mcp-qa.html"><b>suede-mcp-qa</b><span>MCP tools, resources, prompts, catalog output, and docs alignment.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-apps">
       <div class="lane-head"><h3>Apps: iOS &amp; Android</h3><span class="lane-count">2</span></div>
       <a class="row" href="./site-to-ios-app.html"><b>site-to-ios-app</b><span>Website to App Store-ready iOS app: URL audit, 4.2 wrapper-risk gate, shell strategy, and release gate.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./android-app-factory.html"><b>android-app-factory</b><span>One prompt to a Play Store-ready native Android app: Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, signed release.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-recovery">
       <div class="lane-head"><h3>Consumer recovery</h3><span class="lane-count">2</span></div>
       <a class="row" href="./amazon-returns-recovery.html"><b>amazon-returns-recovery</b><span><b>Bezos's worst nightmare:</b> scans Amazon order history for restocking fees and short refunds, then drives Amazon live chat until they're waived. $448.31 recovered in real cases, including a denial overturned after the return window closed.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./subscription-recovery.html"><b>subscription-recovery</b><span>Audits any recurring subscription (Netflix, Spotify, gyms, App Store, Google Play, PayPal) and cancels or negotiates a refund through that service's own support.</span><span class="arrow">-&gt;</span></a>
     </div>
 
-    <div class="lane">
+    <div class="lane" id="lane-creator">
       <div class="lane-head"><h3>Creator toolkit</h3><span class="lane-count">6</span></div>
       <a class="row" href="./suede-clip-to-guide.html"><b>suede-clip-to-guide</b><span>Turn a clip, talk moment, or transcript into a repeatable clip-to-guide funnel package with rights routing and an evidence gate.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-campaign-in-a-box.html"><b>suede-campaign-in-a-box</b><span>Packages rollout phases, copy, content calendar, fan actions, page sections, and next moves.</span><span class="arrow">-&gt;</span></a>
@@ -516,7 +641,7 @@
       <a class="row" href="suede-rights-passport.html"><b>suede-rights-passport</b><span>Local creator rights package with provenance, credits, split notes, license notes, and structured metadata.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-rights-audit.html"><b>suede-rights-audit</b><span>Ownership, contributor, sample, license, split, and intake gap audit.</span><span class="arrow">-&gt;</span></a>
     </div>
-    <div class="lane">
+    <div class="lane" id="lane-marketing">
       <div class="lane-head"><h3>Marketing &amp; growth</h3><span class="lane-count">39</span></div>
       <a class="row" href="./suede-ab-testing.html"><b>suede-ab-testing</b><span>Test so the result means something.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-ad-creative.html"><b>suede-ad-creative</b><span>Produce ad creative at volume.</span><span class="arrow">-&gt;</span></a>
@@ -557,6 +682,53 @@
       <a class="row" href="./suede-sms.html"><b>suede-sms</b><span>Run SMS without getting blocked or resented.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-social.html"><b>suede-social</b><span>Run social as a channel rather than a chore.</span><span class="arrow">-&gt;</span></a>
       <a class="row" href="./suede-video.html"><b>suede-video</b><span>Plan and produce marketing video.</span><span class="arrow">-&gt;</span></a>
+    </div>
+  </section>
+
+  <section class="shell" aria-labelledby="field-notes">
+    <h2 id="field-notes">Field notes</h2>
+    <p class="section-sub">Why the pack is shaped this way: how 71 skills stay cheap to carry, how they route without colliding, and what the ship DAG is actually doing.</p>
+    <div class="notes">
+      <a class="note-row" href="../blog/progressive-disclosure-ship-dag-and-mcp.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">71 skills installed. Your agent reads almost none of them.</span>
+          <span class="note-hook">Progressive disclosure, the ship DAG, and the MCP layer</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="../blog/why-breadth-is-free.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">Why breadth is free now, and what that changes</span>
+          <span class="note-hook">The economics of a 71-skill pack</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="../blog/not-for-the-line-that-makes-a-pack-work.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">NOT FOR: the two words that make a big skill pack work</span>
+          <span class="note-hook">How every row in this catalog stays out of the others' way</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="../blog/memory-belongs-in-skills.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">Your memory file is a tax you pay on every prompt</span>
+          <span class="note-hook">Why memory belongs in skills</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="../blog/">
+        <span class="note-date">Archive</span>
+        <span class="note-copy">
+          <span class="note-title">All essays</span>
+          <span class="note-hook">The full writing archive</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
     </div>
   </section>
 

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -934,6 +934,31 @@ const countChecks = [
   { file: "README.md", label: "skills badge URL value", re: /img\.shields\.io\/badge\/skills-(\d+)-c8a96e/, expected: totalSkillCount },
   { file: "README.md", label: "skills badge alt text", re: /!\[Skills: (\d+)\]/, expected: totalSkillCount },
   { file: "README.md", label: "hero alt skill count", re: /(\d+) open-source skills for Claude Code and Codex/, expected: totalSkillCount },
+  // Homepage prose counts. All five of these sat at stale values (70, 28,
+  // "six disciplines"-era lane math) while the guarded phrases said 71 —
+  // every count a visitor can read must be pinned, not just the meta tags.
+  { file: "docs/index.html", label: "hero subline skill count", re: /(\d+) open-source skills that read every diff/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "lanes sub skill count", re: /Seven lanes, (\d+) skills, one install/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "catalog headline skill count", re: /All (\d+) skills\./, expected: totalSkillCount },
+  { file: "docs/index.html", label: "stats band public skills count", re: /data-count="(\d+)"/, expected: totalSkillCount },
+  { file: "docs/index.html", label: "router headline command count", re: /memorize (\d+) commands/, expected: totalSkillCount },
+  // Catalog page. Its h1 and og:description sat at 70 while the <title> and
+  // meta description said 71 — the number a browsing visitor actually reads
+  // was the stale one.
+  { file: "docs/skills/index.html", label: "catalog h1 skill count", re: /<h1>(\d+) skills\. One honest line each\./, expected: totalSkillCount },
+  { file: "docs/skills/index.html", label: "catalog og:description count", re: /public docs for all (\d+) Suede skills/, expected: totalSkillCount },
+  { file: "docs/skills/index.html", label: "catalog section heading count", re: /All (\d+) skill folders/, expected: totalSkillCount },
+  { file: "docs/skills/index.html", label: "catalog lane-map graphic count", re: /Where the (\d+) live/, expected: totalSkillCount },
+  // Prose and structured-data counts that sat at 70 across four pages while
+  // the guarded surfaces said 71. Every count a visitor or a crawler reads
+  // gets a guard; historical changelog entries ("the pack moves 68 -> 70")
+  // are deliberately not matched, since those record what was true then.
+  { file: "docs/index.html", label: "pack-ships prose count", re: /This pack ships (\d+) of them under the MIT license/, expected: totalSkillCount, every: true },
+  { file: "docs/index.html", label: "structured-data pack size", re: /pack of (\d+) installable Agent Skills/, expected: totalSkillCount, every: true },
+  { file: "docs/guide.html", label: "guide pack size", re: /pack of (\d+) installable Agent Skills/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "guide skill-docs link count", re: /Browse all (\d+) installable skill folders/, expected: totalSkillCount },
+  { file: "docs/plugins.html", label: "install page meta count", re: /Install all (\d+) Suede Creator Skills/, expected: totalSkillCount },
+  { file: "docs/copy.html", label: "copy bank folder count", re: /It ships (\d+) public SKILL\.md folders/, expected: totalSkillCount },
   // The README hero and pack-map are SVGs with the count baked into the
   // artwork — the rendered number lives in the SVG text node, so README
   // prose alone proves nothing. Guard both graphics.
@@ -1097,6 +1122,33 @@ for (const check of countChecks) {
       if (!heroStrip.includes(tileLabel) && !heroStrip.toLowerCase().includes(tileLabel.toLowerCase())) {
         warn.push(`docs/index.html hero strip omits beat-both category "${category}"`);
       }
+    }
+  }
+}
+
+// Lane-math guard. Three surfaces publish a per-lane breakdown of the pack —
+// the homepage lanes overview, the homepage catalog lane heads, and the skill
+// catalog page's own lane badges. The first two drifted to 27 and 28 while
+// every other number on the page said 71. Each set must sum to the pack size,
+// which also catches a lane added to the prose but not to the breakdown.
+{
+  const catalogPagePath = path.join(repoRoot, "docs/skills/index.html");
+  const catalogPageText = fs.existsSync(catalogPagePath) ? readText(catalogPagePath) : "";
+  const laneSets = [
+    { file: "docs/index.html", label: "lanes overview", re: /class="lane-count">(\d+) skills/g, text: docsRootText },
+    { file: "docs/index.html", label: "catalog lane heads", re: /class="catalog-lane-count">(\d+) skills/g, text: docsRootText },
+    // The catalog page's lane badges are bare numbers, not "N skills".
+    { file: "docs/skills/index.html", label: "lane heads", re: /<span class="lane-count">(\d+)<\/span>/g, text: catalogPageText },
+  ];
+  for (const { file, label, re, text } of laneSets) {
+    const counts = [...text.matchAll(re)].map((m) => Number(m[1]));
+    if (counts.length === 0) {
+      warn.push(`${file} ${label} counts not found — lane-math guard skipped`);
+      continue;
+    }
+    const sum = counts.reduce((a, b) => a + b, 0);
+    if (sum !== totalSkillCount) {
+      fail.push(`${file} ${label} counts sum to ${sum} (${counts.join("+")}), not ${totalSkillCount}`);
     }
   }
 }

--- a/tests/test_neutral_oss_positioning.py
+++ b/tests/test_neutral_oss_positioning.py
@@ -117,8 +117,15 @@ class NeutralOssPositioningTests(unittest.TestCase):
         subset_claim = re.compile(
             r"suede-[a-z-]+@suede(?:</code>|`)\s*\((?:\d+)[^)]*\bskills\b[^)]*\)"
         )
+        # Homepage lane counts are per-lane sizes, not pack-size claims: the
+        # marketing lane legitimately holds 39 skills. They are exempt only in
+        # their structured form (class="lane-count" / "catalog-lane-count"),
+        # because scripts/validate-skill-pack.mjs independently requires each
+        # set of lane counts to sum to the actual pack total. A bare number in
+        # prose is still treated as a stale pack-size claim.
+        lane_count_claim = re.compile(r'class="(?:catalog-)?lane-count">\d+ skills<')
         for surface in ["README.md", "docs/index.html", "docs/guide.html", "docs/plugins.html", "docs/copy.html", "docs/skills/index.html", "docs/llms.txt"]:
-            text = subset_claim.sub("", read(surface))
+            text = lane_count_claim.sub("", subset_claim.sub("", read(surface)))
             for stale in stale_counts:
                 with self.subTest(surface=surface, stale=stale):
                     self.assertNotIn(stale, text)


### PR DESCRIPTION
Same treatment as the README, applied to the two pages people actually browse.

**Homepage (`docs/index.html`)**
- **Full Send pipeline diagram** — a new section rendering the controller → parallel lanes → adversarial reconciliation → proof flow as an inline SVG in the site palette (no new asset requests, scrolls on mobile).
- **Field notes** — links all five published essays, plus an all-essays link. The blog previously appeared only in the nav.
- **Marketing lane in the catalog** — 39 chips, each linking to its own docs page, with the Corey Haines credit inline. That lane was 55% of the pack and was invisible on the homepage.
- Added `suede-ship`, `suede-ship-copy`, and `suede-clip-to-guide` rows; corrected every lane count; footer now carries GitHub and Blog links.

**Catalog (`docs/skills/index.html`)**
- **Lane-map graphic** — "Where the 71 live", a bar chart of all eight lanes, with a **jump-nav** to each. For a 71-row page this is the difference between browsing and scrolling.
- Field notes section, a marketing entry point in Start here, and install copy that reflects the native Codex plugin instead of pointing at the repo.
- **Layout fix**: `.page-head { padding: 88px 0 0 }` was resetting `.shell`'s 40px side padding, so the entire hero block sat 40px left of every section below it. Now `padding-top` only.

**Count sweep** — five surfaces still said **70**: homepage prose and JSON-LD, `guide.html` (meta, JSON-LD, body), `plugins.html`, `copy.html`, and the catalog h1 and `og:description`. All corrected to 71, each with a new validator guard. Historical changelog entries recording `68 -> 70` are deliberately untouched.

**Guards added** — homepage hero/lanes/catalog/stats/router counts, catalog h1 + og:description + section heading + lane-map, and prose/structured-data counts on guide, plugins, and copy bank. The lane-math guard now also covers the catalog page's own lane badges and names the right file per surface.

`node scripts/validate-skill-pack.mjs --strict` and all 29 Python tests pass locally.