### PR TITLE
fix(docs): disclose self-graded basis and Overall loss in the hero benchmark claim

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2495,6 +2495,11 @@
     .bench-label .bench-highlight {
       color: #c8a96e;
     }
+    .bench-label a {
+      color: inherit;
+      text-decoration: underline;
+      text-underline-offset: 3px;
+    }
 
     .bench-grid {
       display: grid;
@@ -3412,7 +3417,7 @@
     </div>
 
     <div id="hero-bench" class="hero-anim">
-      <p class="bench-label">Beats GSD and Superpowers in <span class="bench-highlight">4 categories</span>, and publishes the ones it loses</p>
+      <p class="bench-label">Self-graded on the Suede ship-gate rubric: Suede takes <span class="bench-highlight">4 of 14 categories</span> outright, and loses Overall to <a href="#scorecard">Superpowers, A to A-</a>. Every row is published.</p>
       <div class="bench-grid">
         <a class="bench-tile" href="#scorecard">
           <span class="bench-grade">A+</span>
@@ -3888,7 +3893,7 @@
 
     <p class="scorecard-eyebrow reveal">Benchmarks: self-graded, losses shown</p>
     <h2 class="scorecard-headline reveal reveal-d1">Suede against GSD and Superpowers, losses included.</h2>
-    <p class="scorecard-sub reveal reveal-d2">We ran the Suede ship-gate rubric on <strong>Suede Creator Skills</strong>, <strong>GSD</strong>, and <strong>Superpowers</strong> the same way. The full category breakdown is below, including the rows where GSD or Superpowers beats Suede.</p>
+    <p class="scorecard-sub reveal reveal-d2">We ran the Suede ship-gate rubric on <a href="https://github.com/JasonColapietro/suede-creator-skills" rel="noopener">Suede Creator Skills</a>, <strong>GSD</strong>, and <a href="https://github.com/obra/superpowers" rel="nofollow noopener">Superpowers</a> the same way, reading each pack's published skill files, on 2026-07-05. We wrote the rubric, so read this as our reading of three packs, not a neutral benchmark. Superpowers scores higher than Suede on Overall. The full category breakdown is below, including the rows where GSD or Superpowers beats Suede.</p>
 
     <div class="scorecard-table-wrap reveal">
       <table class="scorecard-table scorecard-table--usecase">

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1117,23 +1117,43 @@ for (const check of countChecks) {
     }
     const beatsBoth = scored.filter(([, s, g, p]) => gradeRank[s] > gradeRank[g] && gradeRank[s] > gradeRank[p]);
     const losesBoth = scored.filter(([, s, g, p]) => gradeRank[s] < gradeRank[g] && gradeRank[s] < gradeRank[p]);
-    // Current strip copy: "Beats GSD and Superpowers in <N categories>, and
-    // publishes the ones it loses" — the win count is still a published
-    // assertion and must equal the table's beat-both row count. The strip no
-    // longer states the total or the loss count; losses stay visible through
-    // the table itself and the hero-tile completeness check below.
+    const overallRow = [...detailBlock.matchAll(/<tr>(.*?)<\/tr>/gs)]
+      .map((m) => [...m[1].matchAll(/<t[dh][^>]*>(.*?)<\/t[dh]>/gs)].map((c) => c[1].replace(/<[^>]+>/g, "").trim()))
+      .find((cells) => cells.length === 4 && cells[0] === "Overall");
+    // Current strip copy: "Self-graded on the Suede ship-gate rubric: Suede
+    // takes <N of M categories> outright, and loses Overall to Superpowers,
+    // <their grade> to <our grade>." Every number in it is a published
+    // assertion about named third-party packs, so all four are re-derived
+    // from the table: the win count, the category total, and both Overall
+    // grades. The self-graded basis and the Overall loss must stay in the
+    // strip itself — that is the only benchmark copy above the fold.
     const claim = docsRootText.match(
-      /Beats GSD and Superpowers in <span class="bench-highlight">(\d+) categories<\/span>, and publishes the ones it loses/
+      /Self-graded on the Suede ship-gate rubric: Suede takes <span class="bench-highlight">(\d+) of (\d+) categories<\/span> outright, and loses Overall to <a href="#scorecard">Superpowers, (\S+) to (\S+)<\/a>/
     );
     if (!claim) {
-      fail.push("docs/index.html hero benchmark claim not found or reworded — it must be re-derived from the scorecard table");
+      fail.push("docs/index.html hero benchmark claim not found or reworded — it must be re-derived from the scorecard table and must keep the self-graded disclosure");
     } else {
       const wins = Number(claim[1]);
+      const total = Number(claim[2]);
       if (wins !== beatsBoth.length) {
         fail.push(`docs/index.html hero claims it beats both in ${wins} categories; the scorecard shows ${beatsBoth.length} (${beatsBoth.map((r) => r[0]).join(", ")})`);
       }
+      if (total !== scored.length) {
+        fail.push(`docs/index.html hero claims ${total} graded categories; the scorecard table has ${scored.length}`);
+      }
       if (losesBoth.length === 0) {
-        fail.push('docs/index.html hero says it "publishes the ones it loses" but the scorecard shows no lose-both categories — reword the strip or fix the table');
+        warn.push("docs/index.html scorecard shows no lose-both categories — confirm the table still publishes losses");
+      }
+      if (!overallRow) {
+        fail.push("docs/index.html scorecard has no Overall row — the hero's Overall-loss claim cannot be re-derived");
+      } else {
+        const [, suedeOverall, , powersOverall] = overallRow;
+        if (claim[3] !== powersOverall || claim[4] !== suedeOverall) {
+          fail.push(`docs/index.html hero states Overall "Superpowers, ${claim[3]} to ${claim[4]}"; the scorecard Overall row reads Superpowers ${powersOverall}, Suede ${suedeOverall}`);
+        }
+        if (gradeRank[suedeOverall] >= gradeRank[powersOverall]) {
+          fail.push(`docs/index.html hero says Suede loses Overall to Superpowers, but the scorecard Overall row reads Suede ${suedeOverall} vs Superpowers ${powersOverall} — reword the strip`);
+        }
       }
     }
     // The four hero tiles must be exactly the beat-both categories, or the


### PR DESCRIPTION
## What was wrong

The hero benchmark strip on https://skills.suedeai.ai/ (HTTP 200, fetched 2026-08-09) read:

> Beats GSD and Superpowers in **4 categories**, and publishes the ones it loses

Three problems, all in one line:

1. **No disclosure at the point of claim.** The grading is our own rubric. The live page contains exactly one occurrence of the string `self-graded` (`grep -c 'self-graded'` → 1), inside the `#scorecard` section far below the fold. Above the fold this reads as a neutral, third-party-verified result.
2. **The page's own data contradicts the takeaway.** The scorecard's `Overall` row is Suede `A-`, GSD `A-`, Superpowers `A`. Superpowers grades *higher* than Suede on Suede's own rubric. A reader who only sees the hero takes away the opposite.
3. **Unreproducible.** GSD and Superpowers were named but never linked, and no grading date was published, so the claim could not be checked and both packs move under it over time.

This is a published comparative claim about identifiable third-party products.

## What changed

**Hero strip** — now carries the disclosure, the true win share, and the loss:

> Self-graded on the Suede ship-gate rubric: Suede takes **4 of 14 categories** outright, and loses Overall to [Superpowers, A to A-](#scorecard). Every row is published.

`4` and `14` are re-derived from the scorecard table: 14 graded categories excluding the `Overall` summary row, of which Suede beats both packs on Breadth / Coverage, Code Review / Ship Gate, Evidence / Legal Boundaries, and Domain Expertise.

**Scorecard intro** — adds sources, a date, and an explicit statement of who wrote the rubric:

- Links [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) (HTTP 200) and [Superpowers](https://github.com/obra/superpowers) (HTTP 200, `rel="nofollow noopener"`).
- **GSD is left unlinked.** No canonical GSD repo URL appears anywhere in this repo and none was confirmed, so the plain name stays rather than a guessed link. Worth adding in a follow-up if someone can confirm it.
- Grading date `2026-07-05`, sourced from `48ca6dc` ("Add self-graded scorecard section comparing Suede Skills against GSD and Superpowers"), the commit that produced the table. The only later commit touching a `grade-pill` line is `93d1ff3`, an a11y color fix, not a regrade.
- States plainly that we wrote the rubric and that Superpowers scores higher on Overall.

**The benchmark is not removed.** Publishing the rows we lose is the strongest thing on that page. Only the disclosure moved up to where the claim is made.

## Test updated, not deleted

The competitive-claim guard in `scripts/validate-skill-pack.mjs` matched the old wording verbatim, so it would have failed on the corrected copy. It is updated to assert the new canon and now re-derives more of the claim from the table than before:

- win count == beat-both row count (was already checked)
- stated category total == number of graded rows (new)
- both Overall grades in the strip == the table's Overall row (new)
- Suede must actually rank below Superpowers on Overall, or the strip's wording is flagged (new)

## Verification

- `npm run validate` → `Validated 71 skills against 71 catalog entries.` / `Trigger routing contract OK: 7 groups, 27 cases`
- Negative tests on a scratch copy of the tree: changing the strip to `5 of 14 categories` fails with *"hero claims it beats both in 5 categories; the scorecard shows 4"*; changing it to `Superpowers, A+ to A-` fails with *"the scorecard Overall row reads Superpowers A, Suede A-"*.
- `npm test` was not run to completion: `tests/test_validator_runtime.mjs` spawns `codex app-server` and hangs on this machine. Pre-existing and unrelated to this diff, which touches only `docs/index.html` and the guard covered by `npm run validate`. CI should run the full suite.