### PR TITLE
fix(docs): pin the ship-strip sub line-height so it stops inheriting host prose

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -126,7 +126,7 @@ footer { border-top: 1px solid var(--border); padding: 32px 0 48px; }
   font-size: clamp(30px, 4.5vw, 44px); font-weight: 800;
   letter-spacing: -0.03em; line-height: 1.05; color: #171310; margin: 0 0 8px;
 }
-.ship-strip-sub { font-size: 15.5px; color: rgba(23, 19, 16, 0.75); max-width: 620px; margin-bottom: 24px; }
+.ship-strip-sub { font-size: 15.5px; line-height: 1.6; color: rgba(23, 19, 16, 0.75); max-width: 620px; margin-bottom: 24px; }
 .ship-strip-row { display: flex; flex-wrap: wrap; align-items: center; gap: 14px 24px; }
 .ship-strip-row a {
   display: inline-flex; align-items: center; min-height: 44px;

--- a/tests/test_ship_strip.py
+++ b/tests/test_ship_strip.py
@@ -1,0 +1,162 @@
+"""The ship strip is one component rendered by ~100 hand-written pages.
+
+Nothing here checks how it looks. These are the two ways it has actually
+drifted, both of which were invisible on the page that introduced them and
+only showed up when two page types were measured side by side.
+
+1. Cascade order. `.ship-strip` and its mobile `@media (max-width: 720px)`
+   overrides live in the same stylesheet at equal specificity, so the mobile
+   block only wins if it is declared *after* the base rule. skill.css had them
+   the other way round, which silently killed `padding: 48px` and
+   `font-size: 14px` on 73 pages while the declarations sat there looking live.
+
+2. Typography inheritance. `.ship-strip-sub` is a bare <p>. site.css sets no
+   line-height on it originally, so it inherited whichever `p { line-height }`
+   the host stylesheet happened to declare -- 1.6 on skill pages, 1.75 from
+   prose.css -- and the same component rendered 7px taller on blog and book
+   pages than everywhere else.
+
+Both are the same underlying hazard: a shared component whose final rendering
+is decided by the page that hosts it rather than by the stylesheet that
+defines it.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+ASSETS = DOCS / "assets"
+
+# The container width every ship strip is meant to render at.
+STANDARD_SHELL = 1100
+
+PAGES = sorted(
+    p for p in DOCS.rglob("*.html") if 'class="ship-strip"' in p.read_text(encoding="utf-8")
+)
+
+# Properties the mobile block overrides. Each must survive the cascade, so for
+# each one the base declaration has to come first in the file.
+MOBILE_OVERRIDES = (
+    (r"\.ship-strip\s*\{", "padding"),
+    (r"\.ship-strip-row code\s*\{", "font-size"),
+)
+
+
+def stylesheets_for(page: Path, html: str) -> str:
+    """Inline <style> blocks plus every local stylesheet the page links."""
+    css = "\n".join(re.findall(r"<style>(.*?)</style>", html, re.S))
+    for href in re.findall(r'<link rel="stylesheet" href="([^"]+)"', html):
+        if href.startswith(("http://", "https://", "//")):
+            continue
+        resolved = (page.parent / href).resolve()
+        if resolved.is_file():
+            css += "\n" + resolved.read_text(encoding="utf-8")
+    return css
+
+
+def shell_widths(css: str) -> list:
+    """Every width `.shell` resolves to, following a `var(--shell)` indirection.
+
+    Pages write this two ways: `width: min(1100px, 100%)` inline, or
+    `width: min(calc(100% - 40px), var(--shell))` against a custom property.
+    """
+    widths = []
+    for body in re.findall(r"\.shell\s*\{([^}]*)\}", css):
+        decl = re.search(r"(?:^|;)\s*width:([^;]*)", body)
+        if not decl:
+            continue
+        # Only the width declaration -- `padding: 0 40px` is not a width. And
+        # lengths inside calc() are gutters subtracted from 100%, not caps:
+        # min(calc(100% - 40px), var(--shell)) caps at --shell, not at 40px.
+        expr = re.sub(r"calc\([^()]*\)", "", decl.group(1))
+        widths += re.findall(r"(\d+)px", expr)
+        if "var(--shell)" in expr:
+            widths += re.findall(r"--shell:\s*(\d+)px", css)
+    return widths
+
+
+def mobile_blocks(css: str) -> list:
+    """(start_index, body) for each `@media (max-width: 720px)` block."""
+    out = []
+    for match in re.finditer(r"@media\s*\(max-width:\s*720px\)\s*\{", css):
+        depth = 1
+        i = match.end()
+        while i < len(css) and depth:
+            if css[i] == "{":
+                depth += 1
+            elif css[i] == "}":
+                depth -= 1
+            i += 1
+        out.append((match.start(), css[match.end() : i - 1]))
+    return out
+
+
+class ShipStripTests(unittest.TestCase):
+    def test_every_page_with_a_ship_strip_was_found(self):
+        # Guards discovery itself: an empty page list would let the rest of
+        # this file pass while checking nothing.
+        self.assertGreaterEqual(len(PAGES), 90)
+
+    def test_the_sub_pins_its_own_line_height(self):
+        # Without this the component inherits the host stylesheet's `p` rule,
+        # which is exactly how blog and book pages drifted 7px taller.
+        site = (ASSETS / "site.css").read_text(encoding="utf-8")
+        rule = re.search(r"\.ship-strip-sub\s*\{([^}]*)\}", site)
+        self.assertIsNotNone(rule, ".ship-strip-sub is no longer defined in site.css")
+        self.assertIn(
+            "line-height",
+            rule.group(1),
+            ".ship-strip-sub must set its own line-height or it inherits the "
+            "host page's `p` rule and renders a different height per page type",
+        )
+
+    def test_mobile_overrides_are_declared_after_the_base_rule(self):
+        # Equal specificity, so source order alone decides the winner.
+        for css_name in ("skill.css", "prose.css"):
+            css = (ASSETS / css_name).read_text(encoding="utf-8")
+            for start, body in mobile_blocks(css):
+                for selector, prop in MOBILE_OVERRIDES:
+                    inside = re.search(selector + r"[^}]*" + prop, body)
+                    if not inside:
+                        continue
+                    base = re.search(selector, css)
+                    with self.subTest(css=css_name, selector=selector, prop=prop):
+                        self.assertIsNotNone(base)
+                        self.assertLess(
+                            base.start(),
+                            start,
+                            f"{css_name}: the base rule for {selector!r} is declared "
+                            f"after the 720px block, so the mobile {prop} is dead code",
+                        )
+
+    def test_the_strip_never_inherits_a_narrow_page_shell(self):
+        # A page may narrow `.shell` for readable prose -- prose.css takes it
+        # to 760px, docs/blog/index.html to 900px. When it does, the strip has
+        # to use the dedicated .ship-strip-shell or it silently renders
+        # narrower than the same strip on every other page. Only narrowing
+        # matters; a bespoke page sitting slightly wider is not this bug.
+        for page in PAGES:
+            html = page.read_text(encoding="utf-8")
+            wrapper = re.search(
+                r'<section class="ship-strip"[^>]*>\s*<div class="([a-z-]+)"', html
+            )
+            if not wrapper or wrapper.group(1) != "shell":
+                continue
+            css = stylesheets_for(page, html)
+            widths = [int(w) for w in shell_widths(css)]
+            with self.subTest(page=page.relative_to(ROOT)):
+                self.assertTrue(widths, f"{page.name}: no .shell width could be resolved")
+                self.assertGreaterEqual(
+                    min(widths),
+                    STANDARD_SHELL,
+                    f"{page.name} wraps its ship strip in .shell but narrows "
+                    f".shell to {min(widths)}px -- the strip will render narrower "
+                    f"than on every other page; use .ship-strip-shell instead",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The `.shell` vs `.ship-strip-shell` split was not the cause

Measured first. Both wrappers resolve to a **1100px** container on every page, at every width — they are not producing any difference.

The entire 7px was `.ship-strip-sub`, and it is a component-encapsulation leak. The element is a bare `<p>` and `site.css` set no `line-height`, so the shared component inherited whatever the host stylesheet's `p` rule said:

| host | rule | computed |
|---|---|---|
| skill pages | no bare `p` line-height → `body 1.6` | 24.8px |
| `prose.css:24` | `p { line-height: 1.75 }` | 27.125px |

Three lines of copy × 2.325px ≈ the 7px. Same component, taller on blog and book pages than on the ~77 others.

## Fix

Pin `line-height: 1.6` on `.ship-strip-sub` in `site.css` — the value `site.css`'s own `body` already sets, and what the large majority of pages already rendered. The component now owns its typography instead of borrowing the host page's reading rhythm.

## Why the shell split stays

It is deliberate, not drift. Pages that narrow `.shell` for readable prose use the dedicated class; pages whose `.shell` is already 1100px use it directly:

| page type | `.shell` | strip wrapper | strip renders |
|---|---|---|---|
| skill (71) + plugins/guide/copy/skills-index | 1100px | `.shell` | 1100px |
| `prose.css` (blog posts, book) | 760px | `.ship-strip-shell` | 1100px |
| `docs/blog/index.html` | 900px | `.ship-strip-shell` | 1100px |

`docs/blog/index.html` is the proof: it narrows `.shell` to 900px and correctly reaches for `.ship-strip-shell`. Converting the 76 `.shell` pages would impose prose's necessary workaround on pages that don't need it, for zero visual change.

## Verification

Computed styles read off the live render (Playwright), not the source.

Every child box of `.ship-strip` — shell, head, sub, row, code, link — is now byte-identical between a skill page and a prose page at **390px** and **1280px**. Surveyed all 8 page-type representatives: every one now reports `line-height: 24.8px`, and the strip's inner container measures 1100px on all of them.

Only the 23 prose pages change (439.0px, was 445.9px, at 390px). The five inline-style pages measured 24.8px before and after — untouched.

Swept the other shared `site.css` components for the same leak (`.ship-strip-head`, `.ship-strip-row a`, `.footer-note`, `.footer-links a`, `.nav-inner`, `.footer-divider`) — all consistent. `.ship-strip-sub` was the only one.

## Tests

New `tests/test_ship_strip.py`, each guard **verified to fail without its fix**:

- **the sub pins its own line-height** — reverting `site.css` fails it
- **mobile overrides declared after the base rule** — a regression guard for #89; restoring the pre-#89 ordering fails it on both `padding` and `font-size`
- **a page wrapping the strip in `.shell` must not narrow `.shell`** — narrowing `.shell` to 760px fails it across all 71 skill pages
- plus a discovery guard, so an empty page list cannot make the rest pass vacuously

`npm run test:python` green, 40 tests.

## Left alone

Skill pages carry a 56px top margin above the strip (`section { margin-top: 56px }` in `skill.css`, which the `<section class="ship-strip">` picks up incidentally); prose pages sit flush. That is spacing above the component, not its height, and both read fine — a design call rather than a defect, so it is unchanged here.