### PR TITLE
Fix 'Browse all 70 skills' labels and guard link-label counts

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -19,7 +19,7 @@
     <link rel="preload" as="image" href="./assets/passport-hero.webp" type="image/webp">
     <link rel="image_src" href="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Suede Creator Skills Guide | 70 Agent Skills">
+    <meta property="og:title" content="Suede Creator Skills Guide | 71 Agent Skills">
     <meta property="og:description" content="Read the guide to 71 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.">
     <meta property="og:url" content="https://skills.suedeai.ai/guide.html">
     <meta property="og:site_name" content="Suede Creator Skills">
@@ -67,7 +67,7 @@
             "@type": "WebPage",
             "@id": "https://skills.suedeai.ai/guide.html#webpage",
             "url": "https://skills.suedeai.ai/guide.html",
-            "name": "Suede Creator Skills Guide | 70 Agent Skills",
+            "name": "Suede Creator Skills Guide | 71 Agent Skills",
             "description": "Read the guide to 71 open-source agent skills for Claude Code and Codex: Full Send orchestration, A-F code review, CI, AI evals, Instagram growth, design, SEO, and creator tools.",
             "isPartOf": {
               "@id": "https://skills.suedeai.ai/#website"
@@ -685,7 +685,7 @@
               </a>
 
               <div class="btn-row">
-                <a class="btn btn--gold" href="./skills/">Browse all 70 skills</a>
+                <a class="btn btn--gold" href="./skills/">Browse all 71 skills</a>
                 <a class="btn" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">View GitHub repo</a>
                 <a class="btn" href="#install">Install paths</a>
               </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4197,7 +4197,7 @@
     </div>
 
     <div class="install-links reveal reveal-d2">
-      <a class="install-link install-link-primary" href="skills/">Browse all 70 skills</a>
+      <a class="install-link install-link-primary" href="skills/">Browse all 71 skills</a>
       <a class="install-link install-link-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro suede-creator-skills on GitHub">Star on GitHub</a>
       <a class="install-link" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub repo</a>
       <a class="install-link" href="plugins.html">Codex + MCP install docs</a>
@@ -4646,7 +4646,7 @@
           setTimeout(function(){b.textContent='Copy both commands';},2000);
         }).catch(function(){});
       ">Copy both commands</button>
-      <a class="ship-band-link" href="skills/">Browse all 70 skills</a>
+      <a class="ship-band-link" href="skills/">Browse all 71 skills</a>
     </div>
     <code class="ship-band-cmd">/plugin marketplace add JasonColapietro/suede-creator-skills &rarr; /plugin install suede-skills@suede</code>
   </div>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -308,7 +308,7 @@
 
   <section class="shell" id="claude-code">
     <h2>Claude Code — two lines</h2>
-    <p class="section-sub">Add the marketplace, install the pack. <code>suede-skills</code> installs all 70 skills.</p>
+    <p class="section-sub">Add the marketplace, install the pack. <code>suede-skills</code> installs all 71 skills.</p>
 
     <div class="terminal">
       <div class="terminal-bar" aria-hidden="true">
@@ -422,7 +422,7 @@ codex plugin add suede-skills@suede-codex</code></pre>
     </div>
 
     <div class="btn-row">
-      <a class="btn btn--gold" href="./skills/">Browse all 70 skills</a>
+      <a class="btn btn--gold" href="./skills/">Browse all 71 skills</a>
       <a class="btn" href="./skills/suede-full-send.html">Full Send docs</a>
       <a class="btn" href="./skills/suede-code-grader.html">Code grader docs</a>
       <a class="btn" href="./skills/suede-visibility-grader.html">Visibility grader docs</a>
@@ -487,7 +487,7 @@ codex plugin add suede-skills@suede-codex</code></pre>
         <p class="ship-strip-sub">First install takes two commands. After the marketplace is added, install is one. Every skill is plain Markdown.</p>
         <div class="ship-strip-row">
           <code><span class="prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills &rarr; /plugin install suede-skills@suede</code>
-          <a href="./skills/">Browse all 70 skills</a>
+          <a href="./skills/">Browse all 71 skills</a>
         </div>
       </div>
     </section>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -959,6 +959,15 @@ const countChecks = [
   { file: "docs/guide.html", label: "guide skill-docs link count", re: /Browse all (\d+) installable skill folders/, expected: totalSkillCount },
   { file: "docs/plugins.html", label: "install page meta count", re: /Install all (\d+) Suede Creator Skills/, expected: totalSkillCount },
   { file: "docs/copy.html", label: "copy bank folder count", re: /It ships (\d+) public SKILL\.md folders/, expected: totalSkillCount },
+  // Link labels. "Browse all N skills" is a button on three pages (five
+  // instances) that pointed at a catalog page reading a different number —
+  // the one count a visitor sees immediately before clicking through to be
+  // contradicted. `every` because the phrase repeats within a page.
+  { file: "docs/index.html", label: "browse-all link label", re: /Browse all (\d+) skills/, expected: totalSkillCount, every: true },
+  { file: "docs/guide.html", label: "browse-all link label", re: /Browse all (\d+) skills/, expected: totalSkillCount, every: true },
+  { file: "docs/plugins.html", label: "browse-all link label", re: /Browse all (\d+) skills/, expected: totalSkillCount, every: true },
+  { file: "docs/guide.html", label: "guide title skill count", re: /Suede Creator Skills Guide \| (\d+) Agent Skills/, expected: totalSkillCount, every: true },
+  { file: "docs/plugins.html", label: "umbrella install count", re: /installs all (\d+) skills\./, expected: totalSkillCount },
   // The README hero and pack-map are SVGs with the count baked into the
   // artwork — the rendered number lives in the SVG text node, so README
   // prose alone proves nothing. Guard both graphics.


### PR DESCRIPTION
Caught by verifying the live site after the previous merge, not by the file tree.

Five `Browse all 70 skills` buttons on the homepage, guide, and install page linked straight to a catalog page headed **71 skills** — the last number a visitor reads before the destination contradicts it. The guide's JSON-LD `name` and meta title also said *70 Agent Skills*, and the install page said the umbrella plugin *installs all 70 skills*.

The previous sweep matched longer prose phrases and missed these, because the count here sits in short repeated link text. All five are now guarded with `every: true`, so a second occurrence can't slip past a first-match check.

Historical changelog entries recording `69 -> 70` and `68 -> 70` are deliberately untouched — those record what was true at the time.

`--strict` validator and all 29 Python tests pass locally.