### PR TITLE
Release 0.12.0: estate standards pass

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "suede-skills",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Complete Suede workflow for Claude Code and Codex: Full Send orchestration, reviewed multi-agent execution, code and release gates, design, copy, SEO, app shipping, and creator utilities. Installs all 73 skills.",
   "author": {
     "name": "Jason Colapietro",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "suede-skills",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Seventy-three public Suede skills and a read-only MCP for decisive agent workflows, code review, design, copy, SEO, app shipping, and creator work.",
   "author": {
     "name": "Jason Colapietro",

--- a/docs/index.html
+++ b/docs/index.html
@@ -3557,7 +3557,7 @@
       <h2 id="changelog-headline" class="clog-headline reveal reveal-d1">A review pack had better survive its own review.</h2>
       <p class="clog-sub reveal reveal-d1">So the work ships in public. Every entry below is a real commit on <code>main</code>: what changed, when it landed, and the hash that proves it. No "various improvements."</p>
 
-      <p class="clog-fresh reveal reveal-d2">Version 0.11.1 released Aug 10, 2026 <span id="clog-fresh-rel" data-iso="2026-08-10"></span></p>
+      <p class="clog-fresh reveal reveal-d2">Version 0.12.0 released Aug 15, 2026 <span id="clog-fresh-rel" data-iso="2026-08-15"></span></p>
 
       <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last ten weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, and 56 commits.">
         <span style="height:8%"></span>
@@ -3584,6 +3584,16 @@
 
     <div class="reveal reveal-d1">
       <ol class="clog-list" id="clog-list">
+
+        <li class="clog-item" data-type="fix">
+          <p class="clog-meta">
+            <span class="clog-date">2026-08-15</span>
+            <span class="clog-tag clog-tag--fix">Skills</span>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1163506" target="_blank" rel="noopener" aria-label="View commit 1163506 on GitHub">1163506</a>
+          </p>
+          <h3 class="clog-title">Every skill measured against the packs people actually rate</h3>
+          <p class="clog-detail">Version 0.12.0 audits all 73 skills against Anthropic&rsquo;s Agent Skills guidance, the agentskills.io spec, and the top community packs, with every major cut or addition adversarially re-verified against the file before landing. Around 40 descriptions now lead with a literal &ldquo;Use when&rdquo; trigger and NOT FOR routes. Every orchestrator names its model per dispatch, caps its roster and fix loops numerically, and writes a durable ledger. <code>suede-workflow-skills</code> drops from 601 to 347 lines and finally routes the whole pack &mdash; 44 skills previously had no path from the entry point. Two new tested scripts ship: a commit-dirt scanner for reviews and an MCP surface-drift snapshot.</p>
+        </li>
 
         <li class="clog-item" data-type="fix">
           <p class="clog-meta">

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -1,7 +1,7 @@
 {
   "name": "Suede Skills MCP",
-  "version": "0.11.1",
-  "updated": "2026-08-10",
+  "version": "0.12.0",
+  "updated": "2026-08-15",
   "homepage": "https://skills.suedeai.ai/",
   "repository": "https://github.com/JasonColapietro/suede-creator-skills",
   "summary": "Local MCP access to an open-source Suede skill pack: decisive full-send routing, full-stack design and writing modes, reference-site restyling, SEO/AEO/AI EO, visibility grading, AI eval design, one-pass code review+grade, any-repo CI ship-gate, agent-team orchestration, Codex CLI worker-fleet orchestration, install and launch packaging, MCP QA, artist campaign tools, and creator rights utilities.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "suede-creator-skills",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "suede-creator-skills",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "js-yaml": "5.2.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suede-creator-skills",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/skills/suede-mcp-qa/references/stdio-test-blocks.md
+++ b/skills/suede-mcp-qa/references/stdio-test-blocks.md
@@ -30,7 +30,7 @@ printf '%s\n' \
 ```
 
 The initialization result must report protocol `2025-06-18`, server version
-`0.11.1`, and explicit tools/resources/prompts capabilities. `tools/list` must
+`0.12.0`, and explicit tools/resources/prompts capabilities. `tools/list` must
 return exactly the 8 tools above. Each tool must expose `inputSchema`,
 `outputSchema`, and annotations with `readOnlyHint: true`,
 `destructiveHint: false`, `idempotentHint: true`, and `openWorldHint: false`.


### PR DESCRIPTION
Version bump so the installed plugin refreshes to the merged standards-pass content (#78). Updates package.json, package-lock, catalog.json, both plugin manifests, the suede-mcp-qa manual readback version, the docs release pill, and adds the 0.12.0 changelog entry. All validators green locally.