### PR TITLE
fix(routing): restore suede-clip-to-guide catalog description and add trigger coverage

### DIFF
--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -512,7 +512,7 @@
     {
       "name": "suede-clip-to-guide",
       "area": "workflow",
-      "description": "Turn a clip, talk moment, or transcript into a repeatable clip-to-guide funnel package that bridges short-form attention to a long-form asset.",
+      "description": "Suede-owned short-to-long content funnel blueprint. Use when turning a video, clip, interview moment, talk excerpt, screen recording, or transcript into a repeatable clip-to-guide package that bridges attention to an X Article, LinkedIn article or newsletter, blog guide, playbook, or other long-form asset; includes fit criteria, rights routing, moment scoring, a clip brief, exact post copy, publishing sequence, approval bundle, measured success loop, and a dual-evidence certainty gate when Full Send or Codex Fleet controls the run. NOT FOR: full video editing or production (use suede-video), general social calendars or listening (use suede-social), creating the long-form asset from scratch (use suede-copy and suede-content-strategy), paid ads (use suede-ad-creative), or publishing or reposting without exact-content and visible-identity approval.",
       "useWhen": "Turn a video clip, interview moment, talk excerpt, or transcript into a funnel package with rights routing, post copy, and an evidence gate."
     },
     {

--- a/scripts/validate-trigger-routing.mjs
+++ b/scripts/validate-trigger-routing.mjs
@@ -65,6 +65,7 @@ export function validateContract(contract = loadContract(), catalog = loadCatalo
     "design-visibility",
     "rights-audit-passport",
     "android-ios",
+    "clip-social-video",
     "amazon-subscription",
     "social-instagram",
   ]);

--- a/tests/fixtures/trigger-routing.json
+++ b/tests/fixtures/trigger-routing.json
@@ -256,6 +256,59 @@
       ]
     },
     {
+      "id": "clip-social-video",
+      "skills": ["suede-clip-to-guide", "suede-social", "suede-video"],
+      "fallback": "suede-social",
+      "routes": [
+        {
+          "skill": "suede-clip-to-guide",
+          "positive": ["clip to guide", "video plus guide", "short to long", "x article", "article bridge"],
+          "negative": ["social calendar", "content calendar", "edit footage", "color grade", "export video"],
+          "metadataMustContain": ["short to long", "guide"]
+        },
+        {
+          "skill": "suede-social",
+          "positive": ["social calendar", "content calendar", "platform mix", "social strategy", "listening"],
+          "negative": ["clip to guide", "video plus guide", "edit footage"],
+          "metadataMustContain": ["social", "calendars"]
+        },
+        {
+          "skill": "suede-video",
+          "positive": ["edit footage", "color grade", "animated captions", "export video", "full video production"],
+          "negative": ["social calendar", "clip to guide", "video plus guide"],
+          "metadataMustContain": ["video", "production"]
+        }
+      ],
+      "cases": [
+        {
+          "id": "clip-to-guide-positive",
+          "mode": "positive",
+          "prompt": "Turn this 37-second clip and my X Article into a video-plus-guide short-to-long funnel.",
+          "expected": "suede-clip-to-guide"
+        },
+        {
+          "id": "social-calendar-negative-clip",
+          "mode": "negative",
+          "prompt": "Plan a 30-day social calendar and platform mix for our founder account.",
+          "expected": "suede-social",
+          "forbidden": ["suede-clip-to-guide"]
+        },
+        {
+          "id": "video-production-negative-clip",
+          "mode": "negative",
+          "prompt": "Edit footage, color grade it, add animated captions, and export video for Reels.",
+          "expected": "suede-video",
+          "forbidden": ["suede-clip-to-guide", "suede-social"]
+        },
+        {
+          "id": "social-video-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Repurpose this video for social.",
+          "expected": "suede-social"
+        }
+      ]
+    },
+    {
       "id": "social-instagram",
       "skills": ["suede-social", "suede-instagram-growth"],
       "fallback": "suede-social",


### PR DESCRIPTION
## Background

Started as a request to rebase `codex/suede-clip-to-guide-20260729` onto `main`. That rebase is not the right move — the branch is effectively a duplicate. Its skill directory (`skills/suede-clip-to-guide/`) and `tests/test_clip_to_guide_package.py` are **byte-identical** to `main`, and its docs page and catalog registration are already there too; the work landed via the #53 rescue. Attempting the rebase produced 30 conflicted files, almost all add/add against content `main` already has. Aborted.

The **only** content on that branch not already in `main` is the trigger-routing coverage, which this PR ports.

## What this fixes

Porting the coverage immediately failed:

```
clip-social-video/suede-clip-to-guide: catalog metadata is missing routing signal 'short to long'
```

The check requires the signal in both `SKILL.md` frontmatter and `mcp/catalog.json`. `SKILL.md` has it; the catalog did not.

The #53 rescue condensed the catalog description from 857 chars to 150, dropping the `short-to-long` phrasing **and the entire `NOT FOR:` block** — the negative guidance that steers prompts away from `suede-video`, `suede-social`, `suede-copy`, and `suede-ad-creative`. So the catalog entry and the skill's own frontmatter disagreed, and the skill had no routing coverage to catch it.

## Changes

- `mcp/catalog.json` — description synced **verbatim from `SKILL.md` frontmatter**, so the two cannot drift apart again
- `tests/fixtures/trigger-routing.json` — `clip-social-video` group ported verbatim (4 cases: 1 positive, 2 negative, 1 ambiguous-fallback)
- `scripts/validate-trigger-routing.mjs` — registers the group in `expectedGroups`

`useWhen` and `area` are deliberately untouched — `main`'s versions pass and reflect later intentional choices, so they were not part of the defect.

## Verification

- `npm test` exit 0. Trigger tests 31 → 35; validator clean across 71 skills; Python 29 pass.
- The positive/negative/ambiguous routing cases all passed before the catalog fix — only the metadata-parity assertion failed, which is what isolated the defect.

## Follow-up

`codex/suede-clip-to-guide-20260729` has now had its only unique content extracted and can be deleted.
