### PR TITLE
review(suede-code-review): adopt Matt Pocock upstream review techniques

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -43,4 +43,26 @@ preserving useful domain substance. The adaptation includes:
 
 ---
 
+## skills — Matt Pocock
+
+The Design Smell Baseline in `suede-code-review` (`references/smell-baseline.md`,
+routed from `suede-code`) — a twelve-smell maintainability catalog with
+repo-overrides / judgment-call / skip-tooling binding rules — is **adapted from
+[skills](https://github.com/mattpocock/skills) by Matt Pocock** (itself drawing
+on Martin Fowler's _Refactoring_, ch. 3), used and redistributed under the MIT
+License. The spec-source discovery order and reviewability pre-flight in
+`suede-code-review` are adapted from the same source.
+
+**Upstream:** https://github.com/mattpocock/skills
+**Upstream license:** MIT, Copyright (c) 2026 Matt Pocock — full text in
+[`licenses/mattpocock-skills-MIT.txt`](licenses/mattpocock-skills-MIT.txt)
+
+The adaptation rescopes the material to this pack's review contract: findings
+carry P-levels and confidence labels, smells are diff-scoped and feed the
+Technical Debt lane rather than the Ship Gate, and the two-axis
+standards/spec separation is folded into the existing Intent Compliance
+section instead of shipping as a separate skill.
+
+---
+
 Everything else in this repository is © 2026 Suede Labs AI, MIT licensed — see [`LICENSE`](LICENSE).

--- a/licenses/mattpocock-skills-MIT.txt
+++ b/licenses/mattpocock-skills-MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/suede-code-review/SKILL.md
+++ b/skills/suede-code-review/SKILL.md
@@ -49,6 +49,13 @@ Before review, identify:
 - risk lanes: frontend, backend, data, auth, payments, contracts, iOS, release,
   public copy, analytics, secrets, deployment, and docs.
 
+**Pre-flight, before any analysis or agent lanes spawn:** pin the comparison
+point and prove it is reviewable. `git rev-parse <fixed-point>` must resolve;
+diff with three dots (`git diff <fixed-point>...HEAD`) so the comparison runs
+against the merge-base, not a moving branch tip; and confirm the diff is
+non-empty. A bad ref or empty diff fails here, in one line — not inside a
+half-finished deep review.
+
 ## Context Graph
 
 Build a lightweight graph before judging the diff:
@@ -340,10 +347,28 @@ an API contract an iOS client consumes.
 
 Flag tech debt patterns as P3, group by file, don't block ship. Do not block a ship on P3 tech debt unless it directly obscures a P0/P1 bug. File as follow-up.
 
+### Design Smell Baseline (--standard and --deep)
+
+Beyond what the repo documents, the review carries a fixed twelve-smell
+maintainability baseline (Fowler, _Refactoring_ ch. 3) in
+`references/smell-baseline.md`. Load it on `--standard` and `--deep` reviews and
+match it against the diff only. Its binding rules travel with it: a documented
+repo rule overrides the baseline, every smell finding is a labeled judgment
+call ("possible Feature Envy", P3 by default, confidence `medium` at best), and
+anything tooling already enforces is skipped. Smell findings feed this
+Technical Debt lane — they never outrank correctness findings and never move
+the Ship Gate on their own.
+
 ## Intent Compliance and Scope
 
 Code that works but does not do what it claimed is still a defect.
 
+- **Find the spec first.** Look for the originating spec in this order: issue
+  or ticket references in the commit messages and PR body (`#123`,
+  `Closes #45`); a path the caller passed; a spec file under `docs/`, `specs/`,
+  or a scratch directory matching the branch or feature name. If none exists,
+  say "no spec available" in the output and review intent from the PR
+  description alone — never invent requirements to review against.
 - **Claim vs diff:** restate what the change says it does — PR title, description, linked issue, commit subject — and confirm the diff delivers it. Map every acceptance criterion to a code path or a test. Claimed behavior with no corresponding change is a P1 truth gap.
 - **Scope creep:** flag changes that do more than they claim — an unrelated refactor riding inside a bugfix, a dependency bump bundled with a feature, a formatting sweep that buries the real diff. Name the unrelated clusters and recommend splitting.
 - **Review-effort signal:** state diff size (files / net lines) and an effort read — trivial / moderate / heavy / too-large-to-review-safely. A single PR mixing auth, payments, and a migration should be split before it is safe to judge.

--- a/skills/suede-code-review/references/smell-baseline.md
+++ b/skills/suede-code-review/references/smell-baseline.md
@@ -1,0 +1,68 @@
+# Design Smell Baseline
+
+A fixed maintainability baseline the review carries even when the repo documents
+no coding standards: twelve code smells from Martin Fowler's _Refactoring_
+(ch. 3), as adapted in [mattpocock/skills](https://github.com/mattpocock/skills)
+(MIT, © 2026 Matt Pocock — see `NOTICE.md`). Match each against the diff, not
+the whole file: flag only smells the change introduces or makes worse.
+
+## Binding rules
+
+1. **The repo overrides.** A documented project rule always wins; where the repo
+   endorses a pattern this baseline would flag, suppress the smell. This is the
+   same precedence as Project Rules and Learnings in the skill body.
+2. **Always a judgment call.** Every smell finding is a labeled heuristic —
+   "possible Feature Envy" — never a hard violation. Severity is P3 by default;
+   P2 only when the smell sits on a changed critical path and demonstrably
+   raises defect risk (name the path). Confidence is `medium` at best — these
+   are read from the code, not executed.
+3. **Skip what tooling enforces.** If a linter, formatter, or type checker
+   already catches it, it is that gate's job, not a manual finding.
+4. **Diff-scoped.** Pre-existing smells outside the changed lines are not
+   findings; at most one "residual risk" line if the change builds on them.
+
+## The twelve smells
+
+Each reads *what it is* → *how to fix*:
+
+- **Mysterious Name** — a function, variable, or type whose name doesn't reveal
+  what it does or holds. → Rename it; if no honest name comes, the design is
+  murky — say that instead.
+- **Duplicated Code** — the same logic shape appears in more than one hunk or
+  file in the change. → Extract the shared shape, call it from both.
+- **Feature Envy** — a method that reaches into another object's data more than
+  its own. → Move the method onto the data it envies.
+- **Data Clumps** — the same few fields or params keep traveling together (a
+  type wanting to be born). → Bundle them into one type, pass that.
+- **Primitive Obsession** — a primitive or string standing in for a domain
+  concept that deserves its own type. → Give the concept its own small type.
+- **Repeated Switches** — the same `switch`/`if`-cascade on the same type
+  recurs across the change. → Replace with polymorphism, or one map both sites
+  share.
+- **Shotgun Surgery** — one logical change forces scattered edits across many
+  files in the diff. → Gather what changes together into one module.
+- **Divergent Change** — one file or module is edited for several unrelated
+  reasons. → Split so each module changes for one reason.
+- **Speculative Generality** — abstraction, parameters, or hooks added for
+  needs the spec doesn't have. → Delete it; inline back until a real need
+  shows.
+- **Message Chains** — long `a.b().c().d()` navigation the caller shouldn't
+  depend on. → Hide the walk behind one method on the first object.
+- **Middle Man** — a class or function that mostly just delegates onward. →
+  Cut it, call the real target directly.
+- **Refused Bequest** — a subclass or implementer that ignores or overrides
+  most of what it inherits. → Drop the inheritance, use composition.
+
+## Output shape
+
+Report a smell as a normal P2/P3 finding with the smell named and the hunk
+quoted:
+
+```
+[P3] lib/orders.ts:88 — possible Data Clumps: (currency, amount, region) travel
+together through 3 signatures in this diff; bundle as a Money type. Confidence: medium
+```
+
+Never let smell findings outnumber or outrank correctness findings — they feed
+the Technical Debt lane, not the Ship Gate, unless rule 2's P2 condition is
+met.

--- a/skills/suede-code/SKILL.md
+++ b/skills/suede-code/SKILL.md
@@ -139,7 +139,7 @@ Score each lane A-F, then one overall. For non-Suede work, substitute "domain tr
 - **Data migrations** — A needs a documented rollback + restore tested against prod-like data (or justified waiver); B needs a rollback plan, restore untested; no rollback plan caps at **D**.
 - **Public API changes** — A needs verified backward-compat or a versioned migration path; breaking with no path caps at **C**.
 
-**Tech debt** — grade impact depends on location, not just pattern. Debt in auth/payment/migration paths is one level stricter (a God object in a payment module is D, not C). Debt in core/high-traffic is standard. Debt in utilities/scripts is flagged as a Required Upgrade but does not lower the overall grade unless it bleeds into a critical path. Do not block a ship on tech debt alone unless it directly obscures a P0/P1 bug.
+**Tech debt** — grade impact depends on location, not just pattern. Debt in auth/payment/migration paths is one level stricter (a God object in a payment module is D, not C). Debt in core/high-traffic is standard. Debt in utilities/scripts is flagged as a Required Upgrade but does not lower the overall grade unless it bleeds into a critical path. Do not block a ship on tech debt alone unless it directly obscures a P0/P1 bug. For a named maintainability catalog, load the twelve-smell Design Smell Baseline reference bundled with suede-code-review — same binding rules: repo overrides, judgment-call severity, skip what tooling enforces.
 
 ## Step 5 — Deploy Safety Gate (runs at the end, every time)
 


### PR DESCRIPTION
## What

Reviewed the newly configured Matt Pocock skill pack ([mattpocock/skills](https://github.com/mattpocock/skills), follow-up to #80) against the estate and integrated the techniques that are genuinely additive — same upstream-integration pattern as the Corey Haines work in #76.

**suede-code-review**
- New `references/smell-baseline.md` — twelve-smell Fowler maintainability catalog (what → fix), with binding rules: repo standards override, every smell is a labeled judgment call (P3 default, confidence medium at best), skip what tooling enforces, diff-scoped only. Loaded on `--standard`/`--deep`; feeds the Technical Debt lane, never moves the Ship Gate alone.
- Review Contract pre-flight: `git rev-parse` the fixed point, three-dot merge-base diff, non-empty check — a bad ref fails in one line, not inside a half-finished deep review.
- Intent Compliance: spec-source discovery order (commit/PR issue refs → caller-passed path → docs/specs matching branch name → "no spec available", never invented requirements).

**suede-code** — one routing line from its tech-debt lane to the shared smell baseline.

**NOTICE.md + licenses/** — credit for mattpocock/skills (MIT, © 2026 Matt Pocock), full license text vendored, adaptation notes included.

**Reviewed and deliberately not adopted:** grilling/wizard/wayfinder (suede-think/suede-spec/agent-teams own those jobs), to-tickets/triage (issue-tracker docs landed in #80), setup-pre-commit/git-guardrails (suede-ci-gate territory), prototype (suede-think spike mode). Personal-estate counterparts (suede-debug tight-loop discipline, suede-plan expand–contract, suede-skill-forge authoring levers) landed separately in suede-personal-skills@4dc899c.

## Validation
- `npm run validate` — 73/73 catalog entries, trigger routing 18 groups / 70 cases, book current
- `npm test` — full suite, exit 0
- Estate linter — OK (883 refs/resources, all routes resolve)