### PR TITLE
chore(book): fail validation when BOOK.md drifts from the chapters

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "validate": "node scripts/validate-skill-pack.mjs --strict && node scripts/validate-trigger-routing.mjs && node scripts/build-book-site.mjs --check",
+    "validate": "node scripts/validate-skill-pack.mjs --strict && node scripts/validate-trigger-routing.mjs && node scripts/build-book-site.mjs --check && node scripts/build-book.mjs --check",
     "build:book": "node scripts/build-book.mjs && node scripts/build-book-site.mjs",
     "test:mcp": "node --test tests/test_mcp_protocol.mjs",
     "test:contributions": "node --test tests/test_contribution_ledger.mjs",

--- a/scripts/build-book.mjs
+++ b/scripts/build-book.mjs
@@ -1,12 +1,17 @@
 #!/usr/bin/env node
 // Concatenates book/ into a single readable BOOK.md.
 // Order: front matter, chapters 01..NN, appendices A1..
+//
+// Usage:
+//   node scripts/build-book.mjs          # write book/BOOK.md
+//   node scripts/build-book.mjs --check  # exit 1 if BOOK.md would change
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const bookDir = path.join(repoRoot, "book");
+const checkOnly = process.argv.includes("--check");
 
 const rank = (name) => {
   if (name.startsWith("00-")) return 0;
@@ -23,6 +28,20 @@ const files = fs
 const parts = files.map((f) => fs.readFileSync(path.join(bookDir, f), "utf8").trim());
 const out = `${parts.join("\n\n---\n\n")}\n`;
 
-fs.writeFileSync(path.join(bookDir, "BOOK.md"), out);
+const bookPath = path.join(bookDir, "BOOK.md");
 const words = out.split(/\s+/).filter(Boolean).length;
-console.log(`book/BOOK.md written — ${files.length} files, ${words.toLocaleString()} words`);
+
+// docs/book/ already fails validation when it drifts from the chapters. BOOK.md
+// is the other generated view of the same source and had no such guard, so an
+// edited chapter could ship with the single-file read silently stale.
+if (checkOnly) {
+  const existing = fs.existsSync(bookPath) ? fs.readFileSync(bookPath, "utf8") : null;
+  if (existing !== out) {
+    console.error("book/BOOK.md is stale — run: node scripts/build-book.mjs");
+    process.exit(1);
+  }
+  console.log(`book/BOOK.md is current — ${files.length} files, ${words.toLocaleString()} words`);
+} else {
+  fs.writeFileSync(bookPath, out);
+  console.log(`book/BOOK.md written — ${files.length} files, ${words.toLocaleString()} words`);
+}


### PR DESCRIPTION
## What

`docs/book/` already fails `npm run validate` when it stops matching `book/*.md`. `book/BOOK.md` is the other generated view of the same source and had no such guard, so an edited chapter could ship with the single-file read silently stale.

This adds `--check` to `scripts/build-book.mjs` and wires it into `validate`.

## Why this PR exists at all

The two commits that added the book (`5d38a86`) and published it to the site (`27e3b9c`) landed as direct pushes to `main`. GitHub reported `Bypassed rule violations` on both: they skipped the two required checks rather than passing them. This PR carries a small real change so the pipeline runs against current `main` and those commits get validated after the fact.

## Verification

Guard tested in both directions, not just the passing one:

```
$ printf '\n30. Temporary drift probe.\n' >> book/A2-the-rules.md
$ node scripts/build-book.mjs --check
book/BOOK.md is stale — run: node scripts/build-book.mjs
exit 1

$ git checkout book/A2-the-rules.md
$ node scripts/build-book.mjs --check
book/BOOK.md is current — 17 files, 29,118 words
exit 0
```

Full suite green in the worktree: `npm test` exit 0, zero `not ok` lines, 29 Python tests OK.

Worth noting: the first run of that suite reported nothing useful because the worktree had no `node_modules` and `validate` died on `Cannot find module 'js-yaml'` before a single test ran. `npm ci` first, then the result above.