### PR TITLE
docs(dav): last nav page onto the shared disclosure, plus a drift guard for all 101

### DIFF
--- a/docs/dav/index.html
+++ b/docs/dav/index.html
@@ -1362,14 +1362,20 @@
     /* ============================================================
        MOBILE NAV HAMBURGER
     ============================================================ */
+    /* Mobile nav is a <details> disclosure: it ships open in the markup, so
+       with JS off every link stays reachable. JS collapses it at mobile
+       widths and keeps the summary's label in sync with the state. */
+    .nav-disclosure { display: contents; }
+
     .nav-hamburger {
       display: none;
+      list-style: none;
       flex-direction: column;
       justify-content: center;
       gap: 5px;
-      width: 36px;
-      height: 36px;
-      padding: 4px;
+      width: 44px;
+      height: 44px;
+      padding: 9px;
       background: transparent;
       border: 1px solid var(--color-border);
       border-radius: var(--radius-sm);
@@ -1377,6 +1383,8 @@
       transition: border-color var(--transition-fast);
     }
 
+    .nav-hamburger::-webkit-details-marker { display: none; }
+    .nav-hamburger::marker { content: ""; }
     .nav-hamburger:hover { border-color: var(--color-accent-gold); }
 
     .nav-hamburger span {
@@ -1387,9 +1395,9 @@
       transition: background var(--transition-fast), transform var(--transition-fast), opacity var(--transition-fast);
     }
 
-    .nav-hamburger[aria-expanded="true"] span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
-    .nav-hamburger[aria-expanded="true"] span:nth-child(2) { opacity: 0; }
-    .nav-hamburger[aria-expanded="true"] span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(1) { transform: translateY(6px) rotate(45deg); }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(2) { opacity: 0; }
+    .nav-disclosure[open] .nav-hamburger span:nth-child(3) { transform: translateY(-6px) rotate(-45deg); }
 
     #nav-mobile-menu {
       display: none;
@@ -1407,7 +1415,9 @@
       gap: var(--space-1);
     }
 
-    #nav-mobile-menu.open { display: flex; }
+    @media (max-width: 768px) {
+      .nav-disclosure[open] #nav-mobile-menu { display: flex; }
+    }
 
     .nav-mobile-link {
       display: block;
@@ -1491,18 +1501,19 @@
       <a href="#skills" class="nav-link">Skills</a>
       <a href="#proof" class="nav-link">Proof</a>
       <a href="#install" class="nav-cta">Install</a>
-      <button class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation menu" aria-expanded="false" aria-controls="nav-mobile-menu">
-        <span></span>
-        <span></span>
-        <span></span>
-      </button>
+      <details class="nav-disclosure" id="nav-disclosure" open>
+        <summary class="nav-hamburger" id="nav-hamburger" aria-label="Open navigation menu">
+          <span></span>
+          <span></span>
+          <span></span>
+        </summary>
+        <div id="nav-mobile-menu" role="menu" aria-label="Mobile navigation">
+        <a href="#skills" class="nav-mobile-link" role="menuitem">Skills</a>
+        <a href="#proof" class="nav-mobile-link" role="menuitem">Proof</a>
+        <a href="#install" class="nav-mobile-link nav-mobile-cta" role="menuitem">Install</a>
+        </div>
+      </details>
     </div>
-  </div>
-
-  <div id="nav-mobile-menu" role="menu" aria-label="Mobile navigation">
-    <a href="#skills" class="nav-mobile-link" role="menuitem">Skills</a>
-    <a href="#proof" class="nav-mobile-link" role="menuitem">Proof</a>
-    <a href="#install" class="nav-mobile-link nav-mobile-cta" role="menuitem">Install</a>
   </div>
 </nav>
 
@@ -1804,23 +1815,29 @@
     }, { passive: true });
   })();
 
-  // Mobile nav hamburger
+  // Mobile nav disclosure
   (function() {
+    var box = document.getElementById('nav-disclosure');
     var hamburger = document.getElementById('nav-hamburger');
     var menu = document.getElementById('nav-mobile-menu');
-    if (!hamburger || !menu) return;
+    if (!box || !hamburger || !menu) return;
+    var mq = window.matchMedia('(max-width: 768px)');
 
-    hamburger.addEventListener('click', function() {
-      var expanded = hamburger.getAttribute('aria-expanded') === 'true';
-      hamburger.setAttribute('aria-expanded', String(!expanded));
-      menu.classList.toggle('open', !expanded);
-    });
+    function collapseForViewport() { box.open = !mq.matches; }
+    function syncLabel() {
+      hamburger.setAttribute('aria-label', box.open ? 'Close navigation menu' : 'Open navigation menu');
+    }
 
-    // Close menu when a link is clicked
+    collapseForViewport();
+    syncLabel();
+    box.addEventListener('toggle', syncLabel);
+    if (mq.addEventListener) mq.addEventListener('change', collapseForViewport);
+    else if (mq.addListener) mq.addListener(collapseForViewport);
+
+    // Close after picking a destination (same-page anchors do not reload).
     menu.querySelectorAll('a').forEach(function(link) {
       link.addEventListener('click', function() {
-        hamburger.setAttribute('aria-expanded', 'false');
-        menu.classList.remove('open');
+        if (mq.matches) box.open = false;
       });
     });
   })();

--- a/tests/test_mobile_nav.py
+++ b/tests/test_mobile_nav.py
@@ -1,0 +1,138 @@
+"""The mobile nav is one pattern repeated across 100+ hand-written pages.
+
+Nothing here checks how it looks. These are the invariants that decay quietly:
+a page that drops the `open` attribute and becomes unreachable without
+JavaScript, a touch target shrunk back under 44px, a page that never got the
+pattern at all, and a mobile link list that drifts away from the desktop row
+sitting a few lines above it in the same file.
+
+The design is deliberately inverted: <details> ships `open`, so the browser
+renders every link with no script, and JS *collapses* it at mobile widths.
+That makes `open` load-bearing rather than cosmetic, which is why it gets its
+own test.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+# The only page under docs/ without the site nav is a Google verification stub.
+PAGES = sorted(
+    p for p in DOCS.rglob("*.html") if 'class="nav-logo"' in p.read_text(encoding="utf-8")
+)
+
+# These two carry a second, mobile-only copy of the link list, so their two
+# lists can drift apart. Every other page wraps its single .nav-links row.
+DUPLICATED_LIST_PAGES = {DOCS / "index.html", DOCS / "dav" / "index.html"}
+
+
+def stylesheets_for(page: Path, html: str) -> str:
+    """Inline <style> blocks plus every local stylesheet the page links."""
+    css = "\n".join(re.findall(r"<style>(.*?)</style>", html, re.S))
+    for href in re.findall(r'<link rel="stylesheet" href="([^"]+)"', html):
+        if href.startswith(("http://", "https://", "//")):
+            continue
+        resolved = (page.parent / href).resolve()
+        if resolved.is_file():
+            css += "\n" + resolved.read_text(encoding="utf-8")
+    return css
+
+
+def slice_div(html: str, opening: str) -> str:
+    """Markup of the div starting at `opening`, tags included, depth-aware."""
+    start = html.index(opening)
+    depth = 0
+    for match in re.finditer(r"<div\b|</div>", html[start:]):
+        depth += 1 if match.group(0) == "<div" else -1
+        if depth == 0:
+            return html[start : start + match.end()]
+    raise AssertionError(f"unterminated div for {opening!r}")
+
+
+def hrefs(markup: str) -> list:
+    return re.findall(r'<a\b[^>]*\bhref="([^"]*)"', markup)
+
+
+class MobileNavTests(unittest.TestCase):
+    def test_every_page_with_a_nav_was_found(self):
+        # Guards discovery itself: an empty page list would let every other
+        # test here pass while checking nothing.
+        self.assertGreaterEqual(len(PAGES), 100)
+
+    def test_every_nav_is_a_details_disclosure(self):
+        for page in PAGES:
+            with self.subTest(page=page.relative_to(ROOT)):
+                html = page.read_text(encoding="utf-8")
+                self.assertRegex(html, r'<details class="nav-disclosure"')
+                self.assertRegex(html, r'<summary class="nav-hamburger"')
+
+    def test_the_disclosure_ships_open(self):
+        # The whole no-JS story rests on this attribute. Drop it and the menu
+        # renders closed, with only script able to open it again.
+        for page in PAGES:
+            with self.subTest(page=page.relative_to(ROOT)):
+                html = page.read_text(encoding="utf-8")
+                tag = re.search(r"<details class=\"nav-disclosure\"[^>]*>", html)
+                self.assertIsNotNone(tag)
+                self.assertRegex(
+                    tag.group(0),
+                    r"\bopen\b",
+                    "the disclosure must ship open or the nav needs JS to be reachable",
+                )
+
+    def test_the_control_clears_the_44px_touch_floor(self):
+        # Resolved through linked stylesheets too, since most pages keep their
+        # nav CSS in assets/ rather than inline.
+        for page in PAGES:
+            with self.subTest(page=page.relative_to(ROOT)):
+                css = stylesheets_for(page, page.read_text(encoding="utf-8"))
+                rules = re.findall(
+                    r"\.nav-hamburger[^{;]*\{([^}]*)\}", css, re.S
+                )
+                sized = [r for r in rules if "width:" in r and "height:" in r]
+                self.assertTrue(sized, "no .nav-hamburger rule sets a size")
+                self.assertTrue(
+                    any("44px" in r for r in sized),
+                    "the hamburger must be at least 44px in both directions",
+                )
+
+    def test_pages_with_two_link_lists_keep_them_in_step(self):
+        for page in sorted(DUPLICATED_LIST_PAGES):
+            with self.subTest(page=page.relative_to(ROOT)):
+                html = page.read_text(encoding="utf-8")
+                desktop = slice_div(html, '<div class="nav-right">')
+                # The disclosure lives inside .nav-right on these two, so drop
+                # it before reading the desktop row.
+                desktop = re.sub(r"<details\b.*?</details>", "", desktop, flags=re.S)
+                panel = slice_div(html, '<div id="nav-mobile-menu"')
+                self.assertEqual(
+                    hrefs(desktop),
+                    hrefs(panel),
+                    "mobile menu drifted from the desktop nav",
+                )
+
+    def test_single_list_pages_never_grew_a_second_copy(self):
+        # The other 99 pages wrap one .nav-links row, which is why they cannot
+        # drift. A stray #nav-mobile-menu would reintroduce that risk.
+        for page in PAGES:
+            if page in DUPLICATED_LIST_PAGES:
+                continue
+            with self.subTest(page=page.relative_to(ROOT)):
+                html = page.read_text(encoding="utf-8")
+                self.assertNotIn('id="nav-mobile-menu"', html)
+                self.assertIn('<div class="nav-links">', html)
+
+    def test_the_script_keeps_the_label_honest(self):
+        for page in PAGES:
+            with self.subTest(page=page.relative_to(ROOT)):
+                html = page.read_text(encoding="utf-8")
+                self.assertIn("'Close navigation menu'", html)
+                self.assertIn("'Open navigation menu'", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

Two gaps left over from the mobile nav work in #87 and the pages around it.

`docs/dav/index.html` was the only one of the 101 nav pages still on the old
JS-only button. With JavaScript off, none of its nav links were reachable on
mobile, and the control was 36px, under the 44px touch floor.

And the pattern itself had nothing guarding it. It is repeated by hand across
every page, and the parts that decay are invisible in review.

## What changed

**`docs/dav/index.html`** now uses the same `<details class="nav-disclosure" open>`
pattern as the homepage, mirrored line for line rather than reinvented: the
`<button>` became a `<summary>`, the menu moved inside the `<details>`, the
`[aria-expanded="true"]` transform selectors became `.nav-disclosure[open]`,
the control went 36x36 to 44x44, and the class-toggle handler became the same
`collapseForViewport()` / `syncLabel()` pair the other pages use.

**`tests/test_mobile_nav.py`** guards the pattern across all 101 pages.

`open` gets its own test because this design is inverted. The disclosure ships
open so the browser renders every link with no script, and JS collapses it
below 768px. That makes the attribute load-bearing, not cosmetic, and a
one-word deletion would silently take the nav back to needing JavaScript.

Two details worth flagging for review:

- The 44px check resolves **linked stylesheets**, not just inline `<style>`.
  After #87 moved nav CSS into `assets/`, an inline-only check would have
  passed vacuously on 94 of the pages.
- Link parity is asserted only for `index.html` and `dav/index.html`, the two
  pages carrying a second mobile-only copy of the list. The other 99 wrap a
  single `.nav-links` row where drift is structurally impossible, so they get
  the inverse check: that a second copy never appears.

## Verification

dav measured at 375/390/414 against `docs/index.html` as the reference, and it
now matches on every number: 64px nav, zero horizontal overflow, 44x44 control,
and with JS off the links are reachable at 46px. Previously 0 of 6 links were
reachable with JS off. The native toggle opens and closes it with JS disabled;
with JS on it starts collapsed and the label flips to "Close navigation menu".

Every assertion in the new test was negative-tested rather than assumed:

| Break | Result |
|---|---|
| drop `open` on a skill page | FAILED (1) |
| shrink `skill.css` to 36px | FAILED (71) |
| add a desktop-only link to `index.html` | FAILED (1) |
| grow a second list on `guide.html` | FAILED (1) |
| revert dav to its pre-fix button | FAILED (1) |

The 71 in row two is the useful one: a single shared stylesheet shrunk fails
for all 71 pages importing it, which confirms the resolution reaches through
the link tags.

`validate-skill-pack.mjs --strict` passes (it carries five count checks against
`docs/dav/index.html`) and the Python suite is 36/36. I did not run
`test:validator-runtime`; it exercises the validator against synthetic fixture
repos and never reads `docs/`.

## Known limitation, not introduced here

With JS off the `aria-label` stays "Open navigation menu" while the menu is
open, since only the script syncs it. That is the behavior on every page today,
so dav is now consistent rather than correct in isolation. Fixing it is an
estate-wide change.