### PR TITLE
Guide page: open on a table of contents and a worked run

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -16,7 +16,6 @@
     <link rel="canonical" href="https://skills.suedeai.ai/guide.html">
     <link rel="icon" href="./assets/suede-skill-icon.png" type="image/png">
     <link rel="apple-touch-icon" href="./assets/suede-skill-icon.png">
-    <link rel="preload" as="image" href="./assets/passport-hero.webp" type="image/webp">
     <link rel="image_src" href="https://skills.suedeai.ai/assets/og-image-v2.png">
     <meta property="og:type" content="website">
     <meta property="og:title" content="Suede Creator Skills Guide | 71 Agent Skills">
@@ -413,15 +412,24 @@
       .lead { font-size: 18px; line-height: 1.7; color: var(--muted); max-width: 640px; text-wrap: pretty; }
       .lead strong { color: var(--cream); font-weight: 600; }
       .lead code { font-family: var(--mono); font-size: 0.9em; color: var(--gold); }
-      .hero-media img {
-        border: 1px solid var(--border); border-radius: 6px;
-        width: 100%; height: auto; aspect-ratio: 1672 / 941; object-fit: cover;
-      }
 
-      /* Tiny ship log */
+      .btn-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
+      .btn {
+        display: inline-flex; align-items: center; min-height: 44px; padding: 0 18px;
+        border: 1px solid var(--border); border-radius: 4px;
+        color: var(--muted); font-size: 13.5px; font-weight: 500;
+        transition: color 0.15s, border-color 0.15s, background 0.15s;
+      }
+      .btn:hover { color: var(--gold); border-color: var(--gold); }
+      .btn--gold { border-color: var(--gold); color: var(--cream); background: rgba(200, 169, 110, 0.08); }
+      .btn--gold:hover { background: rgba(200, 169, 110, 0.16); color: var(--cream); }
+
+
+      /* Tiny ship log. Lives under Field notes on this page, not in the hero:
+         the guide's first screen is its own contents, not the homepage's. */
       #hero-shiplog {
         display: flex; align-items: center; gap: 16px;
-        margin: 28px 0 0; padding: 13px 18px; max-width: 560px;
+        margin: 0 0 28px; padding: 13px 18px; max-width: 560px;
         background: var(--surface); border: 1px solid var(--border); border-radius: 6px;
         transition: border-color 0.15s ease, background 0.15s ease;
       }
@@ -445,21 +453,43 @@
         .hero-shiplog-title { white-space: normal; }
       }
 
-      .btn-row { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
-      .btn {
-        display: inline-flex; align-items: center; min-height: 44px; padding: 0 18px;
-        border: 1px solid var(--border); border-radius: 4px;
-        color: var(--muted); font-size: 13.5px; font-weight: 500;
-        transition: color 0.15s, border-color 0.15s, background 0.15s;
+      /* Guide contents — the first screen shows this page's structure, not the pitch */
+      .toc {
+        background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+        padding: 26px 28px;
       }
-      .btn:hover { color: var(--gold); border-color: var(--gold); }
-      .btn--gold { border-color: var(--gold); color: var(--cream); background: rgba(200, 169, 110, 0.08); }
-      .btn--gold:hover { background: rgba(200, 169, 110, 0.16); color: var(--cream); }
+      .toc-head {
+        font-size: 11px; font-weight: 600; letter-spacing: 0.18em;
+        text-transform: uppercase; color: var(--muted); margin-bottom: 18px;
+      }
+      .toc-list { list-style: none; counter-reset: toc; }
+      .toc-list li { counter-increment: toc; border-top: 1px solid var(--border); }
+      .toc-list li:first-child { border-top: 0; }
+      .toc-list a {
+        display: flex; align-items: baseline; gap: 14px; min-height: 44px;
+        padding: 11px 0; color: var(--muted); font-size: 14.5px; line-height: 1.45;
+        transition: color 0.15s ease;
+      }
+      .toc-list a::before {
+        content: counter(toc, decimal-leading-zero);
+        flex: none; font-family: var(--mono); font-size: 11.5px; color: var(--gold);
+        font-weight: 600; letter-spacing: 0.04em;
+      }
+      .toc-list a:hover { color: var(--cream); }
 
-      .metric-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 1px; background: var(--border); border: 1px solid var(--border); border-radius: 6px; overflow: hidden; margin-top: 36px; }
-      .metric { min-width: 0; background: var(--card); padding: 18px 20px; }
-      .metric b { display: block; color: var(--gold); font-size: 26px; font-weight: 800; letter-spacing: -0.02em; line-height: 1; }
-      .metric span { display: block; margin-top: 8px; color: var(--muted); font-size: 12px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+      /* Worked example — one real run, start to finish */
+      .example-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: clamp(20px, 3vw, 36px); align-items: start; margin-top: 32px; }
+      .example-out {
+        background: var(--card); border: 1px solid var(--border); border-radius: 6px;
+        padding: 24px 26px;
+      }
+      .example-out h3 { font-size: 15px; font-weight: 700; color: var(--cream); margin-bottom: 4px; }
+      .example-out > p { font-size: 13.5px; color: var(--muted); line-height: 1.6; margin-bottom: 18px; }
+      .lane { display: grid; grid-template-columns: 30px minmax(0, 1fr); gap: 12px; align-items: baseline; padding: 10px 0; border-top: 1px solid var(--border); }
+      .lane b { font-family: var(--mono); font-size: 15px; font-weight: 700; color: var(--gold); }
+      .lane span { font-size: 13.5px; color: var(--muted); line-height: 1.5; }
+      .lane span i { display: block; color: var(--cream); font-style: normal; font-weight: 600; }
+      @media (max-width: 900px) { .example-grid { grid-template-columns: 1fr; } }
 
       /* Install terminal */
       .term {
@@ -483,13 +513,13 @@
         -webkit-mask-image: linear-gradient(to right, black calc(100% - 28px), transparent 100%);
       }
       .term-code .prompt { color: var(--red-text); user-select: none; }
-      .term-copy {
-        flex-shrink: 0; font-family: var(--mono); font-size: 12.5px;
-        color: var(--muted); background: var(--card); border: 1px solid var(--border);
-        border-radius: 4px; padding: 8px 14px; min-height: 38px; cursor: pointer;
-        transition: color 0.15s, border-color 0.15s;
+      /* Prose prompts wrap. The scroll-and-fade treatment is for install
+         commands, where clipping a long line is expected; here it would hide
+         the end of a sentence the reader is meant to read. */
+      .term-code--wrap {
+        white-space: pre-wrap; overflow-x: visible; line-height: 1.7;
+        mask-image: none; -webkit-mask-image: none;
       }
-      .term-copy:hover { color: var(--gold); border-color: var(--gold); }
 
       section { padding: 88px 0 0; scroll-margin-top: 80px; }
       h2 {
@@ -634,14 +664,12 @@
 
       @media (max-width: 980px) {
         .hero-grid { grid-template-columns: 1fr; }
-        .hero-media { order: -1; max-width: 560px; }
         .grid-3 { grid-template-columns: 1fr; }
         .flow { grid-template-columns: repeat(2, minmax(0, 1fr)); }
       }
       @media (max-width: 820px) {
         .rowd, a.rowl { grid-template-columns: 220px 1fr; }
         a.rowl { grid-template-columns: 220px 1fr auto; }
-        .metric-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
         .faq-grid { grid-template-columns: 1fr; }
       }
       @media (max-width: 720px) {
@@ -718,59 +746,80 @@
           <div class="hero-grid">
             <div class="hero-copy">
               <p class="eyebrow">The full guide</p>
-              <h1 id="hero-headline">Stop rebuilding the prompt stack every time your agent forgets you.</h1>
-              <p class="lead">Suede gives Claude Code or Codex a reusable engineering workflow instead of one giant bloated prompt. <strong>Every capability is an inspectable <code>SKILL.md</code> folder</strong> the agent loads on demand: Full Send outcome routing, orchestration, A-F code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, app shipping, and creator rights. 71 skills, MIT licensed.</p>
-              <a id="hero-shiplog" href="./#changelog" aria-label="Ship log: 223 commits in 10 weeks. Latest entry August 4, 2026: Instagram growth gets an evidence system. Read the full changelog on the homepage.">
-                <span class="hero-spark" aria-hidden="true">
-                  <span style="height:8%"></span>
-                  <span style="height:2%"></span>
-                  <span style="height:2%"></span>
-                  <span style="height:3%"></span>
-                  <span style="height:100%"></span>
-                  <span style="height:39%"></span>
-                  <span style="height:52%"></span>
-                  <span style="height:28%"></span>
-                  <span style="height:30%"></span>
-                  <span style="height:88%"></span>
-                </span>
-                <span class="hero-shiplog-text">
-                  <span class="hero-shiplog-top">Released Aug 10 <b>&middot; a49a998</b></span>
-                  <span class="hero-shiplog-title">Skill search stops needing your exact wording</span>
-                  <span class="hero-shiplog-more">223 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
-                </span>
-              </a>
-
+              <h1 id="hero-headline">How to actually use the pack.</h1>
+              <p class="lead">Suede gives Claude Code or Codex a reusable engineering workflow instead of one giant bloated prompt. <strong>Every capability is an inspectable <code>SKILL.md</code> folder</strong> the agent loads on demand. This page covers one worked run end to end, the routing model that picks a skill for you, what each lane does, and how to install. 71 skills, MIT licensed.</p>
               <div class="btn-row">
-                <a class="btn btn--gold" href="./skills/">Browse all 71 skills</a>
-                <a class="btn" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">View GitHub repo</a>
+                <a class="btn btn--gold" href="#example">Start with a worked run</a>
+                <a class="btn" href="./skills/">Browse all 71 skills</a>
                 <a class="btn" href="#install">Install paths</a>
               </div>
-              <div class="metric-grid" aria-label="Suede Creator Skills summary">
-                <div class="metric"><b>71</b><span>public skills</span></div>
-                <div class="metric"><b>0</b><span>uploads by default</span></div>
-                <div class="metric"><b>7</b><span>MCP tools included</span></div>
-                <div class="metric"><b>MIT</b><span>license</span></div>
+            </div>
+            <nav class="toc" aria-labelledby="toc-head">
+              <p class="toc-head" id="toc-head">On this page</p>
+              <ol class="toc-list">
+                <li><a href="#example">A run, start to finish</a></li>
+                <li><a href="#workflow">What changes once it is installed</a></li>
+                <li><a href="#disclosure">Why 71 skills cost you almost nothing</a></li>
+                <li><a href="#skills">Every lane in the pack</a></li>
+                <li><a href="#use-cases">When to reach for which skill</a></li>
+                <li><a href="#flow">From folder to evidence package</a></li>
+                <li><a href="#install">Install for Claude Code and Codex</a></li>
+                <li><a href="#faq">FAQ</a></li>
+              </ol>
+            </nav>
+          </div>
+        </div>
+      </section>
+
+      <section id="example" aria-labelledby="example-headline">
+        <div class="shell">
+          <h2 id="example-headline">A run, start to finish.</h2>
+          <p class="section-sub">
+            You do not call skills by name. You describe the outcome, the agent matches your request against
+            the one-line descriptions, and it loads the body of the skill it picks. Here is that loop with
+            <a href="./skills/suede-visibility-grader.html">suede-visibility-grader</a>, using the real lanes
+            defined in its <code>SKILL.md</code>.
+          </p>
+
+          <div class="example-grid">
+            <div>
+              <div class="term">
+                <div class="term-bar">
+                  <span class="term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+                  <b>claude code &middot; what you type</b>
+                </div>
+                <div class="term-body">
+                  <pre class="term-code term-code--wrap"><span class="prompt">&gt;</span> grade my landing page before I launch it
+<span class="prompt">&gt;</span> https://example.com/pricing</pre>
+                </div>
+              </div>
+              <div class="rows" style="margin-top:24px">
+                <div class="rowd"><b>1 &middot; Route</b><span>No skill name required. The description &ldquo;grade a public page for launch appeal&rdquo; matches, so the agent loads that one folder. Every other skill stays on disk.</span></div>
+                <div class="rowd"><b>2 &middot; Inspect</b><span>The skill forbids grading from memory. It pulls the live URL, status code, canonical, robots, sitemap, rendered first viewport, headings, CTAs, Open Graph, and JSON-LD before scoring anything.</span></div>
+                <div class="rowd"><b>3 &middot; Score</b><span>Five lanes, each graded A&ndash;F from inspection evidence and mechanical caps &mdash; never impression or generosity &mdash; then one overall grade.</span></div>
+                <div class="rowd"><b>4 &middot; Hand back</b><span>A grade per lane, the evidence behind each, and the ranked fixes. The verdict is advice: a failed gate changes what the agent reports, never what it does.</span></div>
               </div>
             </div>
-            <div class="hero-media">
-              <picture>
-                <source srcset="./assets/passport-hero.webp" type="image/webp">
-                <img src="./assets/passport-hero.png" width="1672" height="941" alt="A polished Suede Creator Skills preview with installable skill surfaces for GitHub, Codex, Claude, docs, design, copy, and creator workflows." fetchpriority="high" decoding="async">
-              </picture>
+
+            <div class="example-out">
+              <h3>What comes back</h3>
+              <p>The five lanes the grader scores, and the question each one answers.</p>
+              <div class="lane"><b>A&ndash;F</b><span><i>Findability</i>Status, canonical, robots, sitemap, title, description, durable keywords, duplicate URL risk.</span></div>
+              <div class="lane"><b>A&ndash;F</b><span><i>First-screen clarity</i>Does the rendered first viewport answer who this is for, what changes for them, and what to do now &mdash; without scrolling?</span></div>
+              <div class="lane"><b>A&ndash;F</b><span><i>CTA pull</i>Primary action, secondary proof action, button text, link targets, and whether there is a reason to click now.</span></div>
+              <div class="lane"><b>A&ndash;F</b><span><i>Proof and trust</i>Screenshots, commands, docs, live routes, source files, receipts, authorship, and evidence boundaries.</span></div>
+              <div class="lane"><b>A&ndash;F</b><span><i>AI readability</i>Can a model summarize and cite the page without hallucinating? Structured lede, citation-ready headings, sourceable claims, entity schema, internal links.</span></div>
+              <div class="btn-row">
+                <a class="btn" href="./skills/suede-visibility-grader.html">Read the full skill</a>
+              </div>
             </div>
           </div>
 
-          <div class="term">
-            <div class="term-bar">
-              <span class="term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
-              <b>claude code &middot; install the pack</b>
-            </div>
-            <div class="term-body">
-              <pre class="term-code" id="install-code"><span class="prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
-<span class="prompt">$</span> /plugin install suede-skills@suede</pre>
-              <button class="term-copy" type="button" data-copy aria-label="Copy install commands">Copy</button>
-            </div>
-          </div>
+          <p class="diagram-note" style="margin-top:28px">
+            Same loop for every other lane: describe the outcome, let routing pick, read the evidence it hands back.
+            Fixes that are conversion-shaped route onward to <a href="./skills/suede-site-alchemy.html">site alchemy</a>;
+            a page shipping as part of a release routes to <a href="./skills/suede-launch-packaging.html">launch packaging</a>.
+          </p>
         </div>
       </section>
 
@@ -1054,6 +1103,25 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
         <div class="shell">
           <h2 id="notes-headline">Field notes.</h2>
           <p class="section-sub">The design decisions behind the pack, written up in full: what a skill costs, how routing avoids collisions, and where memory actually belongs.</p>
+          <a id="hero-shiplog" href="./#changelog" aria-label="Ship log: 223 commits in 10 weeks. Latest entry August 10, 2026: skill search stops needing your exact wording. Read the full changelog on the homepage.">
+            <span class="hero-spark" aria-hidden="true">
+              <span style="height:8%"></span>
+              <span style="height:2%"></span>
+              <span style="height:2%"></span>
+              <span style="height:3%"></span>
+              <span style="height:100%"></span>
+              <span style="height:39%"></span>
+              <span style="height:52%"></span>
+              <span style="height:28%"></span>
+              <span style="height:30%"></span>
+              <span style="height:88%"></span>
+            </span>
+            <span class="hero-shiplog-text">
+              <span class="hero-shiplog-top">Released Aug 10 <b>&middot; a49a998</b></span>
+              <span class="hero-shiplog-title">Skill search stops needing your exact wording</span>
+              <span class="hero-shiplog-more">223 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+            </span>
+          </a>
           <div class="notes">
             <a class="note-row" href="./blog/progressive-disclosure-ship-dag-and-mcp.html">
               <span class="note-date">Aug 2026</span>
@@ -1179,19 +1247,6 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
       </div>
     </footer>
 
-    <script>
-      // Progressive enhancement only: the commands are plain selectable text without JS.
-      document.querySelectorAll("[data-copy]").forEach(function (btn) {
-        btn.addEventListener("click", function () {
-          var code = document.getElementById("install-code");
-          if (!code || !navigator.clipboard) return;
-          navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "")).then(function () {
-            btn.textContent = "Copied";
-            setTimeout(function () { btn.textContent = "Copy"; }, 1600);
-          });
-        });
-      });
-    </script>
   <script>
   // Live star count, cached in localStorage for an hour so a browsing session
   // costs one API call rather than one per page. Silent on failure: the button

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -913,7 +913,11 @@ const countChecks = [
   { file: "docs/index.html", label: "twitter:title", re: /name="twitter:title" content="Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
   { file: "docs/index.html", label: "JSON-LD numberOfItems", re: /"numberOfItems":\s*(\d+)/, expected: totalSkillCount },
   { file: "docs/guide.html", label: "title tag", re: /<title>Suede Creator Skills Guide \| (\d+) Agent Skills/, expected: totalSkillCount },
-  { file: "docs/guide.html", label: "public skills metric", re: /<div class="metric"><b>(\d+)<\/b><span>public skills<\/span><\/div>/, expected: totalSkillCount },
+  // The guide's hero no longer carries the homepage's four-metric strip: the
+  // page opens on its own table of contents so a reader can tell the guide
+  // apart from the homepage at a glance. The pack size is still guarded on
+  // this page by the title tag, the h2 heading, the hero "N skills, MIT
+  // licensed" line, the disclosure headline, and the browse-all link label.
   // Numerals, not wordNumber: both headings used to spell the count out
   // ("Seventy-one skills"), which reads as marketing prose on a technical
   // page and drifts independently of every numeral elsewhere on the site.


### PR DESCRIPTION
## Why

The guide page reused the homepage's hero furniture — ship-log box, four-metric strip, hero image, install terminal — in the same order. Landing on it read as "the homepage again," so the 2,400 words of real material below never got found. The complaint that started this was literally "on the guide page, I can't find the guide."

The page also had no worked example. Every section described what a skill *does*; none showed a single run.

## What changed

**Open on structure, not the pitch.** The first screen is now a numbered table of contents beside the headline, and the H1 says what the page is for. Removed the hero's ship-log box, metric strip, hero image, and duplicate install terminal.

**Added a worked run (`#example`).** What you type in plain English → how routing picks a skill without being named → what the skill inspects before scoring → the five grade lanes it returns. Every detail is read off `skills/suede-visibility-grader/SKILL.md`, including the "never grade from memory" inspection rule and the advisory-gate framing, so nothing is invented. Links onward to site alchemy and launch packaging per the skill's own routing block.

**Ship log kept, relocated.** Moved into Field notes with its date, hash, and commit count unchanged, so the newest-changelog truthfulness guard in `validate-skill-pack.mjs` still matches. It carries recency proof without competing with the guide's opening.

**Fixes found on the way.** `.term-code` masks its right edge for scrollable install commands, which clipped the end of the prose prompt — added `.term-code--wrap`. Removed CSS and the copy-button script left with nothing to bind to (`#install-code` no longer existed), and the one validator rule pointing at the removed metric strip.

## Verification

- `npm test` — 29 passed, exit 0, no warnings.
- All internal anchors resolve; the three linked skill pages exist.
- 375px: no horizontal scroll, nothing overflowing, contents links at the 44px tap-target floor.
- Rendered and checked at 1280px and 375px.

## Note

`package-lock.json` records 0.10.0 while `package.json` is at 0.11.1, so any `npm install` dirties the tree. Deliberately left out of this PR.
