### PR TITLE
Guide and install pages: path map, MCP surface diagram, progressive-disclosure figure

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -532,6 +532,34 @@
       a.rowl:hover .arrow { color: var(--gold); transform: translateX(3px); }
 
       /* Creator flow: a real sequence */
+      /* Progressive-disclosure diagram */
+      .diagram {
+        margin-top: 32px; border: 1px solid var(--border); border-radius: 6px;
+        background: var(--surface); padding: 26px 24px;
+      }
+      .diagram-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+      .diagram-svg { display: block; width: 100%; min-width: 660px; height: auto; }
+      .diagram-note { margin-top: 18px; font-size: 14px; line-height: 1.65; color: var(--muted); max-width: 720px; }
+      .diagram-note a { color: var(--gold); border-bottom: 1px solid rgba(200, 169, 110, 0.35); }
+      .diagram-note a:hover { border-bottom-color: var(--gold); }
+
+      /* Field notes */
+      .notes { margin-top: 32px; border: 1px solid var(--border); border-radius: 6px; background: var(--card); overflow: hidden; }
+      .note-row {
+        display: grid; grid-template-columns: auto minmax(0, 1fr) auto;
+        align-items: center; gap: 20px; padding: 18px 22px;
+        border-bottom: 1px solid var(--border); transition: background 0.15s ease;
+      }
+      .note-row:last-child { border-bottom: 0; }
+      .note-row:hover { background: #141414; }
+      .note-date { font-family: var(--mono); font-size: 12px; color: var(--muted); white-space: nowrap; }
+      .note-copy { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+      .note-title { font-size: 15.5px; font-weight: 600; color: var(--cream); line-height: 1.4; }
+      .note-row:hover .note-title { color: var(--gold); }
+      .note-hook { font-size: 13px; color: var(--muted); line-height: 1.5; }
+      .note-arrow { font-family: var(--mono); font-size: 13px; color: var(--muted); transition: color 0.15s, transform 0.15s; }
+      .note-row:hover .note-arrow { color: var(--gold); transform: translateX(3px); }
+
       .flow { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; margin-top: 32px; }
       .flow-step { min-width: 0; background: var(--card); padding: 22px; }
       .flow-step b { display: block; margin-bottom: 8px; color: var(--gold); font-family: var(--mono); font-size: 14px; font-weight: 500; }
@@ -622,6 +650,9 @@
         section { padding-top: 64px; }
         .rowd, a.rowl { grid-template-columns: 1fr; row-gap: 6px; padding: 17px 0; }
         .flow { grid-template-columns: 1fr; }
+        .diagram { padding: 20px 16px; }
+        .note-row { grid-template-columns: 1fr; row-gap: 6px; }
+        .note-arrow { display: none; }
         .term-body { flex-direction: column; align-items: stretch; }
         .term-code { font-size: 14px; max-width: 100%; }
         .ship-strip { padding: 48px 0; }
@@ -735,9 +766,74 @@
         </div>
       </section>
 
+      <section id="disclosure" aria-labelledby="disclosure-headline">
+        <div class="shell">
+          <h2 id="disclosure-headline">Installing 71 skills does not cost you 71 skills.</h2>
+          <p class="section-sub">The objection to a big pack is always context. It does not apply here: the agent reads a one-line description per skill and loads the body of exactly the one it picks. Everything else stays on disk.</p>
+          <div class="diagram">
+            <div class="diagram-scroll">
+              <svg class="diagram-svg" viewBox="0 0 960 240" role="img" aria-labelledby="disc-t disc-d" xmlns="http://www.w3.org/2000/svg">
+                <title id="disc-t">Progressive disclosure</title>
+                <desc id="disc-d">All 71 skills sit on disk. The agent reads one short description each, matches the request to a single skill, and loads only that skill's full instructions into the context window.</desc>
+                <g font-family="system-ui, -apple-system, sans-serif">
+                  <rect x="2" y="52" width="212" height="136" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+                  <text x="108" y="82" text-anchor="middle" fill="#f0ece4" font-size="14.5" font-weight="800">71 folders on disk</text>
+                  <text x="108" y="102" text-anchor="middle" fill="#888880" font-size="12">costs nothing to have</text>
+                  <g fill="#222222">
+                    <rect x="26" y="118" width="26" height="7" rx="3"/><rect x="58" y="118" width="26" height="7" rx="3"/>
+                    <rect x="90" y="118" width="26" height="7" rx="3"/><rect x="122" y="118" width="26" height="7" rx="3"/>
+                    <rect x="154" y="118" width="26" height="7" rx="3"/>
+                    <rect x="26" y="133" width="26" height="7" rx="3"/><rect x="58" y="133" width="26" height="7" rx="3"/>
+                    <rect x="90" y="133" width="26" height="7" rx="3"/><rect x="122" y="133" width="26" height="7" rx="3"/>
+                    <rect x="154" y="133" width="26" height="7" rx="3"/>
+                    <rect x="26" y="148" width="26" height="7" rx="3"/><rect x="58" y="148" width="26" height="7" rx="3"/>
+                    <rect x="90" y="148" width="26" height="7" rx="3"/><rect x="122" y="148" width="26" height="7" rx="3"/>
+                    <rect x="154" y="148" width="26" height="7" rx="3"/>
+                    <rect x="26" y="163" width="26" height="7" rx="3"/><rect x="58" y="163" width="26" height="7" rx="3"/>
+                    <rect x="90" y="163" width="26" height="7" rx="3"/>
+                  </g>
+                  <rect x="122" y="163" width="26" height="7" rx="3" fill="#c8a96e"/>
+
+                  <path d="M214 120H252" stroke="#c8a96e" stroke-width="1.75"/>
+                  <path d="M252 120l-9 -5v10z" fill="#c8a96e"/>
+
+                  <rect x="256" y="52" width="228" height="136" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+                  <text x="370" y="82" text-anchor="middle" fill="#f0ece4" font-size="14.5" font-weight="800">71 one-line descriptions</text>
+                  <text x="370" y="102" text-anchor="middle" fill="#888880" font-size="12">the only thing always in context</text>
+                  <rect x="278" y="118" width="184" height="9" rx="4" fill="#222222"/>
+                  <rect x="278" y="133" width="184" height="9" rx="4" fill="#222222"/>
+                  <rect x="278" y="148" width="184" height="9" rx="4" fill="#c8a96e"/>
+                  <rect x="278" y="163" width="184" height="9" rx="4" fill="#222222"/>
+
+                  <path d="M484 120H522" stroke="#c8a96e" stroke-width="1.75"/>
+                  <path d="M522 120l-9 -5v10z" fill="#c8a96e"/>
+                  <text x="503" y="110" text-anchor="middle" fill="#888880" font-size="11">match</text>
+
+                  <rect x="526" y="52" width="196" height="136" rx="9" fill="#161616" stroke="#c8a96e" stroke-width="2"/>
+                  <text x="624" y="86" text-anchor="middle" fill="#c8a96e" font-size="15" font-weight="800">1 skill loaded</text>
+                  <text x="624" y="108" text-anchor="middle" fill="#888880" font-size="12">full instructions, on demand</text>
+                  <rect x="548" y="124" width="152" height="9" rx="4" fill="#c8a96e"/>
+                  <rect x="548" y="139" width="152" height="9" rx="4" fill="#c8a96e" opacity="0.75"/>
+                  <rect x="548" y="154" width="120" height="9" rx="4" fill="#c8a96e" opacity="0.5"/>
+
+                  <path d="M722 120H760" stroke="#c8a96e" stroke-width="1.75"/>
+                  <path d="M760 120l-9 -5v10z" fill="#c8a96e"/>
+
+                  <rect x="764" y="52" width="194" height="136" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+                  <text x="861" y="94" text-anchor="middle" fill="#f0ece4" font-size="14.5" font-weight="800">70 stay unread</text>
+                  <text x="861" y="122" text-anchor="middle" fill="#888880" font-size="12">no tokens, no interference,</text>
+                  <text x="861" y="140" text-anchor="middle" fill="#888880" font-size="12">still one prompt away</text>
+                </g>
+              </svg>
+            </div>
+          </div>
+          <p class="diagram-note">This is why breadth is worth having: the marginal cost of the 71st skill is one line of description. <a href="./blog/why-breadth-is-free.html">Why breadth is free now -&gt;</a></p>
+        </div>
+      </section>
+
       <section id="skills">
         <div class="shell">
-          <h2>Seventy-one skills, one portable operating system for agent work.</h2>
+          <h2>71 skills, one portable operating system for agent work.</h2>
           <p class="section-sub">
             The pack leads with coordinated agent teams, code review and A-F grading, CI ship-gates, AI evals, Suedify, design,
             conversion copy, SEO/AEO/GEO/AI EO, visibility grading, site alchemy, launch packaging, and MCP QA,
@@ -925,6 +1021,55 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
             <a class="rowl" href="https://www.amazon.com/dp/B0GD5FX6N6" target="_blank" rel="noopener"><b>Suede Labs: The Human Authenticity Layer</b><span>Ownership, origin, and AI in the creative map.</span><span class="arrow">-&gt;</span></a>
             <a class="rowl" href="https://www.amazon.com/dp/B0GMB2VLXQ" target="_blank" rel="noopener"><b>Proof as Infrastructure</b><span>Durable systems built around proof instead of trust assumptions.</span><span class="arrow">-&gt;</span></a>
             <a class="rowl" href="https://www.amazon.com/dp/B0GRG8LGQQ" target="_blank" rel="noopener"><b>Stake Your Claim</b><span>Creator ownership, authorship, provenance, agents, and durable rights.</span><span class="arrow">-&gt;</span></a>
+          </div>
+        </div>
+      </section>
+
+      <section id="notes" aria-labelledby="notes-headline">
+        <div class="shell">
+          <h2 id="notes-headline">Field notes.</h2>
+          <p class="section-sub">The design decisions behind the pack, written up in full: what a skill costs, how routing avoids collisions, and where memory actually belongs.</p>
+          <div class="notes">
+            <a class="note-row" href="./blog/progressive-disclosure-ship-dag-and-mcp.html">
+              <span class="note-date">Aug 2026</span>
+              <span class="note-copy">
+                <span class="note-title">71 skills installed. Your agent reads almost none of them.</span>
+                <span class="note-hook">Progressive disclosure, the ship DAG, and the MCP layer</span>
+              </span>
+              <span class="note-arrow" aria-hidden="true">-&gt;</span>
+            </a>
+            <a class="note-row" href="./blog/why-breadth-is-free.html">
+              <span class="note-date">Aug 2026</span>
+              <span class="note-copy">
+                <span class="note-title">Why breadth is free now, and what that changes</span>
+                <span class="note-hook">The economics of a 71-skill pack</span>
+              </span>
+              <span class="note-arrow" aria-hidden="true">-&gt;</span>
+            </a>
+            <a class="note-row" href="./blog/not-for-the-line-that-makes-a-pack-work.html">
+              <span class="note-date">Aug 2026</span>
+              <span class="note-copy">
+                <span class="note-title">NOT FOR: the two words that make a big skill pack work</span>
+                <span class="note-hook">How skills route without colliding</span>
+              </span>
+              <span class="note-arrow" aria-hidden="true">-&gt;</span>
+            </a>
+            <a class="note-row" href="./blog/memory-belongs-in-skills.html">
+              <span class="note-date">Aug 2026</span>
+              <span class="note-copy">
+                <span class="note-title">Your memory file is a tax you pay on every prompt</span>
+                <span class="note-hook">Why memory belongs in skills</span>
+              </span>
+              <span class="note-arrow" aria-hidden="true">-&gt;</span>
+            </a>
+            <a class="note-row" href="./blog/">
+              <span class="note-date">Archive</span>
+              <span class="note-copy">
+                <span class="note-title">All essays</span>
+                <span class="note-hook">The full writing archive</span>
+              </span>
+              <span class="note-arrow" aria-hidden="true">-&gt;</span>
+            </a>
           </div>
         </div>
       </section>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -120,7 +120,50 @@
     .nav-cta:hover { background: rgba(200, 169, 110, 0.16); }
 
     /* PAGE HEAD */
-    .page-head { padding: 88px 0 64px; border-bottom: 1px solid var(--hairline); }
+    /* Vertical padding only: the shorthand used to reset .shell's 40px side
+       padding, leaving this block 40px left of every section below it. */
+    .page-head { padding-top: 88px; padding-bottom: 64px; border-bottom: 1px solid var(--hairline); }
+
+    /* Install path map */
+    .pathmap {
+      margin: 40px 0 0; max-width: 900px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 6px; padding: 24px 26px 22px;
+    }
+    .pathmap-head {
+      display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between;
+      gap: 6px 18px; padding-bottom: 16px; margin-bottom: 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .pathmap-title {
+      font-size: 12px; font-weight: 600; letter-spacing: 0.16em;
+      text-transform: uppercase; color: var(--gold);
+    }
+    .pathmap-hint { font-size: 12.5px; color: var(--muted); }
+    .pathmap-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .pathmap-svg { display: block; width: 100%; min-width: 620px; height: auto; }
+
+    /* Field notes */
+    .notes { margin-top: 32px; border: 1px solid var(--border); border-radius: 6px; background: var(--card); overflow: hidden; }
+    .note-row {
+      display: grid; grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: center; gap: 20px; padding: 18px 22px;
+      border-bottom: 1px solid var(--border); transition: background 0.15s ease;
+    }
+    .note-row:last-child { border-bottom: 0; }
+    .note-row:hover { background: #141414; }
+    .note-date { font-family: var(--mono); font-size: 12px; color: var(--muted); white-space: nowrap; }
+    .note-copy { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+    .note-title { font-size: 15.5px; font-weight: 600; color: var(--cream); line-height: 1.4; }
+    .note-row:hover .note-title { color: var(--gold); }
+    .note-hook { font-size: 13px; color: var(--muted); line-height: 1.5; }
+    .note-arrow { font-family: var(--mono); font-size: 13px; color: var(--muted); transition: color 0.15s, transform 0.15s; }
+    .note-row:hover .note-arrow { color: var(--gold); transform: translateX(3px); }
+    @media (max-width: 720px) {
+      .pathmap { padding: 20px 16px 16px; }
+      .note-row { grid-template-columns: 1fr; row-gap: 6px; }
+      .note-arrow { display: none; }
+    }
     .eyebrow {
       font-size: 11px; font-weight: 600; letter-spacing: 0.18em;
       text-transform: uppercase; color: var(--red-text); margin-bottom: 24px;
@@ -244,7 +287,7 @@
     }
     @media (max-width: 720px) {
       .shell { padding: 0 24px; }
-      .page-head { padding: 64px 0 48px; }
+      .page-head { padding-top: 64px; padding-bottom: 48px; }
       .grid-2 { grid-template-columns: 1fr; }
       .row { grid-template-columns: 1fr; row-gap: 6px; padding: 18px 0; }
       .terminal-body { flex-direction: column; align-items: stretch; }
@@ -303,7 +346,64 @@
   <div class="shell page-head">
     <p class="eyebrow">Public installs and MCP</p>
     <h1>Install Suede once. Stop rebuilding the agent brief.</h1>
-    <p class="lead">Seventy-one public skills your agent can load as one workflow. Use <a href="./skills/suede-full-send.html">Suede Full Send</a> for broad, authorized outcomes that need one controller, useful non-colliding lanes, adversarial review, and proof. Install the umbrella to Suedify a target page from a reference URL, rewrite copy, grade visibility, review code A-F, design AI evals, run Instagram growth, ship an iOS or Android app, coordinate agent teams, or package creator campaign and rights evidence. Use MCP when the agent needs structured discovery, install options, audit scaffolds, or QA checklists.</p>
+    <p class="lead">71 public skills your agent can load as one workflow. Use <a href="./skills/suede-full-send.html">Suede Full Send</a> for broad, authorized outcomes that need one controller, useful non-colliding lanes, adversarial review, and proof. Install the umbrella to Suedify a target page from a reference URL, rewrite copy, grade visibility, review code A-F, design AI evals, run Instagram growth, ship an iOS or Android app, coordinate agent teams, or package creator campaign and rights evidence. Use MCP when the agent needs structured discovery, install options, audit scaffolds, or QA checklists.</p>
+
+    <div class="pathmap">
+      <div class="pathmap-head">
+        <span class="pathmap-title">Which install is yours</span>
+        <span class="pathmap-hint">Every path lands the same 71 skills</span>
+      </div>
+      <div class="pathmap-scroll">
+        <svg class="pathmap-svg" viewBox="0 0 980 300" role="img" aria-labelledby="pathmap-t pathmap-d" xmlns="http://www.w3.org/2000/svg">
+          <title id="pathmap-t">Install paths</title>
+          <desc id="pathmap-d">Claude Code installs the plugin in two lines. Codex installs the Codex-native plugin. Cursor, Copilot, and Windsurf install through the skills CLI. A git clone runs install.sh. All four land the same 71 skills; MCP is an optional layer on top.</desc>
+          <g font-family="system-ui, -apple-system, sans-serif">
+            <rect x="2" y="118" width="150" height="66" rx="9" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+            <text x="77" y="147" text-anchor="middle" fill="#c8a96e" font-size="15" font-weight="800">Your agent</text>
+            <text x="77" y="167" text-anchor="middle" fill="#888880" font-size="12">pick one row</text>
+
+            <path d="M152 151C186 151 186 44 220 44" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M152 151C186 151 186 116 220 116" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M152 151C186 151 186 188 220 188" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M152 151C186 151 186 260 220 260" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+
+            <rect x="224" y="20" width="250" height="48" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="242" y="41" fill="#f0ece4" font-size="14" font-weight="700">Claude Code</text>
+            <text x="242" y="59" fill="#888880" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">/plugin install suede-skills@suede</text>
+
+            <rect x="224" y="92" width="250" height="48" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="242" y="113" fill="#f0ece4" font-size="14" font-weight="700">Codex</text>
+            <text x="242" y="131" fill="#888880" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">codex plugin add suede-skills</text>
+
+            <rect x="224" y="164" width="250" height="48" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="242" y="185" fill="#f0ece4" font-size="14" font-weight="700">Cursor / Copilot / Windsurf</text>
+            <text x="242" y="203" fill="#888880" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">npx skills add ...</text>
+
+            <rect x="224" y="236" width="250" height="48" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="242" y="257" fill="#f0ece4" font-size="14" font-weight="700">Anything else</text>
+            <text x="242" y="275" fill="#888880" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">git clone &amp;&amp; install.sh</text>
+
+            <path d="M474 44C512 44 512 151 550 151" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M474 116C512 116 512 151 550 151" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M474 188C512 188 512 151 550 151" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M474 260C512 260 512 151 550 151" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M550 151l-9 -5v10z" fill="#c8a96e"/>
+
+            <rect x="554" y="112" width="180" height="78" rx="9" fill="#161616" stroke="#c8a96e" stroke-width="2"/>
+            <text x="644" y="146" text-anchor="middle" fill="#c8a96e" font-size="30" font-weight="900">71</text>
+            <text x="644" y="171" text-anchor="middle" fill="#888880" font-size="12.5" font-weight="600">skills, loaded on demand</text>
+
+            <path d="M734 151H768" stroke="#222222" stroke-width="1.75" stroke-dasharray="4 4"/>
+            <path d="M768 151l-9 -5v10z" fill="#222222"/>
+
+            <rect x="772" y="112" width="206" height="78" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5" stroke-dasharray="5 4"/>
+            <text x="875" y="140" text-anchor="middle" fill="#f0ece4" font-size="14" font-weight="700">MCP (optional)</text>
+            <text x="875" y="160" text-anchor="middle" fill="#888880" font-size="12">7 tools &#183; 6 resources</text>
+            <text x="875" y="177" text-anchor="middle" fill="#888880" font-size="12">5 prompts &#183; stdio</text>
+          </g>
+        </svg>
+      </div>
+    </div>
   </div>
 
   <section class="shell" id="claude-code">
@@ -445,7 +545,58 @@ codex plugin add suede-skills@suede-codex</code></pre>
     </div>
 
     <div class="prose">
-      <p>Profiles: <code>all</code>, <code>workflow</code>, or <code>creator</code>. It implements <code>initialize</code>, <code>tools/list</code>, <code>tools/call</code>, <code>resources/list</code>, <code>resources/read</code>, <code>prompts/list</code>, and <code>prompts/get</code> — 7 tools, 6 resources, 5 prompts.</p>
+      <p>Profiles: <code>all</code>, <code>workflow</code>, or <code>creator</code>. It implements <code>initialize</code>, <code>tools/list</code>, <code>tools/call</code>, <code>resources/list</code>, <code>resources/read</code>, <code>prompts/list</code>, and <code>prompts/get</code> — 7 tools, 6 resources, 5 prompts. No dependencies, no network calls, no install step beyond running the file.</p>
+    </div>
+
+    <div class="pathmap">
+      <div class="pathmap-head">
+        <span class="pathmap-title">The MCP surface</span>
+        <span class="pathmap-hint">One process, three profiles, zero dependencies</span>
+      </div>
+      <div class="pathmap-scroll">
+        <svg class="pathmap-svg" viewBox="0 0 940 250" role="img" aria-labelledby="mcp-t mcp-d" xmlns="http://www.w3.org/2000/svg">
+          <title id="mcp-t">The Suede Skills MCP surface</title>
+          <desc id="mcp-d">An agent speaks JSON-RPC over stdio to the server, which selects one of three profiles and exposes 7 tools, 6 resources, and 5 prompts.</desc>
+          <g font-family="system-ui, -apple-system, sans-serif">
+            <rect x="2" y="90" width="146" height="70" rx="9" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
+            <text x="75" y="121" text-anchor="middle" fill="#c8a96e" font-size="15" font-weight="800">Your agent</text>
+            <text x="75" y="141" text-anchor="middle" fill="#888880" font-size="12">JSON-RPC</text>
+
+            <path d="M148 125H206" stroke="#c8a96e" stroke-width="1.75"/>
+            <path d="M206 125l-9 -5v10z" fill="#c8a96e"/>
+            <text x="177" y="115" text-anchor="middle" fill="#888880" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">stdio</text>
+
+            <rect x="210" y="62" width="212" height="126" rx="9" fill="#111111" stroke="#c8a96e" stroke-width="1.5"/>
+            <text x="316" y="92" text-anchor="middle" fill="#f0ece4" font-size="14.5" font-weight="800">suede-skills-mcp.mjs</text>
+            <text x="316" y="118" text-anchor="middle" fill="#888880" font-size="12">--profile</text>
+            <rect x="228" y="130" width="44" height="24" rx="12" fill="#161616" stroke="#222222"/>
+            <text x="250" y="146" text-anchor="middle" fill="#c8a96e" font-size="10.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">all</text>
+            <rect x="278" y="130" width="62" height="24" rx="12" fill="#161616" stroke="#222222"/>
+            <text x="309" y="146" text-anchor="middle" fill="#888880" font-size="10.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">workflow</text>
+            <rect x="346" y="130" width="56" height="24" rx="12" fill="#161616" stroke="#222222"/>
+            <text x="374" y="146" text-anchor="middle" fill="#888880" font-size="10.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">creator</text>
+
+            <path d="M446 125C486 125 486 42 526 42" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M446 125C486 125 486 125 526 125" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+            <path d="M446 125C486 125 486 208 526 208" stroke="#c8a96e" stroke-width="1.75" fill="none"/>
+
+            <rect x="530" y="16" width="404" height="52" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="552" y="39" fill="#c8a96e" font-size="17" font-weight="900">7</text>
+            <text x="576" y="39" fill="#f0ece4" font-size="14" font-weight="700">tools</text>
+            <text x="576" y="57" fill="#888880" font-size="11.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">list / get / install_options / grades / qa</text>
+
+            <rect x="530" y="99" width="404" height="52" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="552" y="122" fill="#c8a96e" font-size="17" font-weight="900">6</text>
+            <text x="576" y="122" fill="#f0ece4" font-size="14" font-weight="700">resources</text>
+            <text x="576" y="140" fill="#888880" font-size="11.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">catalog, plugins, audit and grade scaffolds</text>
+
+            <rect x="530" y="182" width="404" height="52" rx="8" fill="#111111" stroke="#222222" stroke-width="1.5"/>
+            <text x="552" y="205" fill="#c8a96e" font-size="17" font-weight="900">5</text>
+            <text x="576" y="205" fill="#f0ece4" font-size="14" font-weight="700">prompts</text>
+            <text x="576" y="223" fill="#888880" font-size="11.5" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">discovery and audit entry points</text>
+          </g>
+        </svg>
+      </div>
     </div>
 
     <h3 style="margin-top:40px;">The 7 tools</h3>
@@ -465,6 +616,45 @@ codex plugin add suede-skills@suede-codex</code></pre>
       <div class="row"><b>Install options</b><span>Public skill installs, MCP, local plugin notes, and skill-copy paths returned as structured guidance.</span></div>
       <div class="row"><b>Grading scaffolds</b><span>Visibility and code checks route through focused A-F graders with evidence requirements instead of vibes.</span></div>
       <div class="row"><b>QA loops</b><span>Full QA passes for skills, MCP, docs, public site changes, and adversarial review loops.</span></div>
+    </div>
+  </section>
+
+  <section class="shell" id="notes">
+    <h2>Before you install</h2>
+    <p class="section-sub">What 71 skills actually cost you in context, and how the routing keeps them out of each other's way.</p>
+    <div class="notes">
+      <a class="note-row" href="./blog/progressive-disclosure-ship-dag-and-mcp.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">71 skills installed. Your agent reads almost none of them.</span>
+          <span class="note-hook">Progressive disclosure, the ship DAG, and this MCP layer</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="./blog/why-breadth-is-free.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">Why breadth is free now, and what that changes</span>
+          <span class="note-hook">Why installing all 71 is not the cost you think it is</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="./blog/not-for-the-line-that-makes-a-pack-work.html">
+        <span class="note-date">Aug 2026</span>
+        <span class="note-copy">
+          <span class="note-title">NOT FOR: the two words that make a big skill pack work</span>
+          <span class="note-hook">How the router picks one skill instead of five</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
+      <a class="note-row" href="./blog/">
+        <span class="note-date">Archive</span>
+        <span class="note-copy">
+          <span class="note-title">All essays</span>
+          <span class="note-hook">The full writing archive</span>
+        </span>
+        <span class="note-arrow" aria-hidden="true">-&gt;</span>
+      </a>
     </div>
   </section>
 

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -899,11 +899,14 @@ const countChecks = [
   { file: "docs/index.html", label: "JSON-LD numberOfItems", re: /"numberOfItems":\s*(\d+)/, expected: totalSkillCount },
   { file: "docs/guide.html", label: "title tag", re: /<title>Suede Creator Skills Guide \| (\d+) Agent Skills/, expected: totalSkillCount },
   { file: "docs/guide.html", label: "public skills metric", re: /<div class="metric"><b>(\d+)<\/b><span>public skills<\/span><\/div>/, expected: totalSkillCount },
-  { file: "docs/guide.html", label: "h2 heading", re: /<h2>([A-Za-z]+(?:-[A-Za-z]+)?) skills, one portable/, expected: totalSkillCount, wordNumber: true },
+  // Numerals, not wordNumber: both headings used to spell the count out
+  // ("Seventy-one skills"), which reads as marketing prose on a technical
+  // page and drifts independently of every numeral elsewhere on the site.
+  { file: "docs/guide.html", label: "h2 heading", re: /<h2>(\d+) skills, one portable/, expected: totalSkillCount },
   { file: "docs/copy.html", label: "og:description agent skills count", re: /og:description" content="Use this copy when explaining Suede Creator Skills: (\d+) agent skills/, expected: totalSkillCount },
   { file: "docs/copy.html", label: "N-skill pack copy block", re: /A (\d+)-skill, MIT-licensed pack/, expected: totalSkillCount },
   { file: "docs/copy.html", label: "Twenty-N public skills paragraph", re: /([A-Za-z]+(?:-[A-Za-z]+)?) public skills your agent loads/, expected: totalSkillCount, wordNumber: true },
-  { file: "docs/plugins.html", label: "lead paragraph", re: /([A-Za-z]+(?:-[A-Za-z]+)?) public skills your agent can load/, expected: totalSkillCount, wordNumber: true },
+  { file: "docs/plugins.html", label: "lead paragraph", re: /(\d+) public skills your agent can load/, expected: totalSkillCount },
   { file: "docs/dav/index.html", label: "meta description", re: /Install (\d+) public Codex and Claude skills/, expected: totalSkillCount },
   { file: "docs/dav/index.html", label: "og:description", re: /property="og:description" content="(\d+) public skills for Suedify/, expected: totalSkillCount },
   { file: "docs/dav/index.html", label: "twitter:description", re: /name="twitter:description" content="(\d+) public skills for Suedify/, expected: totalSkillCount },
@@ -968,6 +971,15 @@ const countChecks = [
   { file: "docs/plugins.html", label: "browse-all link label", re: /Browse all (\d+) skills/, expected: totalSkillCount, every: true },
   { file: "docs/guide.html", label: "guide title skill count", re: /Suede Creator Skills Guide \| (\d+) Agent Skills/, expected: totalSkillCount, every: true },
   { file: "docs/plugins.html", label: "umbrella install count", re: /installs all (\d+) skills\./, expected: totalSkillCount },
+  // New guide and install-page surfaces. The h2 heading and plugins lead are
+  // already guarded above; these cover the copy and graphics added alongside.
+  { file: "docs/guide.html", label: "guide hero pack size", re: /(\d+) skills, MIT licensed/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "disclosure headline", re: /Installing (\d+) skills does not cost you/, expected: totalSkillCount },
+  { file: "docs/guide.html", label: "disclosure description count", re: /(\d+) one-line descriptions/, expected: totalSkillCount },
+  { file: "docs/plugins.html", label: "path-map graphic count", re: /Every path lands the same (\d+) skills/, expected: totalSkillCount },
+  // Derived count: the diagram loads one skill, so the rest stay unread.
+  // Guarded against total-1 so it tracks the pack instead of going stale.
+  { file: "docs/guide.html", label: "disclosure unread count", re: /(\d+) stay unread/, expected: totalSkillCount - 1 },
   // The README hero and pack-map are SVGs with the count baked into the
   // artwork — the rendered number lives in the SVG text node, so README
   // prose alone proves nothing. Guard both graphics.


### PR DESCRIPTION
Same treatment as the README, homepage, and catalog — now for the two remaining docs pages.

**`plugins.html`**
- **"Which install is yours"** — a path map showing four routes (Claude Code, Codex, skills CLI, clone) converging on the same 71 skills, with MCP drawn as the optional dashed layer it actually is. The page answered this in prose only, which is a lot of reading for a question that's fundamentally a fork.
- **MCP surface diagram** — agent → stdio → server → three profiles → 7 tools / 6 resources / 5 prompts. That section was the densest text on the page.
- **Field notes** linking the essays that answer the questions people have *before* installing (what does breadth cost me, how does routing avoid collisions).
- **Layout fix**: `.page-head`'s `padding` shorthand reset `.shell`'s 40px side padding, so the hero block sat 40px left of every section below — the same bug found on the catalog page.

**`guide.html`**
- **"Installing 71 skills does not cost you 71 skills"** — a progressive-disclosure figure: 71 folders on disk, 71 one-line descriptions in context, one skill loaded in full, seventy left unread. This is the guide's central claim and the standard objection to a large pack; it was previously a sentence.
- **Field notes** linking all five essays.

**Copy** — both pages spelled the pack size out (*"Seventy-one skills"*), which reads as marketing prose on a technical page and could only be guarded by a word-number matcher. Both now use numerals; the two existing guards were retargeted and new ones added for the added copy. The "70 stay unread" figure is guarded against `total - 1` so it tracks the pack instead of going stale.

Verified: all three SVGs parse as XML, every local link and anchor resolves, and a geometry check confirms no text or nested rect overflows its container — that check caught a `creator` profile chip overhanging its panel by 18px, now refitted. `--strict` validator and 29 Python tests pass.