### PR TITLE
fix(release): fail validation when package-lock.json version drifts

### DIFF
--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -476,6 +476,26 @@ if (typeof catalog.version !== "string" || !SEMVER_RE.test(catalog.version)) {
 if (packageJson.version !== catalog.version) {
   fail.push(`package.json version (${packageJson.version}) does not match catalog.json version (${catalog.version})`);
 }
+// npm stamps the version in two places, and `npm ci` validates only the
+// dependency tree -- a stale root version sails through CI and is then
+// silently rewritten by the next `npm install`, dropping an unrelated
+// lockfile diff into whichever branch happened to install. Releases 0.11.0
+// and 0.11.1 both drifted this way. Check both fields: a hand-edit that
+// fixes one and misses the other leaves the same trap.
+const packageLockPath = path.join(repoRoot, "package-lock.json");
+if (!fs.existsSync(packageLockPath)) {
+  fail.push("package-lock.json missing — run npm install --package-lock-only to generate it");
+} else {
+  const packageLockJson = JSON.parse(readText(packageLockPath));
+  const lockRootVersion = packageLockJson.version;
+  const lockPackageVersion = packageLockJson.packages?.[""]?.version;
+  if (lockRootVersion !== catalog.version) {
+    fail.push(`package-lock.json version (${lockRootVersion ?? "missing"}) does not match catalog.json version (${catalog.version}) — run npm install --package-lock-only`);
+  }
+  if (lockPackageVersion !== catalog.version) {
+    fail.push(`package-lock.json packages[""] version (${lockPackageVersion ?? "missing"}) does not match catalog.json version (${catalog.version}) — run npm install --package-lock-only`);
+  }
+}
 if (pluginJson.version !== catalog.version) {
   fail.push(`plugin.json version (${pluginJson.version}) does not match catalog.json version (${catalog.version})`);
 }

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -244,6 +244,54 @@ test("packaged validation rejects plugin and catalog version drift", (t) => {
   );
 });
 
+test("packaged validation rejects package-lock version drift", (t) => {
+  const packagedRoot = createPackagedFixture(t, "suede-validator-lockfile-");
+  const lockPath = path.join(packagedRoot, "package-lock.json");
+  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  lock.version = "9.9.9";
+  lock.packages[""].version = "9.9.9";
+  fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+  const catalogPath = path.join(packagedRoot, "mcp", "catalog.json");
+  const catalogVersion = JSON.parse(fs.readFileSync(catalogPath, "utf8")).version;
+  const escaped = catalogVersion.replace(/\./g, "\\.");
+
+  const validation = runValidator(packagedRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(
+    validation.stderr,
+    new RegExp(`package-lock\\.json version \\(9\\.9\\.9\\) does not match catalog\\.json version \\(${escaped}\\)`)
+  );
+  assert.match(
+    validation.stderr,
+    new RegExp(`package-lock\\.json packages\\[""\\] version \\(9\\.9\\.9\\) does not match catalog\\.json version \\(${escaped}\\)`)
+  );
+});
+
+test("packaged validation rejects a package-lock whose two version fields disagree", (t) => {
+  // The real 0.11.x drift left one field stale. A fix that touches only the
+  // root object still leaves the next npm install rewriting the lockfile, so
+  // each field has to fail on its own.
+  const packagedRoot = createPackagedFixture(t, "suede-validator-lockfile-partial-");
+  const lockPath = path.join(packagedRoot, "package-lock.json");
+  const lock = JSON.parse(fs.readFileSync(lockPath, "utf8"));
+  lock.packages[""].version = "9.9.9";
+  fs.writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+  const catalogPath = path.join(packagedRoot, "mcp", "catalog.json");
+  const catalogVersion = JSON.parse(fs.readFileSync(catalogPath, "utf8")).version;
+  const escaped = catalogVersion.replace(/\./g, "\\.");
+
+  const validation = runValidator(packagedRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(
+    validation.stderr,
+    new RegExp(`package-lock\\.json packages\\[""\\] version \\(9\\.9\\.9\\) does not match catalog\\.json version \\(${escaped}\\)`)
+  );
+});
+
 test("packaged validation rejects Codex plugin version and MCP portability drift", (t) => {
   const packagedRoot = createPackagedFixture(t, "suede-validator-codex-version-");
   const pluginPath = path.join(packagedRoot, ".codex-plugin", "plugin.json");


### PR DESCRIPTION
Stacked on #70 — merge that first. Base retargets to `main` automatically once it lands.

## The gap

`scripts/validate-skill-pack.mjs` enforces version parity against `catalog.json` for `package.json`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `CITATION.cff` and `VERSION` — but never `package-lock.json`.

`4c87daa` (0.10.0) bumped the lockfile correctly. Then `d7dcfd2` (0.11.0) and `65b1d39` (0.11.1) bumped the version everywhere else and left the lockfile behind, and validation stayed green through both.

CI's `npm ci --ignore-scripts` does not catch this — `npm ci` validates the dependency tree, not the root version stamp. So the guard belongs with the other parity checks.

## The change

- Parity check for `package-lock.json`, guarded with `existsSync` in the same style as the `VERSION` check, so a missing lockfile produces a clean failure line rather than crashing the validator.
- Both version fields are checked independently. The real 0.11.x drift left one field stale; a hand-edit fixing only the root object would leave the same trap armed.
- Two regression tests modeled on the existing `packaged validation rejects plugin and catalog version drift` case: full drift, and partial drift where only one field is wrong.

## Verification

- `npm test` exit 0 — Node 14/15/31/28 pass, 0 fail; Python 29 pass; validator clean across 71 skills.
- Reverted the validator change and reran: exactly the 2 new tests fail, the other 12 pass. Restored, all green.
