### PR TITLE
fix(docs): order the skill.css ship-strip rules so the mobile block wins

### DIFF
--- a/docs/assets/skill.css
+++ b/docs/assets/skill.css
@@ -65,6 +65,13 @@ a.link-row:hover { background: var(--surface); }
 .link-row b { font-family: var(--mono); font-size: 14px; font-weight: 500; color: var(--gold); word-break: break-word; }
 .link-row span { font-size: 14.5px; color: var(--muted); overflow-wrap: anywhere; }
 section { margin-top: 56px; }
+.ship-strip { background: var(--gold); color: #171310; padding: 64px 0; }
+.ship-strip-row code {
+  font-family: var(--mono); font-size: 16px; font-weight: 600;
+  color: #f0ece4; background: #171310;
+  border-radius: 4px; padding: 13px 20px;
+}
+.ship-strip-row code .prompt { color: var(--gold); user-select: none; }
 @media (max-width: 820px) {
   .hero-grid { grid-template-columns: 1fr; }
   .grid { grid-template-columns: 1fr; }
@@ -86,13 +93,6 @@ section { margin-top: 56px; }
 .plain-ask-arrow { font-family: var(--mono); color: var(--muted); font-size: 13px; }
 .plain-ask-cmd { font-size: 14px; font-weight: 600; }
 .plain-ask-note { flex-basis: 100%; font-size: 12.5px; color: var(--muted); }
-.ship-strip { background: var(--gold); color: #171310; padding: 64px 0; }
-.ship-strip-row code {
-  font-family: var(--mono); font-size: 16px; font-weight: 600;
-  color: #f0ece4; background: #171310;
-  border-radius: 4px; padding: 13px 20px;
-}
-.ship-strip-row code .prompt { color: var(--gold); user-select: none; }
 .skill-term {
   max-width: 760px;
   margin: 4px 0 44px;


### PR DESCRIPTION
## What

The `.ship-strip` base rules in `docs/assets/skill.css` sat **after** the `@media (max-width: 720px)` block. Same specificity, later rule wins — so two mobile declarations never took effect on any of the 73 skill pages:

| declaration | was overridden by |
|---|---|
| `.ship-strip { padding: 48px 0 }` | `padding: 64px 0` |
| `.ship-strip-row code { font-size: 14px }` | `font-size: 16px` |

The original report caught the padding; the font-size was dead the same way and is fixed by the same move.

This ordering came straight from the per-page inline `<style>` blocks and was preserved verbatim by the CSS extraction in #87 — that PR's claim was that rendering did not change, so it correctly carried the bug across rather than fixing it.

`docs/assets/prose.css` already declares these rules **before** its media query, which is why blog and book ship strips have always been right on mobile. This makes skill pages match.

## The change

Pure reorder — the `.ship-strip` block moves above the media queries. Sorted file contents are byte-identical before and after; no declaration was added, removed, or altered.

## Intended visual change

Confirmed with Jason before shipping. At ≤720px, on skill pages only:

| | before | after | prose pages |
|---|---|---|---|
| `.ship-strip` padding | 64px | **48px** | 48px |
| install-code font-size | 16px | **14px** | 14px |
| strip height @390px | 484px | **439px** | 446px |

## Verification

Playwright, `docs/skills/suede-code-review.html`, computed styles read from the live render:

- **≥721px byte-identical to before** — checked at 721 / 760 / 820 / 821 / 900 / 1280px, padding stays 64px and font stays 16px at every one.
- **≤720px picks up the mobile values** — checked at 320 / 390 / 600 / 720px.
- **No horizontal overflow** at any width from 320–1280px.
- **prose pages untouched** — measured as a control, unchanged at 48px/14px.
- `npm test` green, exit code 0 across the full `&&` chain.
- `test_mobile_nav.py` (7) and `test_homepage_quality.py` (10) re-run green after rebasing onto #88.