### PR TITLE
Mobile nav: one no-JS-safe <details> disclosure across the estate

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,6 +73,17 @@ evidence-led, and easy to scan.
 - Catalog live filter on the skills index: hidden until JS reveals it, mono
   input, gold focus ring, `/` focuses, lanes collapse while filtering, and
   the result count announces via `aria-live`.
+- Mobile navigation is one `<details class="nav-disclosure">` pattern on every
+  page, including the generated book. The markup ships `open`, so a visit with
+  JavaScript disabled still reaches every link; JS collapses it at 768px and
+  under, and keeps the summary's `aria-label` swapping between "Open
+  navigation menu" and "Close navigation menu". The summary carries
+  `.nav-hamburger` at a 44px square with the three bars crossing into an X
+  when open. Desktop keeps the inline row: the disclosure is
+  `display: contents` and the summary is hidden, so layout is unchanged.
+  This replaced a homepage menu that could not open without JS and an interior
+  nav that simply wrapped its links, giving three different nav heights and
+  eating roughly a fifth of a phone viewport on the catalog.
 - Changelog ship log: timeline ledger of real commits with type-coded spine
   nodes, commit-activity sparkline, last-shipped freshness pill, and type
   filter chips. Entries carry real dates and short hashes linking to GitHub;

--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -218,12 +218,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -236,7 +270,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -245,6 +285,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -340,5 +381,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -228,12 +228,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -246,7 +280,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -256,6 +296,7 @@
           <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -364,6 +405,29 @@
         reveal(data.stargazers_count);
       })
       .catch(function() {});
+  })();
+</script>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
   })();
 </script>
 </body>

--- a/docs/blog/memory-belongs-in-skills.html
+++ b/docs/blog/memory-belongs-in-skills.html
@@ -234,12 +234,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -252,7 +286,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -261,6 +301,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -335,5 +376,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/blog/not-for-the-line-that-makes-a-pack-work.html
+++ b/docs/blog/not-for-the-line-that-makes-a-pack-work.html
@@ -233,12 +233,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -251,7 +285,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -260,6 +300,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -328,5 +369,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
+++ b/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
@@ -218,12 +218,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -236,7 +270,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -245,6 +285,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -337,5 +378,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/blog/why-breadth-is-free.html
+++ b/docs/blog/why-breadth-is-free.html
@@ -233,12 +233,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -251,7 +285,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -260,6 +300,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -319,5 +360,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/book/anatomy-of-a-skill.html
+++ b/docs/book/anatomy-of-a-skill.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -417,5 +458,28 @@ policy:
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/design-and-copy-are-engineering.html
+++ b/docs/book/design-and-copy-are-engineering.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/evidence-or-it-did-not-ship.html
+++ b/docs/book/evidence-or-it-did-not-ship.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/front-matter.html
+++ b/docs/book/front-matter.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -358,5 +399,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/full-send.html
+++ b/docs/book/full-send.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -374,5 +415,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/getting-found.html
+++ b/docs/book/getting-found.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -377,5 +418,28 @@ and take the intended next action?</code></pre>
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/grading-your-own-work.html
+++ b/docs/book/grading-your-own-work.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -350,12 +350,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -399,7 +433,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -407,7 +447,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -579,5 +620,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/lanes-fleets-and-collisions.html
+++ b/docs/book/lanes-fleets-and-collisions.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/shipping-into-the-real-world.html
+++ b/docs/book/shipping-into-the-real-world.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -367,5 +408,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/skill-index.html
+++ b/docs/book/skill-index.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -357,5 +398,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/taste-judgment-and-stopping.html
+++ b/docs/book/taste-judgment-and-stopping.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -392,5 +433,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/the-competence-gap.html
+++ b/docs/book/the-competence-gap.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -387,5 +428,28 @@ Ship gate: ship | ship-with-caveats | hold</code></pre>
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/the-description-contract.html
+++ b/docs/book/the-description-contract.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -373,5 +414,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/the-first-ninety-days.html
+++ b/docs/book/the-first-ninety-days.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -374,5 +415,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/the-rules.html
+++ b/docs/book/the-rules.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -349,5 +390,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/the-s-tier-ladder.html
+++ b/docs/book/the-s-tier-ladder.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -387,5 +428,28 @@
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/book/write-your-own.html
+++ b/docs/book/write-your-own.html
@@ -235,12 +235,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
 
       .book-meta { display: flex; flex-wrap: wrap; gap: 6px 18px; font-size: 13px; color: var(--muted); letter-spacing: 0.04em; margin-bottom: 28px; }
       ol { list-style: none; counter-reset: item; margin: 0 0 16px; }
@@ -284,7 +318,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="../">Home</a>
           <a href="../skills/">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,7 +332,8 @@
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -379,5 +420,28 @@ cp -R skills/suede-release-notes .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -258,12 +258,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
   <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -277,7 +311,13 @@
       <img src="./assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
       <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
     </a>
-    <div class="nav-links">
+    <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
       <a href="./">Home</a>
       <a href="./skills/">Skills</a>
       <a href="./guide.html">Guide</a>
@@ -287,6 +327,7 @@
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="./plugins.html" class="nav-cta">Install</a>
     </div>
+    </details>
   </div>
 </nav>
 
@@ -611,6 +652,29 @@ Repo: https://github.com/JasonColapietro/suede-creator-skills</pre>
         reveal(data.stargazers_count);
       })
       .catch(function() {});
+  })();
+</script>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
   })();
 </script>
 </body>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -736,6 +736,43 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
   </style>
@@ -750,7 +787,13 @@
           <img src="./assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="./">Home</a>
           <a href="./skills/">Skills</a>
           <a href="./guide.html" aria-current="page">Guide</a>
@@ -760,6 +803,7 @@
           <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="./plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </div>
     </nav>
 
@@ -1308,6 +1352,29 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
         reveal(data.stargazers_count);
       })
       .catch(function() {});
+  })();
+</script>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
   })();
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1959,8 +1959,14 @@
     /* ============================================================
        MOBILE NAV HAMBURGER
     ============================================================ */
+    /* Mobile nav is a <details> disclosure: it ships open in the markup, so
+       with JS off every link stays reachable. JS collapses it at mobile
+       widths and keeps the summary's label in sync with the state. */
+    .nav-disclosure { display: contents; }
+
     .nav-hamburger {
       display: none;
+      list-style: none;
       flex-direction: column;
       justify-content: center;
       gap: 5px;
@@ -1974,6 +1980,8 @@
       transition: border-color var(--transition-fast);
     }
 
+    .nav-hamburger::-webkit-details-marker { display: none; }
+    .nav-hamburger::marker { content: ""; }
     .nav-hamburger:hover { border-color: var(--color-accent-gold); }
 
     .nav-hamburger span {
@@ -1984,9 +1992,9 @@
       transition: background var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
     }
 
-    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
-    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(2) { opacity: 0; }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
 
     #nav-mobile-menu {
       display: none;
@@ -2004,7 +2012,9 @@
       gap: var(--space-1);
     }
 
-    #nav-mobile-menu.open { display: flex; }
+    @media (max-width: 768px) {
+      .nav-disclosure[open] #nav-mobile-menu { display: flex; }
+    }
 
     .nav-mobile-link {
       display: block;
@@ -3553,24 +3563,26 @@
       <a href="blog/" class="nav-link">Blog</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="plugins.html" class="nav-cta">Install</a>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="nav-mobile-menu">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
+      <details class="nav-disclosure" id="nav-disclosure" open>
+        <summary class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </summary>
+        <div id="nav-mobile-menu" role="menu" aria-label="Mobile navigation">
+        <a href="skills/" class="nav-mobile-link" role="menuitem">Skills</a>
+        <a href="#changelog" class="nav-mobile-link" role="menuitem">Changelog</a>
+        <a href="#scorecard" class="nav-mobile-link" role="menuitem">Benchmarks</a>
+        <a href="guide.html" class="nav-mobile-link" role="menuitem">Guide</a>
+        <a href="book/" class="nav-mobile-link" role="menuitem">Book</a>
+        <a href="blog/" class="nav-mobile-link" role="menuitem">Blog</a>
+        <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" class="nav-mobile-link" role="menuitem">Star on GitHub</a>
+        <a href="plugins.html" class="nav-mobile-link nav-mobile-cta" role="menuitem">Install</a>
+        </div>
+      </details>
     </div>
   </div>
 
-  <div id="nav-mobile-menu" role="menu" aria-label="Mobile navigation">
-    <a href="skills/" class="nav-mobile-link" role="menuitem">Skills</a>
-    <a href="#changelog" class="nav-mobile-link" role="menuitem">Changelog</a>
-    <a href="#scorecard" class="nav-mobile-link" role="menuitem">Benchmarks</a>
-    <a href="guide.html" class="nav-mobile-link" role="menuitem">Guide</a>
-    <a href="book/" class="nav-mobile-link" role="menuitem">Book</a>
-    <a href="blog/" class="nav-mobile-link" role="menuitem">Blog</a>
-    <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" class="nav-mobile-link" role="menuitem">Star on GitHub</a>
-    <a href="plugins.html" class="nav-mobile-link nav-mobile-cta" role="menuitem">Install</a>
-  </div>
 </nav>
 
 <main id="main" tabindex="-1">
@@ -5070,25 +5082,30 @@
     }, { passive: true });
   })();
 
-  // Mobile nav hamburger
+  // Mobile nav hamburger. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only.
   (function() {
+    var box = document.getElementById('nav-disclosure');
     var hamburger = document.getElementById('nav-hamburger');
     var menu = document.getElementById('nav-mobile-menu');
-    if (!hamburger || !menu) return;
+    if (!box || !hamburger || !menu) return;
+    var mq = window.matchMedia('(max-width: 768px)');
 
-    hamburger.addEventListener('click', function() {
-      var expanded = hamburger.getAttribute('aria-expanded') === 'true';
-      hamburger.setAttribute('aria-expanded', String(!expanded));
-      hamburger.setAttribute('aria-label', expanded ? 'Open navigation menu' : 'Close navigation menu');
-      menu.classList.toggle('open', !expanded);
-    });
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      hamburger.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
 
-    // Close menu when a link is clicked
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+
+    // Close after picking a destination (same-page anchors do not reload).
     menu.querySelectorAll('a').forEach(function(link) {
       link.addEventListener('click', function() {
-        hamburger.setAttribute('aria-expanded', 'false');
-        hamburger.setAttribute('aria-label', 'Open navigation menu');
-        menu.classList.remove('open');
+        if (mq.matches) box.open = false;
       });
     });
   })();

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -362,12 +362,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
   <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -381,7 +415,13 @@
       <img src="./assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
       <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
     </a>
-    <div class="nav-links">
+    <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
       <a href="./">Home</a>
       <a href="./skills/">Skills</a>
       <a href="./guide.html">Guide</a>
@@ -391,6 +431,7 @@
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="./plugins.html" aria-current="page" class="nav-cta">Install</a>
     </div>
+    </details>
   </div>
 </nav>
 
@@ -816,6 +857,29 @@ codex plugin add suede-skills@suede-codex</code></pre>
         reveal(data.stargazers_count);
       })
       .catch(function() {});
+  })();
+</script>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
   })();
 </script>
 </body>

--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -420,5 +461,28 @@ cp -R /tmp/suede-creator-skills/skills/amazon-returns-recovery .claude/skills/</
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -267,12 +267,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -285,7 +319,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -294,6 +334,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -401,5 +442,28 @@ cp -R /tmp/suede-creator-skills/skills/android-app-factory .claude/skills/</code
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -465,6 +465,43 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
   </style>
@@ -480,7 +517,13 @@
       <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
       <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
     </a>
-    <div class="nav-links">
+    <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
       <a href="../">Home</a>
       <a href="./" aria-current="page">Skills</a>
       <a href="#changelog">Changelog</a>
@@ -491,6 +534,7 @@
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="../plugins.html" class="nav-cta">Install</a>
     </div>
+    </details>
   </div>
 </nav>
 
@@ -1145,6 +1189,29 @@
       input.focus();
     });
     apply();
+  })();
+</script>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
   })();
 </script>
 </body>

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -415,5 +456,28 @@ Primary CTA: book a workflow review.</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -414,5 +455,28 @@ Primary CTA: book a workflow review.</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -420,5 +461,28 @@ cp -R /tmp/suede-creator-skills/skills/site-to-ios-app .claude/skills/</code></p
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -419,5 +460,28 @@ cp -R /tmp/suede-creator-skills/skills/subscription-recovery .claude/skills/</co
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -372,5 +413,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -380,5 +421,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -382,5 +423,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -518,5 +559,28 @@ Next:</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -463,5 +504,28 @@ overall = coverage × 0.6 + infra × 0.4</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ai-seo.html
+++ b/docs/skills/suede-ai-seo.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -373,5 +414,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -370,5 +411,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-attribution.html
+++ b/docs/skills/suede-attribution.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -374,5 +415,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -423,5 +464,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-campaign-in-a-box .claude/skills/</
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ci-gate.html
+++ b/docs/skills/suede-ci-gate.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -420,5 +461,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-ci-gate .claude/skills/</code></pre
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-clip-to-guide.html
+++ b/docs/skills/suede-clip-to-guide.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -282,7 +316,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -291,6 +331,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -361,5 +402,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -466,5 +507,28 @@ Overall: A-F</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -417,5 +458,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-code-review .claude/skills/</code><
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -419,5 +460,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-code .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-codex-fleet.html
+++ b/docs/skills/suede-codex-fleet.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -421,5 +462,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -369,5 +410,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -357,5 +398,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -375,5 +416,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -427,5 +468,28 @@ Primary CTA:</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -421,5 +462,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-design .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -272,12 +272,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -290,7 +324,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -299,6 +339,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -445,5 +486,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-deslop .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -370,5 +411,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -367,5 +408,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-full-send.html
+++ b/docs/skills/suede-full-send.html
@@ -305,12 +305,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
   <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -323,12 +357,19 @@
         <img src="../assets/suede-ai-logo-transparent.webp" alt="" onerror="this.style.display='none'">
         <span>Suede Creator Skills</span>
       </a>
+      <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
       <div class="nav-links">
         <a href="./">Skills</a>
         <a href="../guide.html">Guide</a>
         <a href="../book/">Book</a>
         <a href="../plugins.html" class="nav-cta">Install</a>
       </div>
+    </details>
     </div>
   </nav>
 
@@ -491,5 +532,28 @@ codex plugin add suede-skills@suede-codex</code></pre>
       <span><a href="./">Browse all skills</a> &middot; <a href="../plugins.html">Install paths</a> &middot; <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a></span>
     </div>
   </footer>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
 </body>
 </html>

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-instagram-growth.html
+++ b/docs/skills/suede-instagram-growth.html
@@ -170,12 +170,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
   <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -184,7 +218,14 @@
   <nav aria-label="Primary">
     <div class="shell nav-inner">
       <a class="brand" href="../"><img src="../assets/suede-ai-logo-transparent.webp" alt="">Suede Creator Skills</a>
+      <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
       <div class="nav-links"><a href="./">All skills</a><a href="../guide.html">Guide</a><a href="../book/">Book</a><a href="../plugins.html">Install</a><a href="https://github.com/JasonColapietro/suede-creator-skills">GitHub</a></div>
+    </details>
     </div>
   </nav>
 
@@ -266,5 +307,28 @@
   <footer>
     <div class="shell footer-inner"><span>Built by Jason Colapietro / Suede Labs AI</span><span>MIT licensed. Plain Markdown. Read before you install.</span></div>
   </footer>
+<script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
 </body>
 </html>

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -422,5 +463,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-launch-packaging .claude/skills/</c
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -367,5 +408,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -370,5 +411,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -362,5 +403,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -369,5 +410,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -388,5 +429,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -359,5 +400,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -417,5 +458,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-mcp-qa .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -370,5 +411,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -367,5 +408,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -366,5 +407,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -372,5 +413,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -365,5 +406,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -272,12 +272,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -290,7 +324,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -299,6 +339,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -423,5 +464,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -367,5 +408,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -439,5 +480,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -372,5 +413,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -424,5 +465,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-rights-audit .claude/skills/</code>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -449,5 +490,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -373,5 +414,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -424,5 +465,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-seo-audit .claude/skills/</code></p
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ship-copy.html
+++ b/docs/skills/suede-ship-copy.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -421,5 +462,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship-copy .claude/skills/</code></p
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-ship.html
+++ b/docs/skills/suede-ship.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -420,5 +461,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship .claude/skills/</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -362,5 +403,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -419,5 +460,28 @@ cp -R /tmp/suede-creator-skills/skills/suede-site-alchemy .claude/skills/</code>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -371,5 +412,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -376,5 +417,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -285,12 +285,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -303,7 +337,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -312,6 +352,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -423,5 +464,28 @@ Please build the sync positioning, best scenes, mood tags, lyric flags, asset ch
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -265,12 +265,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -283,7 +317,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -292,6 +332,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -368,5 +409,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -459,5 +500,28 @@ Overall: A-F</code></pre>
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -293,12 +293,46 @@
       letter-spacing: -0.015em;
     }
     h1 { line-height: 1.06; }
+    /* Mobile nav: a <details> disclosure. The markup ships open, so with JS
+       off every link stays reachable; JS collapses it at mobile widths and
+       keeps the summary's label in sync. Replaces the wrapped link row that
+       used to eat a fifth of a phone viewport. */
+    .nav-disclosure { display: contents; }
+    .nav-disclosure > summary.nav-hamburger { display: none; }
+    @media (max-width: 768px) {
+      .nav-inner { flex-wrap: nowrap; }
+      .nav-disclosure { display: block; }
+      .nav-disclosure > summary.nav-hamburger {
+        display: flex; flex-direction: column; justify-content: center; gap: 5px;
+        width: 44px; height: 44px; padding: 9px;
+        border: 1px solid var(--border); border-radius: 4px;
+        background: transparent; cursor: pointer; list-style: none;
+      }
+      .nav-disclosure > summary.nav-hamburger::-webkit-details-marker { display: none; }
+      .nav-disclosure > summary.nav-hamburger::marker { content: ""; }
+      .nav-disclosure > summary.nav-hamburger span {
+        display: block; width: 100%; height: 1px; background: var(--cream);
+        transition: transform 0.15s ease, opacity 0.15s ease;
+      }
+      .nav-disclosure > summary.nav-hamburger:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(2) { opacity: 0; }
+      .nav-disclosure[open] > summary.nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+      .nav-disclosure[open] > .nav-links {
+        position: absolute; top: 100%; left: 0; right: 0;
+        flex-direction: column; align-items: stretch; gap: 0;
+        padding: 6px 20px 14px;
+        background: #0a0a0a;
+        border-bottom: 1px solid var(--border);
+      }
+      .nav-disclosure[open] > .nav-links > * {
+        display: flex; align-items: center; min-height: 44px;
+      }
+      .nav-disclosure[open] > .nav-links > * + * { border-top: 1px solid var(--hairline); }
+    }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
-    @media (max-width: 700px) {
-      .nav-links a { padding: 10px 8px; }
-    }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -311,7 +345,13 @@
           <img src="../assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+      <summary class="nav-hamburger" aria-label="Open navigation menu">
+        <span></span>
+        <span></span>
+        <span></span>
+      </summary>
+      <div class="nav-links">
           <a href="../">Home</a>
           <a href="./">Skills</a>
           <a href="../guide.html">Guide</a>
@@ -320,6 +360,7 @@
           <a href="../copy.html">Copy Bank</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
+    </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -494,5 +535,28 @@
         </div>
       </div>
     </footer>
-  </body>
+  <script>
+  // Mobile nav disclosure. The markup ships <details open> so a no-JS visit
+  // still reaches every link; this collapses it at mobile widths only and
+  // keeps the summary label in sync with the state.
+  (function () {
+    var box = document.querySelector('.nav-disclosure');
+    if (!box) return;
+    var summary = box.querySelector('summary');
+    var mq = window.matchMedia('(max-width: 768px)');
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+    box.querySelectorAll('.nav-links a').forEach(function (link) {
+      link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+    });
+  })();
+</script>
+</body>
 </html>

--- a/scripts/build-book-site.mjs
+++ b/scripts/build-book-site.mjs
@@ -105,7 +105,13 @@ ${JSON.stringify(jsonLd, null, 2)}
           <img src="${up}assets/suede-ai-logo-transparent.webp" alt="Suede AI" width="28" height="28" onerror="this.style.display='none'">
           <span class="nav-logo-wordmark">Suede <span>Creator Skills</span></span>
         </a>
-        <div class="nav-links">
+        <details class="nav-disclosure" open>
+          <summary class="nav-hamburger" aria-label="Open navigation menu">
+            <span></span>
+            <span></span>
+            <span></span>
+          </summary>
+          <div class="nav-links">
           <a href="${up}">Home</a>
           <a href="${up}skills/">Skills</a>
           <a href="${up}guide.html">Guide</a>
@@ -113,7 +119,8 @@ ${JSON.stringify(jsonLd, null, 2)}
           <a href="${up}blog/">Blog</a>
           <a href="${up}copy.html">Copy Bank</a>
           <a href="${up}plugins.html" class="nav-cta">Install</a>
-        </div>
+          </div>
+        </details>
       </nav>
     </header>
     <main id="main" tabindex="-1" class="shell">
@@ -147,6 +154,29 @@ ${body}
         </div>
       </div>
     </footer>
+    <script>
+      // Mobile nav disclosure. The markup ships <details open> so a no-JS
+      // visit still reaches every link; this collapses it at mobile widths
+      // only and keeps the summary label in sync with the state.
+      (function () {
+        var box = document.querySelector('.nav-disclosure');
+        if (!box) return;
+        var summary = box.querySelector('summary');
+        var mq = window.matchMedia('(max-width: 768px)');
+        function collapseForViewport() { box.open = !mq.matches; }
+        function syncLabel() {
+          if (summary) summary.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+        }
+        collapseForViewport();
+        syncLabel();
+        box.addEventListener('toggle', syncLabel);
+        if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+        else if (mq.addListener) mq.addListener(collapseForViewport);
+        box.querySelectorAll('.nav-links a').forEach(function (link) {
+          link.addEventListener('click', function () { if (mq.matches) box.open = false; });
+        });
+      })();
+    </script>
   </body>
 </html>
 `;


### PR DESCRIPTION
One mobile navigation pattern for the whole estate, replacing two separate failures: a homepage menu that could not open at all without JavaScript, and interior pages that had no mobile nav pattern whatsoever — their link row simply wrapped, producing three different nav heights across the site and eating roughly a fifth of a phone viewport on the catalog.

## The pattern

Every page now carries the same `<details class="nav-disclosure">`:

- **The markup ships `open`.** With JavaScript disabled the menu renders expanded and every link stays reachable. That is the whole point: no-JS degradation is now strictly better than the old homepage, where the hamburger was inert and the nav was unreachable.
- **JavaScript collapses it at ≤768px** and keeps the summary's `aria-label` swapping between "Open navigation menu" and "Close navigation menu". A `matchMedia` listener re-syncs on viewport change, so resizing between mobile and desktop never leaves the nav in a broken state.
- **Desktop layout is untouched.** The disclosure is `display: contents` and the summary is hidden, so the inline link row lays out exactly as before.
- The summary carries `.nav-hamburger` at a 44px square; its three bars cross into an X when open. Native `<details>` does the show/hide, so there is no class-toggling state to get out of sync.

Applied to: `docs/index.html`, all 74 `docs/skills/*.html`, `guide.html`, `plugins.html`, `copy.html`, all 6 `docs/blog/*.html`, and the 18 book pages via `scripts/build-book-site.mjs` (generator updated in lockstep, book regenerated).

The homepage's separate `#nav-mobile-menu` list moved inside the disclosure; its show rule is now scoped to mobile widths so a no-JS desktop render keeps the inline row rather than dropping the panel. The superseded `@media (max-width: 700px) { .nav-links a { padding } }` stopgap was removed.

## Verified

Driven in a real browser across nine page families (home, catalog, a skill page, guide, plugins, copy bank, blog index, book index, a book chapter) at 375 / 390 / 414 px, with JavaScript both on and off:

| Check | Result |
| --- | --- |
| Hamburger hit area | 44×44 on every page |
| Menu state with JS | closed on load, opens on click, label swaps correctly |
| Menu links | 44–47px row height |
| Nav height | uniform 64–65px (was three different heights; catalog was worst) |
| Desktop with JS | hamburger hidden, inline links visible |
| **No-JS mobile** | **every link reachable on all nine families** |
| No-JS desktop | inline row intact, panel does not leak |
| Horizontal overflow | none at 375 / 390 / 414 on any page |

`npm test` green, including the two homepage guards that constrain this exact surface: `test_primary_mobile_controls_meet_touch_target_floor` (the `.nav-hamburger` 44px block) and `test_mobile_menu_label_tracks_state` (both label strings). The summary keeps the `.nav-hamburger` class specifically so that guard keeps holding.

`DESIGN.md` records the pattern and why it exists.
