### PR TITLE
fix: sync package-lock.json version to 0.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suede-creator-skills",
-  "version": "0.10.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suede-creator-skills",
-      "version": "0.10.0",
+      "version": "0.11.1",
       "dependencies": {
         "js-yaml": "5.2.2"
       },


### PR DESCRIPTION
`package-lock.json` recorded `0.10.0` in both the root object and `packages[""]`, while `package.json` is at `0.11.1`.

Any `npm install` rewrote the lockfile to match, dropping an unrelated 2-line diff into whichever branch happened to install dependencies.

Regenerated with `npm install --package-lock-only`. The dependency tree was already correct (`js-yaml@5.2.2`), so the version fields are the entire diff — rerunning the command afterward produces no further changes, and `npm ci` runs clean without rewriting the file.

Follow-up in a separate PR adds a validator guard so this cannot drift again.
