### PR TITLE
Update essays subline to 73 skills

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4698,7 +4698,7 @@
   <div class="essays-inner">
     <p class="essays-eyebrow reveal">Field notes</p>
     <h2 id="essays-headline" class="essays-headline reveal reveal-d1">Why it's built this way.</h2>
-    <p class="essays-sub reveal reveal-d1">The design decisions behind the pack, written up as essays: how 71 skills stay cheap to carry, how they route without colliding, and why your memory file should be jealous.</p>
+    <p class="essays-sub reveal reveal-d1">The design decisions behind the pack, written up as essays: how 73 skills stay cheap to carry, how they route without colliding, and why your memory file should be jealous.</p>
     <div class="essays-list reveal reveal-d2">
       <a class="essay-row" href="blog/progressive-disclosure-ship-dag-and-mcp.html">
         <span class="essay-date">Aug 2026</span>


### PR DESCRIPTION
One remaining stale pack-size claim in current prose on the homepage (essays section subline). The historical changelog entry and the published essay title correctly keep 71.