### PR TITLE
fix: changelog cited a squashed-away commit; guard it

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1184,7 +1184,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span style="height:67%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 3754953</b></span>
+              <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 67c4c7f</b></span>
               <span class="hero-shiplog-title">The pack gets five specialities</span>
               <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
             </span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3658,7 +3658,7 @@
             <span style="height:67%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 3754953</b></span>
+            <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 67c4c7f</b></span>
             <span class="hero-shiplog-title">The pack gets five specialities</span>
             <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
           </span>
@@ -3839,7 +3839,7 @@
           <p class="clog-meta">
             <span class="clog-date">2026-08-16</span>
             <span class="clog-tag">Rework</span>
-            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/3754953" target="_blank" rel="noopener" aria-label="View commit 3754953 on GitHub">3754953</a>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/67c4c7f" target="_blank" rel="noopener" aria-label="View commit 67c4c7f on GitHub">67c4c7f</a>
           </p>
           <h3 class="clog-title">The pack gets five specialities</h3>
           <p class="clog-detail">Version 0.13.0 re-cuts how the pack is browsed. The 73 skills were grouped four ways by <code>area</code> — marketing 41, workflow 25, creator 5, consumer 2 — and separately eight ways on the catalog page, with two more inconsistent cuts on the homepage. Marketing was a 41-name wall in every one of them. There are now five specialities, each with named sub-lanes: Ship 15, Craft 9, Get found 12, Convert &amp; earn 23, Strategy &amp; rights 14. The largest bucket goes 41 to 23. <code>area</code> is deliberately unchanged — it still decides which plugin bundle and MCP profile ships a skill, so nothing moved between install surfaces. <code>list_suede_skills</code> and <code>search_suede_skills</code> take a <code>specialty</code> filter, and the per-specialty counts on all three site surfaces are generated guards, not hand-typed numbers.</p>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -567,7 +567,7 @@
         <span style="height:67%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 3754953</b></span>
+        <span class="hero-shiplog-top">Released Aug 16 <b>&middot; 67c4c7f</b></span>
         <span class="hero-shiplog-title">The pack gets five specialities</span>
         <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
       </span>

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1792,6 +1792,11 @@ if (clogItems.length === 0) {
   });
 
   const gitHistory = inspectGitHistory(repoRoot);
+  // Prefer the remote-tracking ref: in a worktree cut from origin/main, local
+  // `main` can sit behind and would flag freshly landed entries as unreachable.
+  const defaultBranchRef = ["origin/main", "main", "HEAD"].find((ref) =>
+    spawnSync("git", ["-C", repoRoot, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`], { stdio: "ignore" }).status === 0
+  ) ?? "HEAD";
   if (gitHistory.state === "complete") {
     for (const entry of clogEntries) {
       if (!entry.hash) continue;
@@ -1802,6 +1807,20 @@ if (clogItems.length === 0) {
       }
       if (probe.status !== 0) {
         fail.push(`docs/index.html changelog cites commit ${entry.hash} which does not resolve to a commit in this repo`);
+        continue;
+      }
+      // Object existence is not enough. Every PR here lands squashed, so a
+      // pre-squash branch commit still resolves in the maintainer's clone
+      // (the branch object is right there) while being unreachable from the
+      // published history — a reader following the link gets nothing. 0.13.0
+      // shipped exactly that. Require reachability from the default branch.
+      const reachable = spawnSync(
+        "git",
+        ["-C", repoRoot, "merge-base", "--is-ancestor", entry.hash, defaultBranchRef],
+        { stdio: "ignore" }
+      );
+      if (reachable.status !== 0) {
+        fail.push(`docs/index.html changelog cites commit ${entry.hash}, which exists but is not reachable from ${defaultBranchRef} — a squash merge rewrites branch commits, so cite the commit that landed`);
       }
     }
   } else if (gitHistory.state === "packaged" || gitHistory.state === "shallow") {


### PR DESCRIPTION
The 0.13.0 entry shipped in #92 cited `3754953` — the pre-squash branch commit. Since every PR here lands squashed, that object is not reachable from `main`: the link 404s for anyone who does not have the branch, and the ship log's own claim that every entry is "a real commit on `main`" is false for the newest one.

- Repointed the entry and all three tiny ship-log boxes to `67c4c7f`, the squash commit that actually landed.
- Hardened the guard. It ran `git cat-file -e`, which passes because the branch object exists in a maintainer's clone. It now also requires ancestry from the default branch — resolved via `origin/main` first, so a worktree cut from a behind local `main` does not throw false failures.

Verified both directions: all 32 existing entries pass the stricter check, and restoring the bad hash reproduces a clean failure —

```
docs/index.html changelog cites commit 3754953, which exists but is not
reachable from origin/main — a squash merge rewrites branch commits, so
cite the commit that landed
```