### PR TITLE
style(docs): drop the duplicate border declaration in prose.css .panel

### DIFF
--- a/docs/assets/prose.css
+++ b/docs/assets/prose.css
@@ -31,7 +31,6 @@ li { padding-left: 20px; position: relative; margin-bottom: 10px; font-size: 16p
 li::before { content: ""; position: absolute; left: 0; top: 11px; width: 9px; height: 1px; background: var(--gold); }
 .panel {
   border: 1px solid var(--border);
-  border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--card);
   padding: 24px 26px;


### PR DESCRIPTION
`.panel` in `docs/assets/prose.css` declared `border: 1px solid var(--border)` twice in a row. The duplicate came from the inline `<style>` block in `docs/blog/*.html` and survived the CSS extraction, which deliberately copied every rule byte-for-byte so rendering could be proven unchanged.

Same property, same value, no intervening declaration — removing it is inert.

## Verification

**Render unchanged.** Served the current tree and a baseline copy (identical except for `prose.css` restored from `HEAD`) on two local ports, then captured full-page Chromium screenshots of four `prose.css` consumers at 1280 and 390:

- `blog/memory-belongs-in-skills.html` (has `.panel`)
- `blog/not-for-the-line-that-makes-a-pack-work.html` (has `.panel`)
- `blog/progressive-disclosure-ship-dag-and-mcp.html` (has `.panel`)
- `book/anatomy-of-a-skill.html` (has `.panel`)

All 8 before/after pairs are byte-identical by SHA-256. The `.panel` border and card background render as before.

**Suite green.** `npm test` exits 0 — 140 node tests + 29 python tests, 0 failures, 1 skipped.