### PR TITLE
Uniform install block with copy button on all 73 skill pages

### DIFF
--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,10 +454,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -431,6 +499,33 @@ cp -R /tmp/suede-creator-skills/skills/amazon-returns-recovery .claude/skills/</
       <section class="panel">
         <h2>Related skills</h2>
         <p>This skill stands alone: discovery, confirmation, dispute chat, and reporting are covered end to end, including the validated Amazon chat click-path and popup workaround in the reference docs. It is the consumer-facing proof case for the same negotiation discipline the code and copy lanes apply elsewhere in the pack.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -483,6 +578,33 @@ cp -R /tmp/suede-creator-skills/skills/amazon-returns-recovery .claude/skills/</
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -309,6 +309,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -364,10 +435,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -412,6 +480,33 @@ cp -R /tmp/suede-creator-skills/skills/android-app-factory .claude/skills/</code
       <section class="panel">
         <h2>Related skills</h2>
         <p>Pairs with <a href="./site-to-ios-app.html">site-to-ios-app</a>, the public iOS counterpart that wraps an existing site instead of scaffolding a new native app. Both end in the same discipline every lane in this pack shares: no release without an explicit ship gate and an owner's confirmation.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -464,6 +559,33 @@ cp -R /tmp/suede-creator-skills/skills/android-app-factory .claude/skills/</code
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -388,7 +459,6 @@
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
 cp -R /tmp/suede-creator-skills/skills/johnny-suede-design .claude/skills/</code></pre>
-        <p>Or install the full pack: <code>/plugin marketplace add JasonColapietro/suede-creator-skills</code> then <code>/plugin install suede-skills@suede</code>.</p>
         <p><strong>Codex</strong>, installing from GitHub:</p>
         <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
   --repo JasonColapietro/suede-creator-skills \
@@ -426,6 +496,33 @@ Primary CTA: book a workflow review.</code></pre>
       <section class="panel">
         <h2>Writing mode inside</h2>
         <p>Johnny Suede Design includes the writing stack. Use <a href="johnny-suede-write.html">Johnny Suede Write</a> directly when the job is copy, product and mobile wording, SEO/AEO/AI EO, company voice, CTAs, launch copy, social/email variants, and evidence-backed line editing.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -478,6 +575,33 @@ Primary CTA: book a workflow review.</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -387,7 +458,6 @@
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
 cp -R /tmp/suede-creator-skills/skills/johnny-suede-write .claude/skills/</code></pre>
-        <p>Or install the full pack: <code>/plugin marketplace add JasonColapietro/suede-creator-skills</code> then <code>/plugin install suede-skills@suede</code>.</p>
         <p><strong>Codex</strong>, installing from GitHub:</p>
         <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
   --repo JasonColapietro/suede-creator-skills \
@@ -425,6 +495,33 @@ Primary CTA: book a workflow review.</code></pre>
       <section class="panel">
         <h2>Pair it with design</h2>
         <p>Use <a href="johnny-suede-design.html">Johnny Suede Design</a> when the work also needs Suedify, mobile or product surface design, UI polish, design-system QA, visibility grading, implementation handoff, and the writing stack included.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -477,6 +574,33 @@ Primary CTA: book a workflow review.</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -431,6 +499,33 @@ cp -R /tmp/suede-creator-skills/skills/site-to-ios-app .claude/skills/</code></p
       <section class="panel">
         <h2>Related skills</h2>
         <p>This skill stands alone: the runbook covers audit, strategy, scaffold, configuration, QA, and the release gate end to end. Private Suede companions go deeper on Capacitor shell internals, native architecture, ASO, and App Store submission, but none are required.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -483,6 +578,33 @@ cp -R /tmp/suede-creator-skills/skills/site-to-ios-app .claude/skills/</code></p
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -430,6 +498,33 @@ cp -R /tmp/suede-creator-skills/skills/subscription-recovery .claude/skills/</co
       <section class="panel">
         <h2>Related skills</h2>
         <p>Pairs with <a href="./amazon-returns-recovery.html">amazon-returns-recovery</a>, which stays scoped to Amazon: returns, restocking fees, and Amazon-billed subscriptions like Prime Video Channels and Audible. Together they're the pack's negotiation lane run against real accounts instead of a repo or a brief; the same discipline the code and copy lanes apply elsewhere in the pack.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -482,6 +577,33 @@ cp -R /tmp/suede-creator-skills/skills/subscription-recovery .claude/skills/</co
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -384,6 +455,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -435,6 +533,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -392,6 +463,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -443,6 +541,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -394,6 +465,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -445,6 +543,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -530,6 +601,33 @@ Next:</code></pre>
           <p>Feedback can happen mid-workflow or at the end. Say <code>Cue Suede</code> to ask for choices: change something, preserve what worked so the agent can mimic it later, or keep as-is by saying nothing.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -581,6 +679,33 @@ Next:</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -475,6 +546,33 @@ overall = coverage × 0.6 + infra × 0.4</code></pre>
           <p>The skill does not claim legal, rights, licensing, medical, financial, or compliance clearance. It does not upload data, call private services, invent datasets, or treat a model's self-judgment as sufficient evidence.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -526,6 +624,33 @@ overall = coverage × 0.6 + infra × 0.4</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ai-seo.html
+++ b/docs/skills/suede-ai-seo.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -385,6 +456,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -436,6 +534,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -388,6 +459,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -439,6 +537,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,6 +453,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -433,6 +531,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-attribution.html
+++ b/docs/skills/suede-attribution.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -386,6 +457,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -437,6 +535,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code</strong> full-pack install:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code</strong> project-level copy:</p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -434,6 +502,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-campaign-in-a-box .claude/skills/</
       <section class="panel">
         <h2>Safety boundary</h2>
         <p>This skill organizes campaign plans and evidence. It does not clear rights, guarantee placements, or approve payouts.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -486,6 +581,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-campaign-in-a-box .claude/skills/</
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ci-gate.html
+++ b/docs/skills/suede-ci-gate.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,10 +454,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -431,6 +499,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ci-gate .claude/skills/</code></pre
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related skills from this docs set: <a href="suede-code.html">Suede Code</a>, <a href="suede-code-grader.html">Suede Code Grader</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -483,6 +578,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ci-gate .claude/skills/</code></pre
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-clip-to-guide.html
+++ b/docs/skills/suede-clip-to-guide.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Primary-source rights references</h2>
         <p>The third-party video lane points to the current <a href="https://www.copyright.gov/fair-use/more-info.html">U.S. Copyright Office fair-use guidance</a> and <a href="https://help.x.com/en/rules-and-policies/fair-use-policy">X fair-use policy</a>. The skill records the four factors but does not grant legal clearance.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -373,6 +444,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -424,6 +522,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -478,6 +549,33 @@ Overall: A-F</code></pre>
           <p>Feedback can happen mid-workflow or at the end. Say <code>Cue Suede</code> to ask for choices: change something, preserve what worked so the agent can mimic it later, or keep as-is by saying nothing.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -529,6 +627,33 @@ Overall: A-F</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -428,6 +496,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-code-review .claude/skills/</code><
       <section class="panel">
         <h2>Related skills</h2>
         <p>For findings plus a letter grade in one pass, use <a href="suede-code.html">Suede Code</a>. For grade-only review with no findings, use <a href="suede-code-grader.html">Suede Code Grader</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -480,6 +575,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-code-review .claude/skills/</code><
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,10 +454,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full-pack install:</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy:</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -430,6 +498,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-code .claude/skills/</code></pre>
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related pages: <a href="suede-code-review.html">Suede Code Review</a>, <a href="suede-code-grader.html">Suede Code Grader</a>, and <a href="suede-ci-gate.html">Suede Ship Gate</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -482,6 +577,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-code .claude/skills/</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-codex-fleet.html
+++ b/docs/skills/suede-codex-fleet.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -432,6 +500,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related skills: <a href="suede-agent-teams.html">Suede Agent Teams</a> and <a href="suede-workflow-skills.html">Suede Workflow Skills</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -484,6 +579,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-codex-fleet .claude/skills/</code><
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -381,6 +452,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -432,6 +530,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -369,6 +440,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -420,6 +518,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -387,6 +458,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -438,6 +536,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code</strong> full-pack install:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code</strong> project-level copy:</p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -439,6 +507,33 @@ Primary CTA:</code></pre>
         <h2>Related skills</h2>
         <p>Use <a href="johnny-suede-write.html">Johnny Suede Write</a> when copy needs the full writing stack with SEO and AI Engine Optimization, <a href="suede-seo-audit.html">Suede SEO Audit</a> for deep standalone SEO audits, and <a href="suede-visibility-grader.html">Suede Visibility Grader</a> before a public launch surface goes live.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -490,6 +585,33 @@ Primary CTA:</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -432,6 +500,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-design .claude/skills/</code></pre>
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related pages: <a href="johnny-suede-design.html">Johnny Suede Design</a> and <a href="suede-visibility-grader.html">Suede Visibility Grader</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -484,6 +579,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-design .claude/skills/</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -314,6 +314,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -369,10 +440,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -457,6 +525,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-deslop .claude/skills/</code></pre>
         <h2>Related skills</h2>
         <p>Pairs with <a href="./suede-copy.html">suede-copy</a>, which writes the conversion copy this skill then cleans, with <a href="./johnny-suede-write.html">johnny-suede-write</a> for the full writing stack, and with <a href="./suede-workflow-skills.html">suede-workflow-skills</a>, the umbrella router that loads whichever lane a plain request names.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -508,6 +603,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-deslop .claude/skills/</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,6 +453,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -433,6 +531,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -379,6 +450,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -430,6 +528,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-full-send.html
+++ b/docs/skills/suede-full-send.html
@@ -347,6 +347,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
   <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
 <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -508,7 +579,7 @@
       </div>
     </section>
 
-    <section class="ship-strip" id="install" aria-labelledby="install-title">
+    <section class="ship-strip" aria-labelledby="install-title">
       <div class="shell">
         <h2 id="install-title">Install the 73-skill pack.</h2>
         <p>Claude Code and Codex can each install the complete public pack through their native marketplace. The direct Codex installer remains available when you want only Full Send.</p>
@@ -523,6 +594,33 @@ codex plugin add suede-skills@suede-codex</code></pre>
   --repo JasonColapietro/suede-creator-skills \
   --path skills/suede-full-send</code></pre>
       </div>
+    </section>
+    <section class="install-block" id="install" aria-labelledby="install-block-title">
+      <h2 id="install-block-title">Install this skill</h2>
+      <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+      <div class="install-term">
+        <div class="install-term-bar">
+          <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+          <b>terminal &middot; install the pack</b>
+        </div>
+        <div class="install-row">
+          <div class="install-cmd">
+            <span class="install-label">Claude Code</span>
+            <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+          </div>
+          <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+        </div>
+        <div class="install-row">
+          <div class="install-cmd">
+            <span class="install-label">Codex</span>
+            <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+          </div>
+          <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+        </div>
+      </div>
+      <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+      <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
     </section>
   </main>
 
@@ -554,6 +652,33 @@ codex plugin add suede-skills@suede-codex</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-instagram-growth.html
+++ b/docs/skills/suede-instagram-growth.html
@@ -212,6 +212,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
   <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -302,6 +373,33 @@
         <a class="link-row" href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/skills/suede-instagram-growth/references/measurement.md"><code>measurement.md</code><span>Objective map, experiment card, rates, diagnosis, and reporting.</span><b>Open</b></a>
       </div>
     </section>
+    <section class="install-block" aria-labelledby="install-block-title">
+      <h2 id="install-block-title">Install this skill</h2>
+      <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+      <div class="install-term">
+        <div class="install-term-bar">
+          <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+          <b>terminal &middot; install the pack</b>
+        </div>
+        <div class="install-row">
+          <div class="install-cmd">
+            <span class="install-label">Claude Code</span>
+            <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+          </div>
+          <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+        </div>
+        <div class="install-row">
+          <div class="install-cmd">
+            <span class="install-label">Codex</span>
+            <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+          </div>
+          <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+        </div>
+      </div>
+      <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+      <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+    </section>
   </main>
 
   <footer>
@@ -329,6 +427,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code</strong> full-pack install:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code</strong> project-level copy:</p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -433,6 +501,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-launch-packaging .claude/skills/</c
       <section class="panel">
         <h2>Evidence boundaries</h2>
         <p>This skill organizes and prepares a release and its install paths. It does NOT clear rights, confirm ownership, approve payouts, write to any registry, or guarantee outcomes (reach, ranking, results).</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -485,6 +580,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-launch-packaging .claude/skills/</c
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -379,6 +450,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -430,6 +528,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,6 +453,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -433,6 +531,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -374,6 +445,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -425,6 +523,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -381,6 +452,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -432,6 +530,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -400,6 +471,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -451,6 +549,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -371,6 +442,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -422,6 +520,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full-pack install:</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy:</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -428,6 +496,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-mcp-qa .claude/skills/</code></pre>
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related pages: <a href="suede-launch-packaging.html">Suede Launch Packaging</a> and <a href="suede-workflow-skills.html">Suede Workflow Skills</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -480,6 +575,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-mcp-qa .claude/skills/</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,6 +453,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -433,6 +531,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -379,6 +450,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -430,6 +528,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -378,6 +449,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -429,6 +527,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -384,6 +455,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -435,6 +533,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -377,6 +448,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -428,6 +526,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -314,6 +314,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -369,10 +440,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -435,6 +503,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
         <h2>Related skills</h2>
         <p>Pairs with <a href="./suede-agent-teams.html">suede-agent-teams</a> for multi-lane coordination once a recommendation spans more than one specialist, and with <a href="./suede-workflow-skills.html">suede-workflow-skills</a>, the umbrella router that loads whichever lane this skill names.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -486,6 +581,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-recommend-next-action .claude/skill
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -379,6 +450,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -430,6 +528,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -451,6 +522,33 @@
           <p>A clean report is not legal clearance, distributor approval, registry write, or payout guarantee. The skill organizes evidence, marks uncertainty, and recommends next fixes. Generated reports are drafts until a creator or operator reviews and redacts them.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -502,6 +600,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -384,6 +455,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -435,6 +533,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code</strong> full-pack install:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code</strong> project-level copy:</p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -435,6 +503,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-rights-audit .claude/skills/</code>
       <section class="panel">
         <h2>Safety boundary</h2>
         <p>This skill finds and organizes rights gaps as local evidence. It does not clear rights, confirm ownership, adjudicate chain of title, grant or imply a license, approve or schedule a payout, move money, write to any registry, or provide legal advice.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -487,6 +582,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-rights-audit .claude/skills/</code>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -461,6 +532,33 @@
           <p>The skill should never claim a work is cleared unless the creator provides proof. It should not ask for seed phrases, private keys, full payment credentials, unreleased secrets, or private Suede implementation details. Generated packages are drafts until reviewed and redacted by the creator or operator.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -512,6 +610,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -385,6 +456,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -436,6 +534,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code</strong> full-pack install:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code</strong> project-level copy:</p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -435,6 +503,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-seo-audit .claude/skills/</code></p
       <section class="panel">
         <h2>Related skills</h2>
         <p>For a fast promotion-readiness verdict, use <a href="suede-visibility-grader.html">Suede Visibility Grader</a>. For evidence-backed writing, use <a href="suede-copy.html">Suede Copy</a>. For conversion and CRO rewrites, use <a href="suede-site-alchemy.html">Suede Site Alchemy</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -487,6 +582,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-seo-audit .claude/skills/</code></p
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ship-copy.html
+++ b/docs/skills/suede-ship-copy.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,10 +454,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -432,6 +500,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship-copy .claude/skills/</code></p
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related skills from this docs set: <a href="suede-ship.html">Suede Ship</a>, <a href="suede-copy.html">Suede Copy</a>, <a href="suede-deslop.html">Suede Deslop</a>, <a href="suede-image.html">Suede Image</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -484,6 +579,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship-copy .claude/skills/</code></p
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-ship.html
+++ b/docs/skills/suede-ship.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,10 +454,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -431,6 +499,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship .claude/skills/</code></pre>
       <section class="panel">
         <h2>Related skills</h2>
         <p>Related skills from this docs set: <a href="suede-codex-fleet.html">Suede Fable Fleet</a>, <a href="suede-agent-teams.html">Suede Agent Teams</a>, <a href="suede-code-review.html">Suede Code Review</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -483,6 +578,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-ship .claude/skills/</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -374,6 +445,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -425,6 +523,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -430,6 +498,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-site-alchemy .claude/skills/</code>
       <section class="panel">
         <h2>Related skills</h2>
         <p>Pair it with <a href="suede-seo-audit.html">Suede SEO Audit</a> for the nine-lane SEO/schema pass, <a href="suede-visibility-grader.html">Suede Visibility Grader</a> for an A-F promotion-readiness grade, and <a href="suede-copy.html">Suede Copy</a> for standalone copywriting.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -482,6 +577,33 @@ cp -R /tmp/suede-creator-skills/skills/suede-site-alchemy .claude/skills/</code>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -383,6 +454,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -434,6 +532,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -388,6 +459,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -439,6 +537,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -327,6 +327,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -382,10 +453,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install commands</h2>
-        <p><strong>Claude Code full pack</strong></p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Claude Code project-level copy</strong></p>
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
@@ -434,6 +502,33 @@ Please build the sync positioning, best scenes, mood tags, lyric flags, asset ch
       <section class="panel">
         <h2>Related skills</h2>
         <p>Pair sync packaging with <a href="suede-rights-passport.html">Suede Rights Passport</a>, <a href="suede-rights-audit.html">Suede Rights Audit</a>, and <a href="suede-release-linter.html">Suede Release Linter</a>.</p>
+      </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
       </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
@@ -486,6 +581,33 @@ Please build the sync positioning, best scenes, mood tags, lyric flags, asset ch
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -307,6 +307,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -380,6 +451,33 @@
         <h2>Credit</h2>
         <p>This Suede skill includes licensed source material. Attribution and licence terms remain in <a href="https://github.com/JasonColapietro/suede-creator-skills/blob/main/NOTICE.md">NOTICE.md</a>.</p>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -431,6 +529,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -395,7 +466,6 @@
         <pre><code>git clone https://github.com/JasonColapietro/suede-creator-skills.git /tmp/suede-creator-skills
 mkdir -p .claude/skills
 cp -R /tmp/suede-creator-skills/skills/suede-visibility-grader .claude/skills/</code></pre>
-        <p>Or install the full pack: <code>/plugin marketplace add JasonColapietro/suede-creator-skills</code> then <code>/plugin install suede-skills@suede</code>.</p>
         <p><strong>Codex</strong> is the public route. It installs from GitHub as a standard Codex skill folder.</p>
         <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
   --repo JasonColapietro/suede-creator-skills \
@@ -471,6 +541,33 @@ Overall: A-F</code></pre>
           <p>Feedback can happen mid-workflow or at the end. Say <code>Cue Suede</code> to ask for choices: change something, preserve what worked so the agent can mimic it later, or keep as-is by saying nothing.</p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -522,6 +619,33 @@ Overall: A-F</code></pre>
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -335,6 +335,77 @@
     [id] { scroll-margin-top: 84px; }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
+  <style>
+    /* Uniform install block. Tokens are page-local and two bespoke pages
+       (suede-full-send, suede-instagram-growth) never declare --card/--border,
+       so every token here carries the estate literal as a fallback. */
+    .install-block { margin: 56px 0 0; }
+    .install-block > h2 { margin-bottom: 8px; }
+    .install-lede { font-size: 14.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 660px; margin-bottom: 20px; }
+    .install-term {
+      max-width: 780px; background: var(--card, #161616);
+      border: 1px solid var(--border, #222222); border-radius: 6px; overflow: hidden;
+    }
+    .install-term-bar {
+      display: flex; align-items: center; gap: 12px;
+      padding: 12px 18px; border-bottom: 1px solid var(--border, #222222);
+    }
+    .install-term-dots { display: flex; gap: 6px; }
+    .install-term-dots span { width: 10px; height: 10px; border-radius: 50%; background: #2a2a28; }
+    .install-term-dots span:first-child { background: #4a2a28; }
+    .install-term-dots span:last-child { background: #2c3a2a; }
+    .install-term-bar b {
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; font-weight: 400; letter-spacing: 0.04em; color: var(--muted, #888880);
+    }
+    .install-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 18px; padding: 18px 22px; }
+    .install-row + .install-row { border-top: 1px solid var(--border, #222222); }
+    /* min-width:0 is what lets the <pre> scroll inside the row instead of
+       stretching it; without it a long command blows out the page on mobile. */
+    .install-cmd { flex: 1; min-width: 0; }
+    .install-label {
+      display: block; margin-bottom: 8px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted, #888880);
+    }
+    .install-code {
+      margin: 0; overflow-x: auto; white-space: pre;
+      /* Pinned, not inherited: every page carries its own generic `pre` rule
+         and they disagree on background, padding, and radius, so an unpinned
+         block is uniform in the markup and three different things on screen. */
+      padding: 16px 18px; background: #080808;
+      border: 1px solid #1a1a18; border-radius: 4px;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 14.5px; line-height: 1.95; color: var(--gold, #c8a96e);
+    }
+    .install-code .install-prompt { color: var(--red-text, #c6625a); user-select: none; }
+    .install-copy {
+      flex-shrink: 0; min-height: 44px; min-width: 92px; padding: 10px 16px; cursor: pointer;
+      font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+      font-size: 12.5px; white-space: nowrap; color: var(--muted, #888880);
+      background: transparent; border: 1px solid var(--border, #222222); border-radius: 4px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .install-copy:hover, .install-copy.copied { color: var(--gold, #c8a96e); border-color: var(--gold, #c8a96e); }
+    /* These pages only ever styled a:focus-visible; this is their first button. */
+    .install-copy:focus-visible { outline: 2px solid var(--gold, #c8a96e); outline-offset: 3px; }
+    .install-note { font-size: 13.5px; line-height: 1.65; color: var(--muted, #888880); max-width: 720px; margin-top: 14px; }
+    .install-note a { color: var(--gold, #c8a96e); }
+    .install-status {
+      position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+    @media (max-width: 640px) {
+      /* align-items above is flex-start, which content-sizes children in the
+         cross axis. In column mode that axis is the width, so the command box
+         must be stretched back or a long command escapes the viewport instead
+         of scrolling inside its own box. */
+      .install-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 16px 16px 18px; }
+      .install-cmd { width: 100%; }
+      .install-copy { width: 100%; }
+      .install-code { font-size: 13px; }
+    }
+  </style>
 </head>
   <body>
 <a class="skip-link" href="#main">Skip to content</a>
@@ -390,10 +461,7 @@
       </div>
 
       <section class="panel">
-        <h2>Public install command</h2>
-        <p><strong>Claude Code</strong>, adding the marketplace and the pack:</p>
-        <pre><code>/plugin marketplace add JasonColapietro/suede-creator-skills
-/plugin install suede-skills@suede</code></pre>
+        <h2>Copy just this skill</h2>
         <p><strong>Codex</strong> installs from GitHub as a standard Codex skill folder:</p>
         <pre><code>python3 ~/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py \
   --repo JasonColapietro/suede-creator-skills \
@@ -506,6 +574,33 @@
           <p><a class="button secondary" href="./">Open skill catalog</a></p>
         </article>
       </section>
+      <section class="install-block" aria-labelledby="install-block-title">
+        <h2 id="install-block-title">Install this skill</h2>
+        <p class="install-lede">It ships inside the Suede Creator Skills pack, so one install brings the whole pack and this skill with it. Claude Code takes two commands the first time and one after that; Codex installs the same pack natively.</p>
+        <div class="install-term">
+          <div class="install-term-bar">
+            <span class="install-term-dots" aria-hidden="true"><span></span><span></span><span></span></span>
+            <b>terminal &middot; install the pack</b>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Claude Code</span>
+              <pre class="install-code"><span class="install-prompt">$</span> /plugin marketplace add JasonColapietro/suede-creator-skills
+<span class="install-prompt">$</span> /plugin install suede-skills@suede</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Claude Code install commands">Copy</button>
+          </div>
+          <div class="install-row">
+            <div class="install-cmd">
+              <span class="install-label">Codex</span>
+              <pre class="install-code"><span class="install-prompt">$</span> codex plugin add suede-skills@suede-codex</pre>
+            </div>
+            <button class="install-copy" type="button" data-install-copy aria-label="Copy the Codex install command">Copy</button>
+          </div>
+        </div>
+        <p class="install-status" role="status" aria-live="polite" data-install-status></p>
+        <p class="install-note">Cursor, Copilot, and Windsurf install through the skills CLI. Every path is on the <a href="../plugins.html">install page</a>, and every folder is readable first on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a>.</p>
+      </section>
     </main>
     <section class="ship-strip" aria-label="Install the pack">
       <div class="shell">
@@ -557,6 +652,33 @@
       link.addEventListener('click', function () { if (mq.matches) box.open = false; });
     });
   })();
+</script>
+<script>
+  // Progressive enhancement only: the commands are plain selectable text
+  // without JS. The button reports state twice -- its own accessible name for
+  // anyone focused on it, and the block's live region for anyone who is not.
+  document.querySelectorAll("[data-install-copy]").forEach(function (btn) {
+    var idleLabel = btn.getAttribute("aria-label");
+    btn.addEventListener("click", function () {
+      var row = btn.closest(".install-row");
+      var code = row && row.querySelector(".install-code");
+      var block = btn.closest(".install-block");
+      var status = block && block.querySelector("[data-install-status]");
+      if (!code || !navigator.clipboard) return;
+      navigator.clipboard.writeText(code.textContent.replace(/^\$ /gm, "").trim()).then(function () {
+        btn.textContent = "Copied";
+        btn.classList.add("copied");
+        btn.setAttribute("aria-label", idleLabel.replace(/^Copy /, "Copied ") + " to clipboard");
+        if (status) status.textContent = idleLabel.replace(/^Copy the /, "") + " copied to clipboard";
+        setTimeout(function () {
+          btn.textContent = "Copy";
+          btn.classList.remove("copied");
+          btn.setAttribute("aria-label", idleLabel);
+          if (status) status.textContent = "";
+        }, 2000);
+      });
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## What

Every `docs/skills/*.html` skill page now ends with the same install block: the two Claude Code commands and the Codex command, each in its own row with its own copy button.

A design review found 45 of the 73 pages had **no install commands at all** — the entire marketing lane among them — and **none of the 73 had a copy button**. The only one on the site was on the catalog page.

## Why the insertion was scripted

The pages share a template by convention only and had drifted. Scripting it with per-page occurrence checks surfaced drift that a find-and-replace would have silently mangled or skipped:

| Drift found | Pages |
|---|---|
| `Public install commands` vs `Public install command` heading | 21 vs 1 |
| Distinct "Claude Code" label wordings above the same `<pre>` | 4 variants |
| Full-pack pair restated as inline prose instead of a `<pre>` | 3 |
| Subset-plugin panels (`suede-agent-workflows@suede`, `suede-code@suede`) | 3 |
| `</main>` at 2-space vs 4-space indent | 2 vs 71 |
| Pages never declaring `--card` / `--border` | 2 |

Every page that did not match its expected shape exactly was reported and left untouched rather than half-edited. Final run: 73/73 matched, 0 failures.

## Uniformity

Block markup, CSS, and JS hash byte-identical across all 73 pages. `suede-full-send` differs by exactly one attribute — it carries `id="install"` so the page's existing "Install the skill" CTA lands on the copyable block rather than the gold marketing band.

## Accessibility

- Copy buttons are `min-height: 44px` (92px wide on desktop, full-width on mobile).
- State is reported twice: the button's own `aria-label` flips for a screen reader focused on it, and a visually hidden `role="status" aria-live="polite"` region announces for one that is not.
- Keyboard focus is visible: these pages only ever styled `a:focus-visible`, and the copy button is the first `<button>` on them, so it gets a matching gold ring rather than the browser default.
- Without JS the commands stay plain selectable text.

## Cleanup

Retires 92 lines of superseded duplicates — 22 full-pack `<pre>` blocks with their label paragraphs, 3 inline prose restatements, and 22 panel headings retitled to **"Copy just this skill"**, which is what those panels actually contain now (per-skill git clone + per-skill Codex installer). Panels that install a *subset* plugin are deliberate, not drift, and were left alone.

## Two bugs caught by measuring, not reading

Both passed every markup-level check and would have shipped:

1. **Command box escaped the viewport at 390px.** `align-items: flex-start` content-sizes children in the cross axis, which becomes the *width* once the row flips to a column, so a long command grew the row instead of scrolling inside it.
2. **`.install-code` inherited each page's generic `pre` rule**, computing to three different backgrounds, paddings, and radii across the estate. Now pinned.

A third was caught only by looking at a screenshot: nesting the block inside `suede-full-send`'s `.ship-strip` (`background: var(--gold)`) rendered its gold note links **gold on gold, 1.00:1**. The contrast check only measured inside the terminal, so it passed. The check now walks up to whatever ancestor actually paints the backdrop — and was confirmed to fail on a copy with the bug reintroduced, so it is not vacuous.

## Verification

All 73 pages at 1280 and 390 with Playwright:

- contrast — command 8.06:1, copy button 5.07:1, `$` prompt 4.56:1, row label 5.07:1
- copy buttons 44px tall, inside the viewport at both widths
- no horizontal page overflow; long commands scroll inside their own box
- both buttons round-trip the correct text to the clipboard, flip `aria-label`, fill the live region, and do not affect each other

`npm test` green: validate (4 steps), validator-runtime 13/13, mcp 15, triggers 74, ship-cost 9, contributions 28, python 29.

> Note for reviewers: the suite takes ~45 min in a fresh worktree and needs `npm install` there first, or `test_validator_runtime` fails on an unresolvable `js-yaml` (it pins `NODE_PATH` to the worktree root). Reproduced identically on pristine `origin/main`.