### PR TITLE
test(routing): cover 10 more skill clusters + collapsible ship-log

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1117,8 +1117,8 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span style="height:88%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Released Aug 10 <b>&middot; a49a998</b></span>
-              <span class="hero-shiplog-title">Skill search stops needing your exact wording</span>
+              <span class="hero-shiplog-top">Released Aug 10 <b>&middot; 672740e</b></span>
+              <span class="hero-shiplog-title">suede-clip-to-guide gets its boundaries back</span>
               <span class="hero-shiplog-more">223 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
             </span>
           </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2917,6 +2917,20 @@
       font-weight: 700;
     }
     .clog-filter:focus-visible { outline: 2px solid var(--color-accent-gold); outline-offset: 2px; }
+    /* Collapse toggle. Ships hidden and is revealed by JS: with no JS every
+       entry is already visible, so an inert button would just be a dead end. */
+    .clog-toggle {
+      margin: 22px 0 0; padding: 9px 18px;
+      font-family: inherit; font-size: 13px; letter-spacing: 0.02em;
+      color: var(--color-text-secondary);
+      background: transparent; border: 1px solid #222222; border-radius: 999px;
+      cursor: pointer;
+      transition: border-color 0.15s ease, color 0.15s ease;
+    }
+    .clog-toggle:hover { border-color: var(--color-accent-gold); color: var(--color-accent-gold); }
+    .clog-toggle:active { transform: translateY(1px); }
+    .clog-toggle:focus-visible { outline: 2px solid var(--color-accent-gold); outline-offset: 2px; }
+    .clog-toggle[hidden] { display: none; }
     .clog-list { list-style: none; margin: 8px 0 0; padding: 0; border-left: 1px solid #1c1c1c; }
     .clog-item { position: relative; padding: 20px 0 20px 30px; border-bottom: 1px solid #141414; }
     .clog-item::before {
@@ -3383,8 +3397,8 @@
             <span style="height:88%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Released Aug 10 <b>&middot; a49a998</b></span>
-            <span class="hero-shiplog-title">Skill search stops needing your exact wording</span>
+            <span class="hero-shiplog-top">Released Aug 10 <b>&middot; 672740e</b></span>
+            <span class="hero-shiplog-title">suede-clip-to-guide gets its boundaries back</span>
             <span class="hero-shiplog-more">223 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
           </span>
         </a>
@@ -3568,6 +3582,16 @@
 
     <div class="reveal reveal-d1">
       <ol class="clog-list" id="clog-list">
+
+        <li class="clog-item" data-type="fix">
+          <p class="clog-meta">
+            <span class="clog-date">2026-08-10</span>
+            <span class="clog-tag clog-tag--fix">Routing</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/672740e" target="_blank" rel="noopener" aria-label="View commit 672740e on GitHub">672740e</a>
+          </p>
+          <h3 class="clog-title">suede-clip-to-guide gets its boundaries back</h3>
+          <p class="clog-detail"><code>suede-clip-to-guide</code> turns a clip, talk moment, or transcript into a package that carries short-form attention to a long-form asset &mdash; moment scoring, rights routing, exact post copy, and an approval bundle. It shipped with a catalog description condensed to a single sentence, and the condensing dropped the <code>NOT FOR:</code> block that keeps it clear of <code>suede-video</code> and <code>suede-social</code> requests. The catalog entry is now copied verbatim from the skill's own frontmatter, so the two cannot disagree again, and a <code>clip-social-video</code> routing group proves the separation holds in both directions.</p>
+        </li>
 
         <li class="clog-item" data-type="fix">
           <p class="clog-meta">
@@ -3801,6 +3825,7 @@
         </li>
 
       </ol>
+      <button class="clog-toggle" id="clog-toggle" type="button" aria-expanded="true" aria-controls="clog-list" hidden>Show fewer</button>
       <a class="clog-more" href="https://github.com/JasonColapietro/suede-creator-skills/commits/main" target="_blank" rel="noopener">Full history on GitHub &rarr;</a>
     </div>
 
@@ -5020,15 +5045,56 @@
 
     var items = Array.prototype.slice.call(list.querySelectorAll('.clog-item'));
     var btns = Array.prototype.slice.call(document.querySelectorAll('.clog-filter'));
+    var toggle = document.getElementById('clog-toggle');
+    var LIMIT = 4;
+    var filter = 'all';
+    // Collapsed is the JS-only default. The no-JS page renders every entry,
+    // which is the honest fallback for a log whose whole point is being
+    // checkable.
+    var collapsed = true;
+
+    // One place decides visibility, so the filter and the toggle can never
+    // disagree about which entries are on screen. Filtering re-counts against
+    // the matching set, not the full list.
+    function apply() {
+      var matching = 0;
+      var shown = 0;
+      items.forEach(function(it) {
+        var passes = filter === 'all' || it.getAttribute('data-type') === filter;
+        if (passes) matching++;
+        var visible = passes && (!collapsed || shown < LIMIT);
+        if (visible) shown++;
+        it.hidden = !visible;
+      });
+      if (!toggle) return;
+      var collapsible = matching > LIMIT;
+      toggle.hidden = !collapsible;
+      toggle.setAttribute('aria-expanded', String(!collapsed));
+      toggle.textContent = collapsed ? 'Show all ' + matching + ' entries' : 'Show fewer';
+    }
+
     btns.forEach(function(btn) {
       btn.addEventListener('click', function() {
         btns.forEach(function(b) { b.setAttribute('aria-pressed', String(b === btn)); });
-        var t = btn.getAttribute('data-filter');
-        items.forEach(function(it) {
-          it.hidden = t !== 'all' && it.getAttribute('data-type') !== t;
-        });
+        filter = btn.getAttribute('data-filter');
+        apply();
       });
     });
+
+    if (toggle) {
+      toggle.addEventListener('click', function() {
+        collapsed = !collapsed;
+        apply();
+        // Collapsing can strand the reader below the list; pull the section
+        // header back into view instead of leaving them mid-page.
+        if (collapsed) {
+          var head = document.getElementById('changelog-headline');
+          if (head && head.scrollIntoView) head.scrollIntoView({ block: 'start' });
+        }
+      });
+    }
+
+    apply();
 
     // The release pill gains a client-computed relative label; the static
     // date stays as the no-JS truth.

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -465,8 +465,8 @@
         <span style="height:88%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Released Aug 10 <b>&middot; a49a998</b></span>
-        <span class="hero-shiplog-title">Skill search stops needing your exact wording</span>
+        <span class="hero-shiplog-top">Released Aug 10 <b>&middot; 672740e</b></span>
+        <span class="hero-shiplog-title">suede-clip-to-guide gets its boundaries back</span>
         <span class="hero-shiplog-more">223 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
       </span>
     </a>

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -488,13 +488,13 @@
     {
       "name": "suede-seo-audit",
       "area": "workflow",
-      "description": "Run a nine-lane SEO, AEO, and AI-citation audit: access, intent, metadata, structure, schema, E-E-A-T, clusters, and rewrite fixes.",
+      "description": "Run a nine-lane evidence-based SEO and generative-search audit: access, intent, metadata, structure, supported schema, E-E-A-T, clusters, and exact rewrite fixes.",
       "useWhen": "Audit Suede pages, GitHub Pages, README files, skill docs, launch pages, copy banks, install pages, and AI-result surfaces."
     },
     {
       "name": "suede-ship",
       "area": "workflow",
-      "description": "Canonical Suede shipping DAG: scout, multi-lens research, gap critic, lane plan with explicit file ownership, disjoint parallel build, dual-lens review, adversarial refute, integration gate, and release verification. Use for any nontrivial change to a repo that touches more than one file or surface. Halts on a blocking hazard (a real secret in a tracked file, a live process holding a target worktree) or a lane collision rather than plowing through. Reads production; never deploys. NOT FOR: high-volume, well-specified work that splits into independent worker-sized tasks (use suede-codex-fleet); findings-only review with no code change (use suede-code-review); CI and branch-protection wiring (use suede-ci-gate).",
+      "description": "Canonical Suede shipping DAG: scout, multi-lens research, gap critic, lane plan with explicit file ownership, disjoint parallel build, dual-lens review, adversarial refute, integration gate, and release verification. Use for any nontrivial change to a repo that touches more than one file or surface and deserves roughly fifty agents of surgical, research-heavy fan-out. Halts on a blocking hazard (a real secret in a tracked file, a live process holding a target worktree) or a lane collision rather than plowing through. Reads production; never deploys. NOT FOR: high-volume, well-specified work that splits into independent worker-sized tasks (use suede-codex-fleet, which bills to the OpenAI subscription instead); findings-only review with no code change (use suede-code-review); CI and branch-protection wiring (use suede-ci-gate).",
       "useWhen": "Take a nontrivial multi-file change through a research-heavy agent graph that halts on hazards and gates on real tests."
     },
     {

--- a/scripts/validate-trigger-routing.mjs
+++ b/scripts/validate-trigger-routing.mjs
@@ -68,6 +68,16 @@ export function validateContract(contract = loadContract(), catalog = loadCatalo
     "clip-social-video",
     "amazon-subscription",
     "social-instagram",
+    "competitor-intel",
+    "paid-ads",
+    "messaging-channels",
+    "pricing-offers",
+    "marketing-planning",
+    "seo-surfaces",
+    "writing-surfaces",
+    "activation",
+    "ship-release",
+    "growth-loops",
   ]);
   const catalogByName = new Map(catalog.skills.map((skill) => [skill.name, skill]));
   const seenGroups = new Set();

--- a/tests/fixtures/trigger-routing.json
+++ b/tests/fixtures/trigger-routing.json
@@ -387,6 +387,979 @@
           "expected": "subscription-recovery"
         }
       ]
+    },
+    {
+      "id": "competitor-intel",
+      "skills": [
+        "suede-competitors",
+        "suede-competitor-profiling"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-competitors",
+          "positive": [
+            "versus page",
+            "alternative page",
+            "comparison page",
+            "comparison content"
+          ],
+          "negative": [
+            "competitive landscape",
+            "public urls",
+            "competitor profiles",
+            "competitive intelligence"
+          ],
+          "metadataMustContain": [
+            "comparison page"
+          ]
+        },
+        {
+          "skill": "suede-competitor-profiling",
+          "positive": [
+            "competitive landscape",
+            "public urls",
+            "competitor profiles",
+            "competitive intelligence"
+          ],
+          "negative": [
+            "versus page",
+            "alternative page",
+            "comparison page"
+          ],
+          "metadataMustContain": [
+            "competitive intelligence"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "competitors-versus-page-positive",
+          "mode": "positive",
+          "prompt": "Write a versus page and an alternative page against named competitors.",
+          "expected": "suede-competitors"
+        },
+        {
+          "id": "competitor-profiling-negative",
+          "mode": "negative",
+          "prompt": "Build competitor profiles and a competitive landscape from their public URLs.",
+          "expected": "suede-competitor-profiling",
+          "forbidden": [
+            "suede-competitors"
+          ]
+        },
+        {
+          "id": "competitor-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help me with competitors.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "paid-ads",
+      "skills": [
+        "suede-ads",
+        "suede-ad-creative"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-ads",
+          "positive": [
+            "campaign structure",
+            "budget pacing",
+            "negative keywords",
+            "paid campaigns",
+            "bidding"
+          ],
+          "negative": [
+            "ad copy",
+            "hooks",
+            "creative concepts",
+            "variant batches"
+          ],
+          "metadataMustContain": [
+            "paid acquisition"
+          ]
+        },
+        {
+          "skill": "suede-ad-creative",
+          "positive": [
+            "ad copy",
+            "hooks",
+            "creative concepts",
+            "variant batches",
+            "ad creative"
+          ],
+          "negative": [
+            "campaign structure",
+            "budget pacing",
+            "negative keywords",
+            "bidding"
+          ],
+          "metadataMustContain": [
+            "ad creative"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "ads-campaign-structure-positive",
+          "mode": "positive",
+          "prompt": "Fix our campaign structure, bidding, and budget pacing across Google and Meta.",
+          "expected": "suede-ads"
+        },
+        {
+          "id": "ad-creative-negative",
+          "mode": "negative",
+          "prompt": "Produce ad copy variations, hooks, and creative concepts to test.",
+          "expected": "suede-ad-creative",
+          "forbidden": [
+            "suede-ads"
+          ]
+        },
+        {
+          "id": "paid-ads-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help with our advertising.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "messaging-channels",
+      "skills": [
+        "suede-emails",
+        "suede-cold-email",
+        "suede-sms"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-emails",
+          "positive": [
+            "lifecycle email",
+            "drip campaign",
+            "welcome sequence",
+            "nurture",
+            "post purchase"
+          ],
+          "negative": [
+            "cold email",
+            "outbound email",
+            "prospecting sequence",
+            "sms",
+            "text message"
+          ],
+          "metadataMustContain": [
+            "lifecycle email"
+          ]
+        },
+        {
+          "skill": "suede-cold-email",
+          "positive": [
+            "cold email",
+            "outbound email",
+            "prospecting sequence",
+            "subject lines"
+          ],
+          "negative": [
+            "lifecycle email",
+            "drip campaign",
+            "welcome sequence",
+            "sms",
+            "text message"
+          ],
+          "metadataMustContain": [
+            "cold email"
+          ]
+        },
+        {
+          "skill": "suede-sms",
+          "positive": [
+            "sms",
+            "text message",
+            "mms"
+          ],
+          "negative": [
+            "lifecycle email",
+            "drip campaign",
+            "cold email",
+            "outbound email"
+          ],
+          "metadataMustContain": [
+            "sms"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "emails-lifecycle-positive",
+          "mode": "positive",
+          "prompt": "Design a lifecycle email drip campaign with a welcome sequence.",
+          "expected": "suede-emails"
+        },
+        {
+          "id": "cold-email-negative",
+          "mode": "negative",
+          "prompt": "Write cold email subject lines for an outbound email prospecting sequence.",
+          "expected": "suede-cold-email",
+          "forbidden": [
+            "suede-emails"
+          ]
+        },
+        {
+          "id": "sms-channel-negative",
+          "mode": "negative",
+          "prompt": "Add SMS and MMS marketing with a consent aware text message cadence.",
+          "expected": "suede-sms",
+          "forbidden": [
+            "suede-emails",
+            "suede-cold-email"
+          ]
+        },
+        {
+          "id": "messaging-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Improve the messages we send.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "pricing-offers",
+      "skills": [
+        "suede-pricing",
+        "suede-offers",
+        "suede-paywalls"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-pricing",
+          "positive": [
+            "value metric",
+            "price increase",
+            "willingness to pay",
+            "freemium",
+            "tiers"
+          ],
+          "negative": [
+            "risk reversal",
+            "guarantees",
+            "paywall",
+            "feature gate",
+            "trial expiry"
+          ],
+          "metadataMustContain": [
+            "value metric"
+          ]
+        },
+        {
+          "skill": "suede-offers",
+          "positive": [
+            "risk reversal",
+            "guarantees",
+            "bonuses",
+            "high ticket"
+          ],
+          "negative": [
+            "value metric",
+            "willingness to pay",
+            "paywall",
+            "feature gate"
+          ],
+          "metadataMustContain": [
+            "risk reversal"
+          ]
+        },
+        {
+          "skill": "suede-paywalls",
+          "positive": [
+            "paywall",
+            "feature gate",
+            "trial expiry",
+            "usage limit",
+            "upgrade moments"
+          ],
+          "negative": [
+            "value metric",
+            "willingness to pay",
+            "risk reversal",
+            "guarantees"
+          ],
+          "metadataMustContain": [
+            "paywall"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "pricing-value-metric-positive",
+          "mode": "positive",
+          "prompt": "Choose a value metric, restructure tiers, and research willingness to pay.",
+          "expected": "suede-pricing"
+        },
+        {
+          "id": "paywalls-negative",
+          "mode": "negative",
+          "prompt": "Design the paywall screen, feature gate, and trial expiry upgrade moments.",
+          "expected": "suede-paywalls",
+          "forbidden": [
+            "suede-pricing"
+          ]
+        },
+        {
+          "id": "offers-negative",
+          "mode": "negative",
+          "prompt": "Build the guarantees, bonuses, and risk reversal for a high ticket offer.",
+          "expected": "suede-offers",
+          "forbidden": [
+            "suede-pricing",
+            "suede-paywalls"
+          ]
+        },
+        {
+          "id": "monetization-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help us make more money.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "marketing-planning",
+      "skills": [
+        "suede-marketing-plan",
+        "suede-marketing-ideas",
+        "suede-marketing-council",
+        "suede-marketing-loops"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-marketing-plan",
+          "positive": [
+            "90 day plan",
+            "12 month roadmap",
+            "growth plan",
+            "go to market"
+          ],
+          "negative": [
+            "shortlist",
+            "tactic library",
+            "simulated advisors",
+            "recurring workflow",
+            "weekly review"
+          ],
+          "metadataMustContain": [
+            "marketing planning"
+          ]
+        },
+        {
+          "skill": "suede-marketing-ideas",
+          "positive": [
+            "shortlist",
+            "tactic library",
+            "growth tactics",
+            "stuck"
+          ],
+          "negative": [
+            "90 day plan",
+            "12 month roadmap",
+            "simulated advisors",
+            "recurring workflow"
+          ],
+          "metadataMustContain": [
+            "marketing ideation"
+          ]
+        },
+        {
+          "skill": "suede-marketing-council",
+          "positive": [
+            "simulated advisors",
+            "expert lenses",
+            "disagreements"
+          ],
+          "negative": [
+            "90 day plan",
+            "shortlist",
+            "tactic library",
+            "recurring workflow"
+          ],
+          "metadataMustContain": [
+            "simulated advisors"
+          ]
+        },
+        {
+          "skill": "suede-marketing-loops",
+          "positive": [
+            "recurring workflow",
+            "weekly review",
+            "content refresh",
+            "ad fatigue",
+            "churn watch"
+          ],
+          "negative": [
+            "90 day plan",
+            "12 month roadmap",
+            "shortlist",
+            "simulated advisors"
+          ],
+          "metadataMustContain": [
+            "recurring marketing workflow"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "marketing-plan-positive",
+          "mode": "positive",
+          "prompt": "Build a 90 day plan and 12 month roadmap as our go to market document.",
+          "expected": "suede-marketing-plan"
+        },
+        {
+          "id": "marketing-ideas-negative",
+          "mode": "negative",
+          "prompt": "I am stuck — give me a shortlist of growth tactics from the tactic library.",
+          "expected": "suede-marketing-ideas",
+          "forbidden": [
+            "suede-marketing-plan"
+          ]
+        },
+        {
+          "id": "marketing-loops-negative",
+          "mode": "negative",
+          "prompt": "Design a recurring workflow for ad fatigue, content refresh, and weekly review.",
+          "expected": "suede-marketing-loops",
+          "forbidden": [
+            "suede-marketing-plan",
+            "suede-marketing-ideas"
+          ]
+        },
+        {
+          "id": "marketing-council-negative",
+          "mode": "negative",
+          "prompt": "Give me simulated advisors and expert lenses that surface disagreements.",
+          "expected": "suede-marketing-council",
+          "forbidden": [
+            "suede-marketing-plan",
+            "suede-marketing-loops"
+          ]
+        },
+        {
+          "id": "marketing-planning-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help with marketing.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "seo-surfaces",
+      "skills": [
+        "suede-seo-audit",
+        "suede-programmatic-seo"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-seo-audit",
+          "positive": [
+            "seo audit",
+            "generative search",
+            "rewrite fixes",
+            "nine lane"
+          ],
+          "negative": [
+            "programmatic seo",
+            "at scale",
+            "index worthiness",
+            "location pages"
+          ],
+          "metadataMustContain": [
+            "generative search"
+          ]
+        },
+        {
+          "skill": "suede-programmatic-seo",
+          "positive": [
+            "programmatic seo",
+            "at scale",
+            "index worthiness",
+            "location pages",
+            "directory"
+          ],
+          "negative": [
+            "seo audit",
+            "generative search",
+            "rewrite fixes"
+          ],
+          "metadataMustContain": [
+            "programmatic seo"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "seo-audit-positive",
+          "mode": "positive",
+          "prompt": "Run an SEO audit with generative search lanes and exact rewrite fixes.",
+          "expected": "suede-seo-audit"
+        },
+        {
+          "id": "programmatic-seo-negative",
+          "mode": "negative",
+          "prompt": "Design programmatic SEO location pages at scale with index worthiness gates.",
+          "expected": "suede-programmatic-seo",
+          "forbidden": [
+            "suede-seo-audit"
+          ]
+        },
+        {
+          "id": "seo-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help with search.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "writing-surfaces",
+      "skills": [
+        "suede-copy",
+        "johnny-suede-write",
+        "suede-ship-copy"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-copy",
+          "positive": [
+            "conversion copy",
+            "landing sections",
+            "microcopy",
+            "anti slop"
+          ],
+          "negative": [
+            "public explainers",
+            "product listings",
+            "publish readiness",
+            "adversarial refutation",
+            "research lenses"
+          ],
+          "metadataMustContain": [
+            "conversion copy"
+          ]
+        },
+        {
+          "skill": "johnny-suede-write",
+          "positive": [
+            "public explainers",
+            "product listings",
+            "sharper"
+          ],
+          "negative": [
+            "conversion copy",
+            "landing sections",
+            "publish readiness",
+            "adversarial refutation"
+          ],
+          "metadataMustContain": [
+            "public explainers"
+          ]
+        },
+        {
+          "skill": "suede-ship-copy",
+          "positive": [
+            "publish readiness",
+            "adversarial refutation",
+            "research lenses",
+            "high stakes"
+          ],
+          "negative": [
+            "conversion copy",
+            "microcopy",
+            "public explainers",
+            "product listings"
+          ],
+          "metadataMustContain": [
+            "publish readiness"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "copy-conversion-positive",
+          "mode": "positive",
+          "prompt": "Write conversion copy for the landing sections and the microcopy.",
+          "expected": "suede-copy"
+        },
+        {
+          "id": "ship-copy-negative",
+          "mode": "negative",
+          "prompt": "Run the research lenses and adversarial refutation to a publish readiness gate for this high stakes page.",
+          "expected": "suede-ship-copy",
+          "forbidden": [
+            "suede-copy"
+          ]
+        },
+        {
+          "id": "johnny-write-negative",
+          "mode": "negative",
+          "prompt": "Write sharper product listings and public explainers.",
+          "expected": "johnny-suede-write",
+          "forbidden": [
+            "suede-copy",
+            "suede-ship-copy"
+          ]
+        },
+        {
+          "id": "writing-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Write something for us.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "activation",
+      "skills": [
+        "suede-signup",
+        "suede-onboarding",
+        "suede-churn-prevention"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-signup",
+          "positive": [
+            "account creation",
+            "registration",
+            "field friction",
+            "progressive profiling",
+            "trial start"
+          ],
+          "negative": [
+            "first value",
+            "empty states",
+            "setup checklists",
+            "cancel flows",
+            "win back"
+          ],
+          "metadataMustContain": [
+            "signup conversion"
+          ]
+        },
+        {
+          "skill": "suede-onboarding",
+          "positive": [
+            "first value",
+            "empty states",
+            "setup checklists",
+            "activation milestones",
+            "time to value"
+          ],
+          "negative": [
+            "account creation",
+            "registration",
+            "field friction",
+            "cancel flows",
+            "win back"
+          ],
+          "metadataMustContain": [
+            "time to value"
+          ]
+        },
+        {
+          "skill": "suede-churn-prevention",
+          "positive": [
+            "cancel flows",
+            "win back",
+            "save offers",
+            "failed payment",
+            "pause paths"
+          ],
+          "negative": [
+            "account creation",
+            "registration",
+            "first value",
+            "empty states"
+          ],
+          "metadataMustContain": [
+            "failed payment recovery"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "signup-positive",
+          "mode": "positive",
+          "prompt": "Audit account creation and registration for field friction and progressive profiling.",
+          "expected": "suede-signup"
+        },
+        {
+          "id": "onboarding-negative",
+          "mode": "negative",
+          "prompt": "Users never reach first value — design empty states, setup checklists, and time to value.",
+          "expected": "suede-onboarding",
+          "forbidden": [
+            "suede-signup"
+          ]
+        },
+        {
+          "id": "churn-negative",
+          "mode": "negative",
+          "prompt": "Design cancel flows, pause paths, save offers, and failed payment recovery.",
+          "expected": "suede-churn-prevention",
+          "forbidden": [
+            "suede-signup",
+            "suede-onboarding"
+          ]
+        },
+        {
+          "id": "activation-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Improve activation.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "ship-release",
+      "skills": [
+        "suede-ship",
+        "suede-ci-gate",
+        "suede-launch-packaging",
+        "suede-release-linter"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-ship",
+          "positive": [
+            "shipping dag",
+            "lane plan",
+            "integration gate",
+            "release verification",
+            "disjoint parallel build"
+          ],
+          "negative": [
+            "branch protection",
+            "required checks",
+            "install commands",
+            "release folders",
+            "stems"
+          ],
+          "metadataMustContain": [
+            "shipping dag"
+          ]
+        },
+        {
+          "skill": "suede-ci-gate",
+          "positive": [
+            "branch protection",
+            "required checks",
+            "merge gates",
+            "duplicate pipeline"
+          ],
+          "negative": [
+            "shipping dag",
+            "lane plan",
+            "install commands",
+            "release folders",
+            "stems"
+          ],
+          "metadataMustContain": [
+            "branch protection"
+          ]
+        },
+        {
+          "skill": "suede-launch-packaging",
+          "positive": [
+            "install commands",
+            "handoff notes",
+            "proof links",
+            "release copy"
+          ],
+          "negative": [
+            "shipping dag",
+            "branch protection",
+            "release folders",
+            "stems",
+            "lyrics"
+          ],
+          "metadataMustContain": [
+            "handoff notes"
+          ]
+        },
+        {
+          "skill": "suede-release-linter",
+          "positive": [
+            "release folders",
+            "stems",
+            "artwork",
+            "lyrics",
+            "rights blockers"
+          ],
+          "negative": [
+            "shipping dag",
+            "branch protection",
+            "install commands",
+            "handoff notes"
+          ],
+          "metadataMustContain": [
+            "release folders"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "ci-gate-positive",
+          "mode": "positive",
+          "prompt": "Set up branch protection, required checks, and merge gates that do not deadlock.",
+          "expected": "suede-ci-gate"
+        },
+        {
+          "id": "release-linter-negative",
+          "mode": "negative",
+          "prompt": "Audit the release folders: stems, artwork, lyrics, and rights blockers.",
+          "expected": "suede-release-linter",
+          "forbidden": [
+            "suede-launch-packaging",
+            "suede-ship"
+          ]
+        },
+        {
+          "id": "launch-packaging-negative",
+          "mode": "negative",
+          "prompt": "Write install commands, proof links, release copy, and handoff notes.",
+          "expected": "suede-launch-packaging",
+          "forbidden": [
+            "suede-release-linter",
+            "suede-ci-gate"
+          ]
+        },
+        {
+          "id": "suede-ship-dag-negative",
+          "mode": "negative",
+          "prompt": "Run the shipping dag with a lane plan, integration gate, and release verification.",
+          "expected": "suede-ship",
+          "forbidden": [
+            "suede-ci-gate",
+            "suede-launch-packaging"
+          ]
+        },
+        {
+          "id": "ship-release-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help me ship this.",
+          "expected": "clarify"
+        }
+      ]
+    },
+    {
+      "id": "growth-loops",
+      "skills": [
+        "suede-referrals",
+        "suede-co-marketing",
+        "suede-community-marketing"
+      ],
+      "fallback": "clarify",
+      "routes": [
+        {
+          "skill": "suede-referrals",
+          "positive": [
+            "refer a friend",
+            "affiliate",
+            "ambassador",
+            "payout logic",
+            "viral loop"
+          ],
+          "negative": [
+            "audience overlap",
+            "joint offers",
+            "cross promotion",
+            "moderation",
+            "subreddit"
+          ],
+          "metadataMustContain": [
+            "referral and affiliate program"
+          ]
+        },
+        {
+          "skill": "suede-co-marketing",
+          "positive": [
+            "audience overlap",
+            "joint offers",
+            "cross promotion",
+            "partner fit"
+          ],
+          "negative": [
+            "refer a friend",
+            "affiliate",
+            "payout logic",
+            "moderation",
+            "subreddit"
+          ],
+          "metadataMustContain": [
+            "co marketing"
+          ]
+        },
+        {
+          "skill": "suede-community-marketing",
+          "positive": [
+            "subreddit",
+            "moderation",
+            "member purpose",
+            "seeding",
+            "health metrics"
+          ],
+          "negative": [
+            "refer a friend",
+            "affiliate",
+            "audience overlap",
+            "joint offers"
+          ],
+          "metadataMustContain": [
+            "community growth"
+          ]
+        }
+      ],
+      "cases": [
+        {
+          "id": "referrals-positive",
+          "mode": "positive",
+          "prompt": "Design refer a friend and ambassador mechanics with payout logic and viral loop measurement.",
+          "expected": "suede-referrals"
+        },
+        {
+          "id": "co-marketing-negative",
+          "mode": "negative",
+          "prompt": "Find partner fit with audience overlap and plan joint offers and cross promotion.",
+          "expected": "suede-co-marketing",
+          "forbidden": [
+            "suede-referrals"
+          ]
+        },
+        {
+          "id": "community-negative",
+          "mode": "negative",
+          "prompt": "Grow a subreddit with member purpose, seeding, moderation, and health metrics.",
+          "expected": "suede-community-marketing",
+          "forbidden": [
+            "suede-referrals",
+            "suede-co-marketing"
+          ]
+        },
+        {
+          "id": "growth-loops-ambiguous-fallback",
+          "mode": "ambiguous",
+          "prompt": "Help us grow.",
+          "expected": "clarify"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Two commits.

## 1. Routing coverage: 19/71 → 48/71 skills

Routing coverage was 19 of 71 skills. The gap was **not** 52 untested skills — a routing group only asserts something when two or more skills can be mistaken for each other. A skill with no confusable sibling has nothing to route against.

Ten genuine clusters, now covered:

`competitor-intel` · `paid-ads` · `messaging-channels` · `pricing-offers` · `marketing-planning` · `seo-surfaces` · `writing-surfaces` · `activation` · `ship-release` · `growth-loops`

**8 → 18 groups, 31 → 70 cases.** The remaining 23 skills have no confusable sibling.

Signals are transcribed from each skill's own `SKILL.md` description rather than invented — most already spell out their boundaries in a `NOT FOR:` block naming the sibling skill, so the routing intent was already written down.

Two catalog descriptions had drifted from their `SKILL.md` and are synced verbatim (`suede-seo-audit`, `suede-ship`) — the same fix as `suede-clip-to-guide` in #72.

**Teeth check:** repointing any of the 70 cases at any sibling skill or at `clarify` fails the contract — **118/118 mutations caught.** These tests are load-bearing, not decorative.

## 2. Changelog entry + collapsible ship-log

Adds a changelog entry for `672740e` explaining what `suede-clip-to-guide` does, since the site never introduced it.

The ship-log had reached 25 entries with no way to skim. It now collapses to the newest four:

- **Collapsed is the JS-only default.** The no-JS page renders all 25 — the honest fallback for a log whose whole point is being checkable — and the toggle carries `hidden` in the markup so it is never a dead control.
- **One `apply()` decides visibility**, so the type filters and the toggle cannot disagree. The label counts the *filtered* set ("Show all 8 entries" under Fixes), and the toggle hides itself when a filter leaves four or fewer.
- **Collapsing scrolls the header back into view** rather than stranding the reader below a list that just shrank.

The three mirrored hero ship-log boxes follow the new newest entry, as the release-log guard requires.

## Verification

- `npm test` exit 0 — validator clean across 71 skills; trigger routing 74 pass; 14/15/28 pass elsewhere; Python 29 pass.
- Collapse behavior driven in a real browser: 4 of 25 collapsed, 25 expanded, label and `aria-expanded` track state, filter interaction correct at every step, toggle hit-testable and keyboard-focusable.
