### PR TITLE
Six specialities, and an MCP that navigates all of them

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4157,9 +4157,9 @@
 <!-- LANE INDEX -->
 <section id="lanes" aria-labelledby="lanes-headline">
   <div class="lanes-inner">
-    <p class="lanes-eyebrow reveal">One pack, five specialities</p>
+    <p class="lanes-eyebrow reveal">One pack, six specialities</p>
     <h2 id="lanes-headline" class="lanes-headline reveal reveal-d1">Code review is just the opening act.</h2>
-    <p class="lanes-sub reveal reveal-d1">The same discipline that grades your diffs also designs the page, writes the copy, runs the whole marketing engine, ships the iOS and Android app, packages the release rights, and argues your money back. Five specialities, 73 skills, one install.</p>
+    <p class="lanes-sub reveal reveal-d1">The same discipline that grades your diffs also designs the page, writes the copy, runs the whole marketing engine, ships the iOS and Android app, packages the release rights, and argues your money back. Six specialities, 73 skills, one install.</p>
     <div class="lanes-list reveal reveal-d2">
       <a class="lane-row" href="#lane-ship">
         <span class="lane-name">Ship</span>
@@ -4176,10 +4176,15 @@
         <span class="lane-desc">Search &amp; AI visibility, Content &amp; audience</span>
         <span class="lane-count">12 skills</span>
       </a>
-      <a class="lane-row" href="#lane-earn">
-        <span class="lane-name">Convert &amp; earn</span>
-        <span class="lane-desc">Demand channels, Money &amp; funnel, Measure &amp; operate, Consumer recovery</span>
-        <span class="lane-count">23 skills</span>
+      <a class="lane-row" href="#lane-demand">
+        <span class="lane-name">Demand channels</span>
+        <span class="lane-desc">Paid &amp; outbound, Lifecycle messaging, Acquisition assets</span>
+        <span class="lane-count">8 skills</span>
+      </a>
+      <a class="lane-row" href="#lane-revenue">
+        <span class="lane-name">Revenue &amp; retention</span>
+        <span class="lane-desc">Money &amp; funnel, Measure &amp; operate, Consumer recovery</span>
+        <span class="lane-count">15 skills</span>
       </a>
       <a class="lane-row" href="#lane-position">
         <span class="lane-name">Strategy &amp; rights</span>
@@ -4644,26 +4649,6 @@
       </div>
       <p class="catalog-lane-lead">Get the change built, reviewed, and merged.</p>
       <p class="catalog-sublane">Orchestration &amp; routing</p>
-      <a class="catalog-row" href="skills/suede-ship.html">
-        <span class="catalog-skill">suede-ship</span>
-        <span class="catalog-desc">The canonical orchestration DAG for repo changes: research, red-teamed planning, disjoint lanes, adversarial review, release verification</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
-      <a class="catalog-row" href="skills/suede-ship-copy.html">
-        <span class="catalog-skill">suede-ship-copy</span>
-        <span class="catalog-desc">The same DAG rebuilt for one high-stakes piece of writing: blind research, claim audit, section writers, refutation, publish gate</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
-      <a class="catalog-row" href="skills/suede-full-send.html">
-        <span class="catalog-skill">suede-full-send</span>
-        <span class="catalog-desc">Route broad, authorized outcome-bound work to one controller, useful non-colliding lanes, adversarial review, and proof</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
-      <a class="catalog-row" href="skills/suede-workflow-skills.html">
-        <span class="catalog-skill">suede-workflow-skills</span>
-        <span class="catalog-desc">Umbrella skill that loads the full pack as one workflow</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
       <a class="catalog-row" href="skills/suede-agent-teams.html">
         <span class="catalog-skill">suede-agent-teams</span>
         <span class="catalog-desc">Coordinate agent lanes with WIP collision detection, RFC mode, rollback trees, and a signed handoff</span>
@@ -4674,20 +4659,40 @@
         <span class="catalog-desc">The Suede Fable Fleet: brief, spawn, and review parallel OpenAI Codex CLI workers — Claude judges, Codex generates</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
+      <a class="catalog-row" href="skills/suede-full-send.html">
+        <span class="catalog-skill">suede-full-send</span>
+        <span class="catalog-desc">Route broad, authorized outcome-bound work to one controller, useful non-colliding lanes, adversarial review, and proof</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
       <a class="catalog-row" href="skills/suede-recommend-next-action.html">
         <span class="catalog-skill">suede-recommend-next-action</span>
         <span class="catalog-desc">Scores 2-4 candidate moves on goal fit, urgency, and leverage, then hands back one recommendation as a short runnable prompt</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
+      <a class="catalog-row" href="skills/suede-ship.html">
+        <span class="catalog-skill">suede-ship</span>
+        <span class="catalog-desc">The canonical orchestration DAG for repo changes: research, red-teamed planning, disjoint lanes, adversarial review, release verification</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-ship-copy.html">
+        <span class="catalog-skill">suede-ship-copy</span>
+        <span class="catalog-desc">The same DAG rebuilt for one high-stakes piece of writing: blind research, claim audit, section writers, refutation, publish gate</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-workflow-skills.html">
+        <span class="catalog-skill">suede-workflow-skills</span>
+        <span class="catalog-desc">Umbrella skill that loads the full pack as one workflow</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
       <p class="catalog-sublane">Code review &amp; CI</p>
+      <a class="catalog-row" href="skills/suede-ai-eval.html">
+        <span class="catalog-skill">suede-ai-eval</span>
+        <span class="catalog-desc">AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for AI surfaces</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
       <a class="catalog-row" href="skills/suede-code.html">
         <span class="catalog-skill">suede-code</span>
         <span class="catalog-desc">Deep review plus the A-F ship grade in one pass, from web stacks to Swift/iOS</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
-      <a class="catalog-row" href="skills/suede-code-review.html">
-        <span class="catalog-skill">suede-code-review</span>
-        <span class="catalog-desc">Findings-only review with TypeScript, React, Next.js, Swift/iOS, OWASP, accessibility, and database checklists</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-code-grader.html">
@@ -4695,14 +4700,9 @@
         <span class="catalog-desc">A-F ship verdict only: 7 evidence lanes, instant-F triggers, grade caps for auth and payment surfaces</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
-      <a class="catalog-row" href="skills/suede-ci-gate.html">
-        <span class="catalog-skill">suede-ci-gate</span>
-        <span class="catalog-desc">CI that gates the merge: stack and lockfile detection, one required check, branch protection</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
-      <a class="catalog-row" href="skills/suede-ai-eval.html">
-        <span class="catalog-skill">suede-ai-eval</span>
-        <span class="catalog-desc">AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for AI surfaces</span>
+      <a class="catalog-row" href="skills/suede-code-review.html">
+        <span class="catalog-skill">suede-code-review</span>
+        <span class="catalog-desc">Findings-only review with TypeScript, React, Next.js, Swift/iOS, OWASP, accessibility, and database checklists</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-mcp-qa.html">
@@ -4710,15 +4710,20 @@
         <span class="catalog-desc">QA pass for the bundled Suede Skills MCP server before it ships</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
-      <p class="catalog-sublane">Apps: iOS &amp; Android</p>
-      <a class="catalog-row" href="skills/site-to-ios-app.html">
-        <span class="catalog-skill">site-to-ios-app</span>
-        <span class="catalog-desc">Convert any website into an App Store-ready iOS app: URL audit, 4.2 wrapper-risk gate, Capacitor or native shell, release gate</span>
+      <a class="catalog-row" href="skills/suede-ci-gate.html">
+        <span class="catalog-skill">suede-ci-gate</span>
+        <span class="catalog-desc">CI that gates the merge: stack and lockfile detection, one required check, branch protection</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
+      <p class="catalog-sublane">Apps: iOS &amp; Android</p>
       <a class="catalog-row" href="skills/android-app-factory.html">
         <span class="catalog-skill">android-app-factory</span>
         <span class="catalog-desc">One prompt to a Play Store-ready native app: Kotlin + Jetpack Compose scaffolding, Play Billing, ASO listing, signed release</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/site-to-ios-app.html">
+        <span class="catalog-skill">site-to-ios-app</span>
+        <span class="catalog-desc">Convert any website into an App Store-ready iOS app: URL audit, 4.2 wrapper-risk gate, Capacitor or native shell, release gate</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
     </div>
@@ -4729,24 +4734,24 @@
       </div>
       <p class="catalog-lane-lead">Make the thing look and read like someone built it on purpose.</p>
       <p class="catalog-sublane">Design &amp; copy</p>
-      <a class="catalog-row" href="skills/johnny-suede-write.html">
-        <span class="catalog-skill">johnny-suede-write</span>
-        <span class="catalog-desc">Full writing lane: structure, persuasion frameworks, anti-slop gate, copy score</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
       <a class="catalog-row" href="skills/johnny-suede-design.html">
         <span class="catalog-skill">johnny-suede-design</span>
         <span class="catalog-desc">Full design lane: brand and product surfaces, tokens, visual QA, ship gate</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
-      <a class="catalog-row" href="skills/suede-design.html">
-        <span class="catalog-skill">suede-design</span>
-        <span class="catalog-desc">Design laws, dark-mode tokens, fluid type, component rules, and App Store screenshot specs. Includes Suedify</span>
+      <a class="catalog-row" href="skills/johnny-suede-write.html">
+        <span class="catalog-skill">johnny-suede-write</span>
+        <span class="catalog-desc">Full writing lane: structure, persuasion frameworks, anti-slop gate, copy score</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-copy.html">
         <span class="catalog-skill">suede-copy</span>
         <span class="catalog-desc">Conversion copy: headline formulas, A/B variants, anti-slop gate</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-design.html">
+        <span class="catalog-skill">suede-design</span>
+        <span class="catalog-desc">Design laws, dark-mode tokens, fluid type, component rules, and App Store screenshot specs. Includes Suedify</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-deslop.html">
@@ -4786,54 +4791,67 @@
       <div class="catalog-chips">
         <a class="catalog-chip" href="skills/suede-ai-seo.html">suede-ai-seo</a>
         <a class="catalog-chip" href="skills/suede-aso.html">suede-aso</a>
-        <a class="catalog-chip" href="skills/suede-programmatic-seo.html">suede-programmatic-seo</a>
         <a class="catalog-chip" href="skills/suede-directory-submissions.html">suede-directory-submissions</a>
+        <a class="catalog-chip" href="skills/suede-programmatic-seo.html">suede-programmatic-seo</a>
       </div>
       <p class="catalog-sublane">Content &amp; audience</p>
       <div class="catalog-chips">
-        <a class="catalog-chip" href="skills/suede-content-strategy.html">suede-content-strategy</a>
-        <a class="catalog-chip" href="skills/suede-social.html">suede-social</a>
-        <a class="catalog-chip" href="skills/suede-instagram-growth.html">suede-instagram-growth</a>
-        <a class="catalog-chip" href="skills/suede-community-marketing.html">suede-community-marketing</a>
-        <a class="catalog-chip" href="skills/suede-public-relations.html">suede-public-relations</a>
         <a class="catalog-chip" href="skills/suede-co-marketing.html">suede-co-marketing</a>
+        <a class="catalog-chip" href="skills/suede-community-marketing.html">suede-community-marketing</a>
+        <a class="catalog-chip" href="skills/suede-content-strategy.html">suede-content-strategy</a>
+        <a class="catalog-chip" href="skills/suede-instagram-growth.html">suede-instagram-growth</a>
+        <a class="catalog-chip" href="skills/suede-public-relations.html">suede-public-relations</a>
+        <a class="catalog-chip" href="skills/suede-social.html">suede-social</a>
       </div>
     </div>
-    <div class="catalog-lane reveal" id="lane-earn">
+    <div class="catalog-lane reveal" id="lane-demand">
       <div class="catalog-lane-head">
-        <span class="catalog-lane-name">Convert &amp; earn</span>
-        <span class="catalog-lane-count">23 skills</span>
+        <span class="catalog-lane-name">Demand channels</span>
+        <span class="catalog-lane-count">8 skills</span>
       </div>
-      <p class="catalog-lane-lead">Turn attention into signups, revenue, and retention.</p>
-      <p class="catalog-sublane">Demand channels</p>
+      <p class="catalog-lane-lead">Reach people who have not heard of you yet.</p>
+      <p class="catalog-sublane">Paid &amp; outbound</p>
       <div class="catalog-chips">
         <a class="catalog-chip" href="skills/suede-ads.html">suede-ads</a>
         <a class="catalog-chip" href="skills/suede-cold-email.html">suede-cold-email</a>
+        <a class="catalog-chip" href="skills/suede-prospecting.html">suede-prospecting</a>
+      </div>
+      <p class="catalog-sublane">Lifecycle messaging</p>
+      <div class="catalog-chips">
         <a class="catalog-chip" href="skills/suede-emails.html">suede-emails</a>
         <a class="catalog-chip" href="skills/suede-sms.html">suede-sms</a>
-        <a class="catalog-chip" href="skills/suede-prospecting.html">suede-prospecting</a>
-        <a class="catalog-chip" href="skills/suede-referrals.html">suede-referrals</a>
-        <a class="catalog-chip" href="skills/suede-lead-magnets.html">suede-lead-magnets</a>
-        <a class="catalog-chip" href="skills/suede-free-tools.html">suede-free-tools</a>
       </div>
+      <p class="catalog-sublane">Acquisition assets</p>
+      <div class="catalog-chips">
+        <a class="catalog-chip" href="skills/suede-free-tools.html">suede-free-tools</a>
+        <a class="catalog-chip" href="skills/suede-lead-magnets.html">suede-lead-magnets</a>
+        <a class="catalog-chip" href="skills/suede-referrals.html">suede-referrals</a>
+      </div>
+    </div>
+    <div class="catalog-lane reveal" id="lane-revenue">
+      <div class="catalog-lane-head">
+        <span class="catalog-lane-name">Revenue &amp; retention</span>
+        <span class="catalog-lane-count">15 skills</span>
+      </div>
+      <p class="catalog-lane-lead">Convert the attention, then keep what it earned.</p>
       <p class="catalog-sublane">Money &amp; funnel</p>
-      <a class="catalog-row" href="skills/suede-site-alchemy.html">
-        <span class="catalog-skill">suede-site-alchemy</span>
-        <span class="catalog-desc">Funnel analysis, friction audit, conversion math, and ranked quick wins for landing pages</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
       <a class="catalog-row" href="skills/suede-launch-packaging.html">
         <span class="catalog-skill">suede-launch-packaging</span>
         <span class="catalog-desc">Package work as a launch: docs, verified install commands, proof links, QA gate</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
+      <a class="catalog-row" href="skills/suede-site-alchemy.html">
+        <span class="catalog-skill">suede-site-alchemy</span>
+        <span class="catalog-desc">Funnel analysis, friction audit, conversion math, and ranked quick wins for landing pages</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
       <div class="catalog-chips">
-        <a class="catalog-chip" href="skills/suede-pricing.html">suede-pricing</a>
-        <a class="catalog-chip" href="skills/suede-offers.html">suede-offers</a>
-        <a class="catalog-chip" href="skills/suede-paywalls.html">suede-paywalls</a>
-        <a class="catalog-chip" href="skills/suede-signup.html">suede-signup</a>
-        <a class="catalog-chip" href="skills/suede-onboarding.html">suede-onboarding</a>
         <a class="catalog-chip" href="skills/suede-churn-prevention.html">suede-churn-prevention</a>
+        <a class="catalog-chip" href="skills/suede-offers.html">suede-offers</a>
+        <a class="catalog-chip" href="skills/suede-onboarding.html">suede-onboarding</a>
+        <a class="catalog-chip" href="skills/suede-paywalls.html">suede-paywalls</a>
+        <a class="catalog-chip" href="skills/suede-pricing.html">suede-pricing</a>
+        <a class="catalog-chip" href="skills/suede-signup.html">suede-signup</a>
       </div>
       <p class="catalog-sublane">Measure &amp; operate</p>
       <div class="catalog-chips">
@@ -4863,15 +4881,15 @@
       <p class="catalog-lane-lead">Know the market you are in and own what you make.</p>
       <p class="catalog-sublane">Strategy &amp; research</p>
       <div class="catalog-chips">
-        <a class="catalog-chip" href="skills/suede-marketing-plan.html">suede-marketing-plan</a>
+        <a class="catalog-chip" href="skills/suede-competitor-profiling.html">suede-competitor-profiling</a>
+        <a class="catalog-chip" href="skills/suede-competitors.html">suede-competitors</a>
+        <a class="catalog-chip" href="skills/suede-customer-research.html">suede-customer-research</a>
+        <a class="catalog-chip" href="skills/suede-marketing-council.html">suede-marketing-council</a>
         <a class="catalog-chip" href="skills/suede-marketing-ideas.html">suede-marketing-ideas</a>
         <a class="catalog-chip" href="skills/suede-marketing-loops.html">suede-marketing-loops</a>
-        <a class="catalog-chip" href="skills/suede-marketing-council.html">suede-marketing-council</a>
+        <a class="catalog-chip" href="skills/suede-marketing-plan.html">suede-marketing-plan</a>
         <a class="catalog-chip" href="skills/suede-marketing-psychology.html">suede-marketing-psychology</a>
         <a class="catalog-chip" href="skills/suede-product-marketing.html">suede-product-marketing</a>
-        <a class="catalog-chip" href="skills/suede-customer-research.html">suede-customer-research</a>
-        <a class="catalog-chip" href="skills/suede-competitors.html">suede-competitors</a>
-        <a class="catalog-chip" href="skills/suede-competitor-profiling.html">suede-competitor-profiling</a>
       </div>
       <p class="catalog-sublane">Creator toolkit</p>
       <a class="catalog-row" href="skills/suede-campaign-in-a-box.html">
@@ -4879,14 +4897,14 @@
         <span class="catalog-desc">Turn a song, release, or drop into a full artist campaign: eras, hooks, stunts, and fan missions</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
-      <a class="catalog-row" href="skills/suede-sync-packaging.html">
-        <span class="catalog-skill">suede-sync-packaging</span>
-        <span class="catalog-desc">Package songs for sync pitching: scene-fit angles, supervisor-safe one-sheets, rights status</span>
-        <span class="catalog-arrow">-&gt;</span>
-      </a>
       <a class="catalog-row" href="skills/suede-release-linter.html">
         <span class="catalog-skill">suede-release-linter</span>
         <span class="catalog-desc">Release folder audit before a drop: artwork, audio, metadata, and naming checks</span>
+        <span class="catalog-arrow">-&gt;</span>
+      </a>
+      <a class="catalog-row" href="skills/suede-rights-audit.html">
+        <span class="catalog-skill">suede-rights-audit</span>
+        <span class="catalog-desc">Rights and ownership gap check across a catalog or release</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
       <a class="catalog-row" href="skills/suede-rights-passport.html">
@@ -4894,9 +4912,9 @@
         <span class="catalog-desc">Prepare project folders for rights packaging: provenance, splits, licensing review, registry prep</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
-      <a class="catalog-row" href="skills/suede-rights-audit.html">
-        <span class="catalog-skill">suede-rights-audit</span>
-        <span class="catalog-desc">Rights and ownership gap check across a catalog or release</span>
+      <a class="catalog-row" href="skills/suede-sync-packaging.html">
+        <span class="catalog-skill">suede-sync-packaging</span>
+        <span class="catalog-desc">Package songs for sync pitching: scene-fit angles, supervisor-safe one-sheets, rights status</span>
         <span class="catalog-arrow">-&gt;</span>
       </a>
     </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -101,7 +101,7 @@ Install the full pack for Codex: `codex plugin marketplace add JasonColapietro/s
 
 ## MCP server
 
-- Suede Skills MCP: Optional Model Context Protocol server for structured skill discovery, install guidance, SEO/AEO/GEO/AI EO audit scaffolds, and QA checklists. 8 tools, 6 resources, 5 prompts, dependency-free stdio. Source: https://github.com/JasonColapietro/suede-creator-skills/blob/main/mcp/suede-skills-mcp.mjs
+- Suede Skills MCP: Optional Model Context Protocol server for structured skill discovery, install guidance, SEO/AEO/GEO/AI EO audit scaffolds, and QA checklists. 9 tools, 7 resources, 5 prompts, dependency-free stdio. Source: https://github.com/JasonColapietro/suede-creator-skills/blob/main/mcp/suede-skills-mcp.mjs
 
 ## Evidence boundary
 

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -491,7 +491,7 @@
 
             <rect x="772" y="112" width="206" height="78" rx="9" fill="#111111" stroke="#222222" stroke-width="1.5" stroke-dasharray="5 4"/>
             <text x="875" y="140" text-anchor="middle" fill="#f0ece4" font-size="14" font-weight="700">MCP (optional)</text>
-            <text x="875" y="160" text-anchor="middle" fill="#888880" font-size="12">7 tools &#183; 6 resources</text>
+            <text x="875" y="160" text-anchor="middle" fill="#888880" font-size="12">9 tools &#183; 7 resources</text>
             <text x="875" y="177" text-anchor="middle" fill="#888880" font-size="12">5 prompts &#183; stdio</text>
           </g>
         </svg>
@@ -638,7 +638,7 @@ codex plugin add suede-skills@suede-codex</code></pre>
     </div>
 
     <div class="prose">
-      <p>Profiles: <code>all</code>, <code>workflow</code>, <code>marketing</code>, <code>creator</code>, or <code>consumer</code>. It implements <code>initialize</code>, <code>tools/list</code>, <code>tools/call</code>, <code>resources/list</code>, <code>resources/read</code>, <code>prompts/list</code>, and <code>prompts/get</code>: 8 tools, 6 resources, 5 prompts. No dependencies, no network calls, no install step beyond running the file.</p>
+      <p>Profiles: <code>all</code>, the bundle areas <code>workflow</code>, <code>marketing</code>, <code>creator</code>, <code>consumer</code>, or any one specialty &mdash; <code>ship</code>, <code>craft</code>, <code>found</code>, <code>demand</code>, <code>revenue</code>, <code>position</code>. It implements <code>initialize</code>, <code>tools/list</code>, <code>tools/call</code>, <code>resources/list</code>, <code>resources/read</code>, <code>prompts/list</code>, and <code>prompts/get</code>: 9 tools, 7 resources, 5 prompts. No dependencies, no network calls, no install step beyond running the file.</p>
     </div>
 
     <div class="pathmap">
@@ -649,7 +649,7 @@ codex plugin add suede-skills@suede-codex</code></pre>
       <div class="pathmap-scroll">
         <svg class="pathmap-svg" viewBox="0 0 940 250" role="img" aria-labelledby="mcp-t mcp-d" xmlns="http://www.w3.org/2000/svg">
           <title id="mcp-t">The Suede Skills MCP surface</title>
-          <desc id="mcp-d">An agent speaks JSON-RPC over stdio to the server, which selects one of five profiles and exposes 8 tools, 6 resources, and 5 prompts.</desc>
+          <desc id="mcp-d">An agent speaks JSON-RPC over stdio to the server, which selects one of eleven profiles and exposes 9 tools, 7 resources, and 5 prompts.</desc>
           <g font-family="system-ui, -apple-system, sans-serif">
             <rect x="2" y="90" width="146" height="70" rx="9" fill="#161616" stroke="#c8a96e" stroke-width="1.5"/>
             <text x="75" y="121" text-anchor="middle" fill="#c8a96e" font-size="15" font-weight="800">Your agent</text>
@@ -696,9 +696,10 @@ codex plugin add suede-skills@suede-codex</code></pre>
       </div>
     </div>
 
-    <h3 style="margin-top:40px;">The 8 tools</h3>
+    <h3 style="margin-top:40px;">The 9 tools</h3>
     <div class="rows">
-      <div class="row"><b>list_suede_skills</b><span>Lists Suede skills by workflow, marketing, creator, consumer, or all areas.</span></div>
+      <div class="row"><b>list_suede_specialties</b><span>Lists the six specialities, their sub-lanes, and skill counts. Call it first to pick a specialty, then filter with it.</span></div>
+      <div class="row"><b>list_suede_skills</b><span>Lists Suede skills, optionally narrowed to one bundle area or one specialty.</span></div>
       <div class="row"><b>search_suede_skills</b><span>Ranks the pack against a task description and returns the best-matching skills instead of all 73.</span></div>
       <div class="row"><b>get_suede_skill</b><span>Returns one skill description and when to use it, or the full SKILL.md with <code>includeBody</code>.</span></div>
       <div class="row"><b>suede_install_options</b><span>Returns public skill, MCP, local plugin, and skill-copy install options.</span></div>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -551,7 +551,7 @@
   <div class="shell page-head">
     <p class="eyebrow">Skill catalog</p>
     <h1>73 skills. One honest line each.</h1>
-    <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Five specialities:</strong> ship (15), craft (9), get found (12), convert &amp; earn (23), and strategy &amp; rights (14). Each one breaks down further into sub-lanes, so no bucket is a wall of names. This catalog links each skill to its deep docs and its source folder on GitHub. No sign-up, no telemetry, nothing to uninstall but a folder.</p>
+    <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Six specialities:</strong> ship (15), craft (9), get found (12), demand channels (8), revenue &amp; retention (15), and strategy &amp; rights (14). Each one breaks down further into sub-lanes, so no bucket is a wall of names. This catalog links each skill to its deep docs and its source folder on GitHub. No sign-up, no telemetry, nothing to uninstall but a folder.</p>
 
     <a id="hero-shiplog" href="#changelog" aria-label="Ship log. Latest entry August 15, 2026: the entire skill pack gets its first major redesign. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
@@ -591,9 +591,9 @@
         <span class="lanemap-title">Where the 73 live</span>
         <span class="lanemap-hint">Jump to a specialty</span>
       </div>
-      <div class="lanemap-scroll"><svg class="lanemap-svg" viewBox="0 0 1000 192" role="img" aria-labelledby="lanemap-t lanemap-d" xmlns="http://www.w3.org/2000/svg">
+      <div class="lanemap-scroll"><svg class="lanemap-svg" viewBox="0 0 1000 228" role="img" aria-labelledby="lanemap-t lanemap-d" xmlns="http://www.w3.org/2000/svg">
         <title id="lanemap-t">Skills per specialty</title>
-        <desc id="lanemap-d">Ship 15, Craft 9, Get found 12, Convert and earn 23, Strategy and rights 14.</desc>
+        <desc id="lanemap-d">Ship 15, Craft 9, Get found 12, Demand channels 8, Revenue and retention 15, Strategy and rights 14.</desc>
         <g font-family="system-ui, -apple-system, sans-serif">
           <text x="250" y="30" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Ship</text>
           <rect x="264" y="17" width="238" height="18" rx="4" fill="#c8a96e"/>
@@ -604,19 +604,23 @@
           <text x="250" y="102" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Get found</text>
           <rect x="264" y="89" width="191" height="18" rx="4" fill="#c8a96e"/>
           <text x="469" y="103" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">12</text>
-          <text x="250" y="138" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Convert &amp; earn</text>
-          <rect x="264" y="125" width="365" height="18" rx="4" fill="#c8a96e"/>
-          <text x="643" y="139" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">23</text>
-          <text x="250" y="174" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Strategy &amp; rights</text>
-          <rect x="264" y="161" width="222" height="18" rx="4" fill="#c8a96e"/>
-          <text x="500" y="175" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">14</text>
+          <text x="250" y="138" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Demand channels</text>
+          <rect x="264" y="125" width="127" height="18" rx="4" fill="#c8a96e"/>
+          <text x="405" y="139" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">8</text>
+          <text x="250" y="174" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Revenue &amp; retention</text>
+          <rect x="264" y="161" width="238" height="18" rx="4" fill="#c8a96e"/>
+          <text x="516" y="175" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">15</text>
+          <text x="250" y="210" text-anchor="end" fill="#f0ece4" font-size="14.5" font-weight="600">Strategy &amp; rights</text>
+          <rect x="264" y="197" width="222" height="18" rx="4" fill="#c8a96e"/>
+          <text x="500" y="211" fill="#c8a96e" font-size="14" font-weight="700" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">14</text>
         </g>
       </svg></div>
       <nav class="lanemap-jump" aria-label="Jump to a catalog specialty">
         <a href="#spec-ship">Ship</a>
         <a href="#spec-craft">Craft</a>
         <a href="#spec-found">Get found</a>
-        <a href="#spec-earn">Convert &amp; earn</a>
+        <a href="#spec-demand">Demand channels</a>
+        <a href="#spec-revenue">Revenue &amp; retention</a>
         <a href="#spec-position">Strategy &amp; rights</a>
       </nav>
     </div>
@@ -676,11 +680,11 @@
       <article class="cell">
         <span class="cell-label">The growth org</span>
         <h3>41 marketing &amp; growth skills</h3>
-        <p>Spread across three specialities — get found, convert &amp; earn, and strategy &amp; rights: paid acquisition and outbound, pricing and offers, lifecycle and retention, and the measurement layer that keeps the rest honest. Start with the plan, then work the channel you actually need.</p>
+        <p>Spread across four specialities — get found, demand channels, revenue &amp; retention, and strategy &amp; rights: paid acquisition and outbound, pricing and offers, lifecycle and retention, and the measurement layer that keeps the rest honest. Start with the plan, then work the channel you actually need.</p>
         <div class="btn-row">
           <a class="btn btn--gold" href="suede-marketing-plan.html">Marketing plan</a>
           <a class="btn" href="suede-pricing.html">Pricing</a>
-          <a class="btn" href="#spec-earn">Convert &amp; earn -&gt;</a>
+          <a class="btn" href="#spec-revenue">Revenue &amp; retention -&gt;</a>
         </div>
       </article>
     </div>
@@ -701,27 +705,27 @@
       <p class="spec-sub">Get the change built, reviewed, and merged.</p>
       <div class="lane" id="lane-orchestration">
         <div class="lane-head"><h4>Orchestration &amp; routing</h4><span class="lane-count">7</span></div>
-        <a class="row" href="suede-ship.html"><b>suede-ship</b><span>Canonical shipping DAG: scout, multi-lens research, lane plan with file ownership, parallel build, adversarial refute, and an integration gate. Halts on hazards and collisions.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-ship-copy.html"><b>suede-ship-copy</b><span>The same graph for copy: blind research lenses, an audit of every agent-generated claim, one message per section, adversarial review, and a deslop pass. Never audits what you supplied.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-full-send.html"><b>suede-full-send</b><span>Routes broad, authorized outcome-bound work to one controller, useful non-colliding lanes, adversarial review, and proof.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-workflow-skills.html"><b>suede-workflow-skills</b><span>Umbrella workflow for the full public Suede stack.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="suede-agent-teams.html"><b>suede-agent-teams</b><span>Coordinate complex changes across agent lanes with collision detection, quality gates, and a signed handoff.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-codex-fleet.html"><b>suede-codex-fleet</b><span>Suede Fable Fleet: Claude decomposes, briefs, and reviews; parallel OpenAI Codex CLI workers generate the volume.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-full-send.html"><b>suede-full-send</b><span>Routes broad, authorized outcome-bound work to one controller, useful non-colliding lanes, adversarial review, and proof.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="suede-recommend-next-action.html"><b>suede-recommend-next-action</b><span>Scores candidate moves on goal fit, unblocking, evidence, urgency, and leverage, then hands back one recommendation as a short runnable prompt.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-ship.html"><b>suede-ship</b><span>Canonical shipping DAG: scout, multi-lens research, lane plan with file ownership, parallel build, adversarial refute, and an integration gate. Halts on hazards and collisions.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-ship-copy.html"><b>suede-ship-copy</b><span>The same graph for copy: blind research lenses, an audit of every agent-generated claim, one message per section, adversarial review, and a deslop pass. Never audits what you supplied.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-workflow-skills.html"><b>suede-workflow-skills</b><span>Umbrella workflow for the full public Suede stack.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-code">
         <div class="lane-head"><h4>Code review &amp; CI</h4><span class="lane-count">6</span></div>
-        <a class="row" href="./suede-code.html"><b>suede-code</b><span>Unified code review and A-F grading for correctness, security, data/state, deploy readiness, and ship risk.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-code-review.html"><b>suede-code-review</b><span>Deep diff review with TypeScript, React, Next.js, Swift/mobile, OWASP, and database checklists plus fix briefs and a grade.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-code-grader.html"><b>suede-code-grader</b><span>A blunt A-F ship verdict across seven evidence-backed lanes, with instant-F triggers and surface grade caps.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-ci-gate.html"><b>suede-ci-gate</b><span>Any-repo CI gate that blocks a merge when required checks fail. Prompted only, plugs into any CI or workflow system.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="suede-ai-eval.html"><b>suede-ai-eval</b><span>AI-SPECs, failure-mode rubrics, eval cases, acceptance gates, and coverage audits for AI-powered product surfaces.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-code.html"><b>suede-code</b><span>Unified code review and A-F grading for correctness, security, data/state, deploy readiness, and ship risk.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-code-grader.html"><b>suede-code-grader</b><span>A blunt A-F ship verdict across seven evidence-backed lanes, with instant-F triggers and surface grade caps.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-code-review.html"><b>suede-code-review</b><span>Deep diff review with TypeScript, React, Next.js, Swift/mobile, OWASP, and database checklists plus fix briefs and a grade.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-mcp-qa.html"><b>suede-mcp-qa</b><span>MCP tools, resources, prompts, catalog output, and docs alignment.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-ci-gate.html"><b>suede-ci-gate</b><span>Any-repo CI gate that blocks a merge when required checks fail. Prompted only, plugs into any CI or workflow system.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-apps">
         <div class="lane-head"><h4>Apps: iOS &amp; Android</h4><span class="lane-count">2</span></div>
-        <a class="row" href="./site-to-ios-app.html"><b>site-to-ios-app</b><span>Website to App Store-ready iOS app: URL audit, 4.2 wrapper-risk gate, shell strategy, and release gate.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./android-app-factory.html"><b>android-app-factory</b><span>One prompt to a Play Store-ready native Android app: Kotlin + Jetpack Compose scaffold, Play Billing, ASO listing, signed release.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./site-to-ios-app.html"><b>site-to-ios-app</b><span>Website to App Store-ready iOS app: URL audit, 4.2 wrapper-risk gate, shell strategy, and release gate.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
     </section>
     <section class="spec" id="spec-craft" aria-labelledby="spec-craft-h">
@@ -729,18 +733,18 @@
       <p class="spec-sub">Make the thing look and read like someone built it on purpose.</p>
       <div class="lane" id="lane-design">
         <div class="lane-head"><h4>Design &amp; copy</h4><span class="lane-count">5</span></div>
-        <a class="row" href="johnny-suede-write.html"><b>johnny-suede-write</b><span>Full writing mode for Suede or a supplied company: copy, company voice, product and mobile copy, SEO/AEO/AI EO, CTAs, launch copy, and anti-slop line editing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="johnny-suede-design.html"><b>johnny-suede-design</b><span>Full design mode for Suede or a supplied company: Suedify, mobile and product surfaces, product screenshots, UI polish, design-system QA, visual QA, visibility grading, implementation handoff, company voice, and copy.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-design.html"><b>suede-design</b><span>Design laws, component rules, dark-mode tokens, fluid type, motion sequencing, and visual QA for any Suede surface.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="johnny-suede-write.html"><b>johnny-suede-write</b><span>Full writing mode for Suede or a supplied company: copy, company voice, product and mobile copy, SEO/AEO/AI EO, CTAs, launch copy, and anti-slop line editing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-copy.html"><b>suede-copy</b><span>Conversion copy with headline formulas, persuasion frameworks, A/B variants, an anti-slop gate, and a copy score.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-design.html"><b>suede-design</b><span>Design laws, component rules, dark-mode tokens, fluid type, motion sequencing, and visual QA for any Suede surface.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-deslop.html"><b>suede-deslop</b><span>Strips AI writing patterns from prose before it ships: merged kill list, structure fixes, active voice, varied rhythm, and a 50-point score gate.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-creative">
         <div class="lane-head"><h4>Creative assets</h4><span class="lane-count">4</span></div>
         <a class="row" href="./suede-ad-creative.html"><b>suede-ad-creative</b><span>Produce ad creative at volume.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-image.html"><b>suede-image</b><span>Create and optimise marketing imagery.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-video.html"><b>suede-video</b><span>Plan and produce marketing video.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-clip-to-guide.html"><b>suede-clip-to-guide</b><span>Turn a clip, talk moment, or transcript into a repeatable clip-to-guide funnel package with rights routing and an evidence gate.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-video.html"><b>suede-video</b><span>Plan and produce marketing video.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
     </section>
     <section class="spec" id="spec-found" aria-labelledby="spec-found-h">
@@ -748,47 +752,57 @@
       <p class="spec-sub">Be discoverable by search, by AI answers, and by an audience.</p>
       <div class="lane" id="lane-seo">
         <div class="lane-head"><h4>Search &amp; AI visibility</h4><span class="lane-count">6</span></div>
-        <a class="row" href="./suede-seo-audit.html"><b>suede-seo-audit</b><span>Search intent, answer intent, metadata, schema, links, and trust checks.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-visibility-grader.html"><b>suede-visibility-grader</b><span>A-F grading for findability, first-screen clarity, CTA pull, proof, AI readability, rendered design signal, evidence, grade caps, and Google and Gemini result surfaces.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-ai-seo.html"><b>suede-ai-seo</b><span>Get cited in AI-generated answers.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-aso.html"><b>suede-aso</b><span>Optimise an App Store or Play listing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-programmatic-seo.html"><b>suede-programmatic-seo</b><span>Build search pages at scale without building junk.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-directory-submissions.html"><b>suede-directory-submissions</b><span>Work the directory layer deliberately.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-programmatic-seo.html"><b>suede-programmatic-seo</b><span>Build search pages at scale without building junk.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-seo-audit.html"><b>suede-seo-audit</b><span>Search intent, answer intent, metadata, schema, links, and trust checks.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-visibility-grader.html"><b>suede-visibility-grader</b><span>A-F grading for findability, first-screen clarity, CTA pull, proof, AI readability, rendered design signal, evidence, grade caps, and Google and Gemini result surfaces.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-content">
         <div class="lane-head"><h4>Content &amp; audience</h4><span class="lane-count">6</span></div>
-        <a class="row" href="./suede-content-strategy.html"><b>suede-content-strategy</b><span>Decide what to publish and why.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-social.html"><b>suede-social</b><span>Run social as a channel rather than a chore.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-instagram-growth.html"><b>suede-instagram-growth</b><span>Audit an Instagram account, map views to qualified action, and create account-specific Reels, carousels, Stories, and daily approval-ready content.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-community-marketing.html"><b>suede-community-marketing</b><span>Build a community that compounds.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-public-relations.html"><b>suede-public-relations</b><span>Earn coverage without a retainer.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-co-marketing.html"><b>suede-co-marketing</b><span>Find and run partner campaigns.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-community-marketing.html"><b>suede-community-marketing</b><span>Build a community that compounds.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-content-strategy.html"><b>suede-content-strategy</b><span>Decide what to publish and why.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-instagram-growth.html"><b>suede-instagram-growth</b><span>Audit an Instagram account, map views to qualified action, and create account-specific Reels, carousels, Stories, and daily approval-ready content.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-public-relations.html"><b>suede-public-relations</b><span>Earn coverage without a retainer.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-social.html"><b>suede-social</b><span>Run social as a channel rather than a chore.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
     </section>
-    <section class="spec" id="spec-earn" aria-labelledby="spec-earn-h">
-      <div class="spec-head"><h3 id="spec-earn-h">Convert &amp; earn</h3><span class="spec-count">23</span></div>
-      <p class="spec-sub">Turn attention into signups, revenue, and retention.</p>
-      <div class="lane" id="lane-demand">
-        <div class="lane-head"><h4>Demand channels</h4><span class="lane-count">8</span></div>
+    <section class="spec" id="spec-demand" aria-labelledby="spec-demand-h">
+      <div class="spec-head"><h3 id="spec-demand-h">Demand channels</h3><span class="spec-count">8</span></div>
+      <p class="spec-sub">Reach people who have not heard of you yet.</p>
+      <div class="lane" id="lane-paid">
+        <div class="lane-head"><h4>Paid &amp; outbound</h4><span class="lane-count">3</span></div>
         <a class="row" href="./suede-ads.html"><b>suede-ads</b><span>Run paid acquisition that pays back.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-cold-email.html"><b>suede-cold-email</b><span>Write B2B cold outreach that gets replies.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-prospecting.html"><b>suede-prospecting</b><span>Build and qualify a target list before you write a word.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+      </div>
+      <div class="lane" id="lane-lifecycle">
+        <div class="lane-head"><h4>Lifecycle messaging</h4><span class="lane-count">2</span></div>
         <a class="row" href="./suede-emails.html"><b>suede-emails</b><span>Design lifecycle email that runs itself.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-sms.html"><b>suede-sms</b><span>Run SMS without getting blocked or resented.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-prospecting.html"><b>suede-prospecting</b><span>Build and qualify a target list before you write a word.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-referrals.html"><b>suede-referrals</b><span>Turn customers into a channel.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-lead-magnets.html"><b>suede-lead-magnets</b><span>Decide what to give away for an email.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-free-tools.html"><b>suede-free-tools</b><span>Engineering as marketing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
+      <div class="lane" id="lane-assets">
+        <div class="lane-head"><h4>Acquisition assets</h4><span class="lane-count">3</span></div>
+        <a class="row" href="./suede-free-tools.html"><b>suede-free-tools</b><span>Engineering as marketing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-lead-magnets.html"><b>suede-lead-magnets</b><span>Decide what to give away for an email.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-referrals.html"><b>suede-referrals</b><span>Turn customers into a channel.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+      </div>
+    </section>
+    <section class="spec" id="spec-revenue" aria-labelledby="spec-revenue-h">
+      <div class="spec-head"><h3 id="spec-revenue-h">Revenue &amp; retention</h3><span class="spec-count">15</span></div>
+      <p class="spec-sub">Convert the attention, then keep what it earned.</p>
       <div class="lane" id="lane-funnel">
         <div class="lane-head"><h4>Money &amp; funnel</h4><span class="lane-count">8</span></div>
-        <a class="row" href="./suede-pricing.html"><b>suede-pricing</b><span>Decide what to charge and how to package it.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-offers.html"><b>suede-offers</b><span>Construct the thing you actually sell.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-paywalls.html"><b>suede-paywalls</b><span>Design in-app upgrade moments that convert without resentment.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-signup.html"><b>suede-signup</b><span>Cut friction out of registration.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-onboarding.html"><b>suede-onboarding</b><span>Get a new user to first value fast.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-site-alchemy.html"><b>suede-site-alchemy</b><span>Landing page, CTA routing, conversion, and site polish workflow.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-launch-packaging.html"><b>suede-launch-packaging</b><span>Public launch copy, proof links, install paths, QA, and handoff.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-churn-prevention.html"><b>suede-churn-prevention</b><span>Keep subscribers who are leaving and recover the ones you lose to billing.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-launch-packaging.html"><b>suede-launch-packaging</b><span>Public launch copy, proof links, install paths, QA, and handoff.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-offers.html"><b>suede-offers</b><span>Construct the thing you actually sell.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-onboarding.html"><b>suede-onboarding</b><span>Get a new user to first value fast.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-paywalls.html"><b>suede-paywalls</b><span>Design in-app upgrade moments that convert without resentment.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-pricing.html"><b>suede-pricing</b><span>Decide what to charge and how to package it.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-signup.html"><b>suede-signup</b><span>Cut friction out of registration.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-site-alchemy.html"><b>suede-site-alchemy</b><span>Landing page, CTA routing, conversion, and site polish workflow.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-measure">
         <div class="lane-head"><h4>Measure &amp; operate</h4><span class="lane-count">5</span></div>
@@ -809,23 +823,23 @@
       <p class="spec-sub">Know the market you are in and own what you make.</p>
       <div class="lane" id="lane-strategy">
         <div class="lane-head"><h4>Strategy &amp; research</h4><span class="lane-count">9</span></div>
-        <a class="row" href="./suede-marketing-plan.html"><b>suede-marketing-plan</b><span>Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-competitor-profiling.html"><b>suede-competitor-profiling</b><span>Research competitors from their public surfaces and turn the findings into structured profiles.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-competitors.html"><b>suede-competitors</b><span>Write comparison and alternative pages that rank and convert without misrepresenting anyone.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-customer-research.html"><b>suede-customer-research</b><span>Find out what customers actually think.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-marketing-council.html"><b>suede-marketing-council</b><span>Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-marketing-ideas.html"><b>suede-marketing-ideas</b><span>Get unstuck with a structured idea library rather than a blank page.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-marketing-loops.html"><b>suede-marketing-loops</b><span>Turn marketing into a recurring loop an agent runs on a cadence.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-marketing-council.html"><b>suede-marketing-council</b><span>Convene a panel of legendary marketers on one question, surface where they disagree, and synthesise a recommendation from the strongest arguments.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-marketing-plan.html"><b>suede-marketing-plan</b><span>Produce a full marketing plan structured by acquisition, activation, retention, referral, and revenue, sized to the current budget, team, and stage.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-marketing-psychology.html"><b>suede-marketing-psychology</b><span>Apply behavioural science honestly.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-product-marketing.html"><b>suede-product-marketing</b><span>Establish the product context every other marketing lane reads from.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-customer-research.html"><b>suede-customer-research</b><span>Find out what customers actually think.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-competitors.html"><b>suede-competitors</b><span>Write comparison and alternative pages that rank and convert without misrepresenting anyone.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-competitor-profiling.html"><b>suede-competitor-profiling</b><span>Research competitors from their public surfaces and turn the findings into structured profiles.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
       <div class="lane" id="lane-creator">
         <div class="lane-head"><h4>Creator toolkit</h4><span class="lane-count">5</span></div>
         <a class="row" href="./suede-campaign-in-a-box.html"><b>suede-campaign-in-a-box</b><span>Packages rollout phases, copy, content calendar, fan actions, page sections, and next moves.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="./suede-sync-packaging.html"><b>suede-sync-packaging</b><span>Prepares sync-style review packages without placement promises, clearance claims, outreach claims, or a Suede promo CTA.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="suede-release-linter.html"><b>suede-release-linter</b><span>Release metadata, files, credits, splits, samples, provenance, and readiness audit.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
-        <a class="row" href="suede-rights-passport.html"><b>suede-rights-passport</b><span>Local creator rights package with provenance, credits, split notes, license notes, and structured metadata.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
         <a class="row" href="./suede-rights-audit.html"><b>suede-rights-audit</b><span>Ownership, contributor, sample, license, split, and intake gap audit.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="suede-rights-passport.html"><b>suede-rights-passport</b><span>Local creator rights package with provenance, credits, split notes, license notes, and structured metadata.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
+        <a class="row" href="./suede-sync-packaging.html"><b>suede-sync-packaging</b><span>Prepares sync-style review packages without placement promises, clearance claims, outreach claims, or a Suede promo CTA.</span><span class="arrow" aria-hidden="true">-&gt;</span></a>
       </div>
     </section>
   </section>

--- a/mcp/catalog.json
+++ b/mcp/catalog.json
@@ -192,15 +192,31 @@
       ]
     },
     {
-      "key": "earn",
-      "label": "Convert & earn",
-      "summary": "Turn attention into signups, revenue, and retention.",
-      "count": 23,
+      "key": "demand",
+      "label": "Demand channels",
+      "summary": "Reach people who have not heard of you yet.",
+      "count": 8,
       "lanes": [
         {
-          "label": "Demand channels",
-          "count": 8
+          "label": "Paid & outbound",
+          "count": 3
         },
+        {
+          "label": "Lifecycle messaging",
+          "count": 2
+        },
+        {
+          "label": "Acquisition assets",
+          "count": 3
+        }
+      ]
+    },
+    {
+      "key": "revenue",
+      "label": "Revenue & retention",
+      "summary": "Convert the attention, then keep what it earned.",
+      "count": 15,
+      "lanes": [
         {
           "label": "Money & funnel",
           "count": 8
@@ -236,7 +252,7 @@
     {
       "name": "amazon-returns-recovery",
       "area": "consumer",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Consumer recovery",
       "description": "Use when the user wants to audit Amazon returns or Amazon-billed subscriptions, mentions a restocking fee, short or denied refund, forgotten Prime Video Channel, Audible, Kindle Unlimited, or Prime charge, or asks whether Amazon still owes or bills them. Read order, refund, and subscription evidence first; report findings and require confirmation before chat, cancellation, or dispute. The documented cases recovered $448.31, but never promise recovery. Requires an authenticated Claude in Chrome session. NOT FOR: bank chargebacks, marketplace A-to-z seller claims, price-protection claims, or subscriptions billed outside Amazon — use subscription-recovery for those.",
       "useWhen": "The user mentions Amazon returns, restocking fees, a refund that looks short, or wants to check whether Amazon still owes them money on a past return."
@@ -276,7 +292,7 @@
     {
       "name": "subscription-recovery",
       "area": "consumer",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Consumer recovery",
       "description": "Use when the user wants to find, audit, cancel, or dispute recurring charges billed outside Amazon, including App Store, Google Play, PayPal, direct-bill streaming, gyms, news, and SaaS. Discover charges from evidence the user directly provides or authenticated service pages, report findings first, and require confirmation before cancellation or refund contact. Never enter payment credentials or promise recovery. Requires Claude in Chrome for browser actions. NOT FOR: Amazon returns, restocking fees, or Amazon-billed Prime Video Channels, Audible, Kindle Unlimited, or Prime — use amazon-returns-recovery for those.",
       "useWhen": "The user wants to audit recurring charges generally, asks what subscriptions they're paying for, mentions a non-Amazon subscription by name, or wants to find and cancel unused subscriptions."
@@ -284,7 +300,7 @@
     {
       "name": "suede-ab-testing",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Measure & operate",
       "description": "Suede-owned experimentation discipline for hypotheses, sample sizing, test duration, significance, and repeatable experiment programs. Use when comparing variants, deciding whether a result is reliable, or building an experiment backlog and cadence. NOT FOR: analytics instrumentation (use suede-analytics), post-click conversion diagnosis (use suede-site-alchemy), or writing the variant copy itself (use suede-copy).",
       "useWhen": "The user wants to A/B test a change, judge whether a result is real, or build an experimentation practice."
@@ -300,8 +316,8 @@
     {
       "name": "suede-ads",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Paid & outbound",
       "description": "Suede-owned paid-acquisition operating system for channel choice, campaign structure, audiences, bidding, budget pacing, negative keywords, retargeting, and kill-or-scale decisions. Use when planning, auditing, or optimizing paid campaigns on Google, Meta, LinkedIn, X, or comparable platforms. NOT FOR: producing creative variants (use suede-ad-creative), implementing measurement (use suede-analytics), or optimizing the landing page (use suede-site-alchemy).",
       "useWhen": "The user is planning, running, or fixing paid campaigns on Google, Meta, LinkedIn, or X, or weighing whether to run ads at all."
     },
@@ -332,7 +348,7 @@
     {
       "name": "suede-analytics",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Measure & operate",
       "description": "Suede-owned measurement discipline for tracking plans, event and conversion instrumentation, UTMs, attribution, and verification of what actually fires. Use when setting up, auditing, or repairing analytics across web, product, paid, and lifecycle surfaces. NOT FOR: experiment design or significance decisions (use suede-ab-testing), campaign optimization (use suede-ads), or revenue-process architecture (use suede-revops).",
       "useWhen": "The user is setting up or fixing analytics, conversion tracking, or attribution, or cannot tell whether a change moved anything."
@@ -348,7 +364,7 @@
     {
       "name": "suede-attribution",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Measure & operate",
       "description": "Suede-affiliated marketing attribution discipline for choosing or interpreting an attribution model and reconciling conflicting cross-tool numbers into a defensible read on what drove revenue. Use when the user wants to know which marketing drove conversions, pick or interpret an attribution model, or instrument attribution themselves. NOT FOR: general analytics instrumentation and reporting (use suede-analytics) or revenue-ops pipeline work (use suede-revops).",
       "useWhen": "The user wants to figure out which marketing actually drives conversions and revenue, choose or interpret an attribution model, or reconcile conflicting numbers across tools."
@@ -364,7 +380,7 @@
     {
       "name": "suede-churn-prevention",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-owned retention discipline for voluntary and involuntary churn: cancel flows, pause paths, evidence-based save offers, failed-payment recovery, proactive signals, and win-back design. Use when diagnosing subscriber loss or designing a bounded retention intervention. NOT FOR: lifecycle-email production (use suede-emails), pricing architecture (use suede-pricing), paywall design (use suede-paywalls), or event instrumentation (use suede-analytics).",
       "useWhen": "The user is losing subscribers, designing a cancellation flow, or recovering revenue lost to failed payments."
@@ -412,8 +428,8 @@
     {
       "name": "suede-cold-email",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Paid & outbound",
       "description": "Suede-owned B2B cold-email discipline for evidence-based personalization, subject lines, opening lines, concise bodies, one clear CTA, and bounded follow-up sequences. Use when writing or repairing outbound email to qualified prospects. NOT FOR: building or qualifying the prospect list (use suede-prospecting), lifecycle or nurture email (use suede-emails), or broader sales collateral (use suede-sales-enablement).",
       "useWhen": "The user is writing cold outbound email or a prospecting sequence, or nobody is replying to the ones they sent."
     },
@@ -492,16 +508,16 @@
     {
       "name": "suede-emails",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Lifecycle messaging",
       "description": "Suede-affiliated lifecycle email design for welcome, onboarding, nurture, re-engagement, post-purchase, and trigger-based sequences. Use when the user needs a multi-email flow, entry criteria, cadence, message roles, and measurement plan. NOT FOR: cold prospecting (use suede-cold-email), in-product activation flows (use suede-onboarding), or lifecycle-stage operations beyond email (use suede-revops).",
       "useWhen": "The user is building an automated email sequence, drip campaign, or lifecycle flow."
     },
     {
       "name": "suede-free-tools",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Acquisition assets",
       "description": "Suede-affiliated engineering-as-marketing strategy for selecting, scoring, and scoping calculators, graders, generators, and other free interactive tools. Use when the user wants a lead, link, education, or product-adoption asset with a measurable path to the paid product. NOT FOR: downloadable lead assets (use suede-lead-magnets), implementation of a full website (use suede-site-alchemy), or search diagnostics (use suede-seo-audit).",
       "useWhen": "The user is weighing or building a free calculator, grader, generator, or other interactive tool for lead generation or links."
     },
@@ -524,7 +540,7 @@
     {
       "name": "suede-launch-packaging",
       "area": "workflow",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-owned launch packaging and install verification. Use when finished software work needs a clean public package — README, docs page, install command, release note, GitHub Pages update, skill-pack release, MCP server, or launch/social copy — or when a release needs handoff notes, an install fails, a public user cannot add a skill, a raw-vs-blob URL returns HTML, or `@personal` or a local plugin alias leaks into public docs. Verifies the live URL and runs the exact install command from a clean temporary directory before anything is called live. NOT FOR: product, course, or artist campaign launches (use suede-campaign-in-a-box or suede-marketing-plan); writing announcement copy from scratch (use suede-copy); MCP tool-catalog QA (use suede-mcp-qa); landing-page conversion work (use suede-site-alchemy).",
       "useWhen": "Package a skill, repo, site, MCP server, feature, docs update, failed install, or public launch so a stranger can use it."
@@ -540,8 +556,8 @@
     {
       "name": "suede-lead-magnets",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Acquisition assets",
       "description": "Suede-affiliated lead-magnet strategy for choosing a downloadable format, defining useful depth, setting honest gating, planning delivery, and measuring qualified capture. Use when the user needs an ebook, checklist, template, content upgrade, or resource exchanged for contact details. NOT FOR: interactive free tools (use suede-free-tools), lifecycle sequences after capture (use suede-emails), or production copy (use suede-copy).",
       "useWhen": "The user is planning gated content, a content upgrade, a template, or any downloadable in exchange for contact details."
     },
@@ -596,7 +612,7 @@
     {
       "name": "suede-offers",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-affiliated offer design for value framing, bonuses, guarantees, risk reversal, honest scarcity, naming, and payment structure. Use when the user is building or diagnosing a service, course, coaching, information-product, agency, or high-ticket B2B offer. NOT FOR: SaaS tier and value-metric architecture (use suede-pricing), sales-page copy (use suede-copy), or in-product upgrade prompts (use suede-paywalls).",
       "useWhen": "The user is building or fixing an offer for a service, agency, course, coaching, info product, or high-ticket B2B sale."
@@ -604,7 +620,7 @@
     {
       "name": "suede-onboarding",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-affiliated onboarding and activation strategy for first-run sequencing, empty states, setup checklists, activation milestones, time to value, and retention-linked measurement. Use when users sign up but fail to reach first value or the product needs a new first-session flow. NOT FOR: registration optimization (use suede-signup), lifecycle email sequences (use suede-emails), or monetization prompts (use suede-paywalls).",
       "useWhen": "The user has people signing up but not activating, or wants to design the first session in a product."
@@ -612,7 +628,7 @@
     {
       "name": "suede-paywalls",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-affiliated in-product monetization design for paywall screens, feature gates, trial-expiry states, usage-limit prompts, and free-to-paid upgrade moments. Use when the user needs trigger timing, message structure, plan presentation, or experiment design after users have experienced value. NOT FOR: public pricing pages (use suede-site-alchemy), tier architecture (use suede-pricing), or cancellation and save flows (use suede-churn-prevention).",
       "useWhen": "The user wants to build or improve an in-product upgrade screen, feature gate, or trial-expiration prompt."
@@ -620,7 +636,7 @@
     {
       "name": "suede-pricing",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-owned pricing and packaging discipline. Use when deciding what to charge, structuring tiers, choosing a value metric, comparing free trials with freemium, researching willingness to pay, or planning a price increase. NOT FOR: in-product upgrade screens (use suede-paywalls), offer bonuses and guarantees (use suede-offers), or executing billing changes.",
       "useWhen": "The user is deciding what to charge, restructuring plans, weighing a free tier or trial, or raising prices."
@@ -644,8 +660,8 @@
     {
       "name": "suede-prospecting",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Paid & outbound",
       "description": "Suede-owned prospecting and qualification discipline. Use when defining an ICP, sourcing and enriching a bounded lead list, finding early adopters or design partners, scoring account fit, or documenting disqualification evidence. NOT FOR: sending outreach (use suede-cold-email), changing CRM routing (use suede-revops), or profiling competitors instead of prospects (use suede-competitor-profiling).",
       "useWhen": "The user needs a prospect or lead list, or is deciding which accounts to go after."
     },
@@ -668,8 +684,8 @@
     {
       "name": "suede-referrals",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Acquisition assets",
       "description": "Suede-owned referral and affiliate program discipline. Use when designing refer-a-friend mechanics, ambassador or partner incentives, fraud controls, attribution, payout logic, or viral-loop measurement. NOT FOR: executing payouts or changing billing, launch-wide packaging (use suede-launch-packaging), lifecycle messaging (use suede-emails), or reporting unverified referral lift.",
       "useWhen": "The user wants existing users or partners bringing in new customers, or is designing a referral or affiliate program."
     },
@@ -684,7 +700,7 @@
     {
       "name": "suede-revops",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Measure & operate",
       "description": "Suede-owned revenue-operations discipline. Use when defining lead scoring and routing, MQL or SQL criteria, pipeline stages, CRM hygiene, automation, deal-desk rules, or marketing-to-sales handoffs. NOT FOR: writing outreach (use suede-cold-email), lifecycle campaigns (use suede-emails), pricing strategy (use suede-pricing), or mutating production CRM records without approval.",
       "useWhen": "The user is defining lead qualification, routing leads to sales, or fixing the handoff between marketing and revenue."
@@ -708,7 +724,7 @@
     {
       "name": "suede-sales-enablement",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Measure & operate",
       "description": "Suede-owned sales-enablement discipline. Use when creating pitch decks, one-pagers, objection guides, demo scripts, talk tracks, battle cards, proposal structures, buyer cards, or deal-level ROI framing. NOT FOR: setting price or terms (use suede-pricing), building the offer (use suede-offers), sending outreach (use suede-cold-email), or publishing unsupported proof.",
       "useWhen": "The user needs sales collateral, a demo script, objection handling, or materials for a sales conversation."
@@ -756,7 +772,7 @@
     {
       "name": "suede-signup",
       "area": "marketing",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Suede-owned signup conversion discipline. Use when auditing or redesigning account creation, registration, or trial-start flows, including field friction, progressive profiling, identity options, mobile behavior, abandonment, and measurement. NOT FOR: post-signup activation (use suede-onboarding), lead-capture forms (use suede-site-alchemy), or deploying auth and compliance changes without review.",
       "useWhen": "The user has a signup, registration, or trial-start flow that loses people partway through."
@@ -764,7 +780,7 @@
     {
       "name": "suede-site-alchemy",
       "area": "workflow",
-      "specialty": "earn",
+      "specialty": "revenue",
       "lane": "Money & funnel",
       "description": "Turn a page into a conversion path: hero, friction, proof, CTA, pricing, A/B ideas, quick wins, and mobile CRO.",
       "useWhen": "Improve page conversion, package website growth offers, or route conversion work into the full design workflow."
@@ -772,8 +788,8 @@
     {
       "name": "suede-sms",
       "area": "marketing",
-      "specialty": "earn",
-      "lane": "Demand channels",
+      "specialty": "demand",
+      "lane": "Lifecycle messaging",
       "description": "Suede-owned SMS and MMS marketing discipline. Use when evaluating SMS as a channel, designing consent-aware sequences, drafting messages, setting cadence, comparing number types or platforms, and defining measurement. NOT FOR: email campaigns (use suede-emails), phone capture UX (use suede-site-alchemy), legal certification, or sending, scheduling, importing, or registering anything without approval.",
       "useWhen": "The user is adding SMS or text-message marketing, or writing messages for an existing SMS list."
     },
@@ -821,6 +837,7 @@
   "mcp": {
     "tools": [
       "list_suede_skills",
+      "list_suede_specialties",
       "search_suede_skills",
       "get_suede_skill",
       "suede_install_options",
@@ -831,6 +848,7 @@
     ],
     "resources": [
       "suede://catalog",
+      "suede://specialties",
       "suede://plugins",
       "suede://copy-seo-audit",
       "suede://visibility-grade",

--- a/mcp/suede-skills-mcp.mjs
+++ b/mcp/suede-skills-mcp.mjs
@@ -5,9 +5,16 @@ import { fileURLToPath } from "node:url";
 
 const PROTOCOL_VERSION = "2025-06-18";
 const SUPPORTED_PROTOCOL_VERSIONS = new Set([PROTOCOL_VERSION, "2025-03-26", "2024-11-05"]);
-const VALID_PROFILES = new Set(["all", "workflow", "artist", "creator", "marketing", "consumer"]);
+const SPECIALTY_KEYS = ["ship", "craft", "found", "demand", "revenue", "position"];
+// Profiles come in two flavours now. The area profiles (workflow/creator/
+// marketing/consumer) mirror the plugin bundles and are what .mcp.json
+// registers. The specialty profiles mirror how the pack is browsed, so a client
+// that wants only the revenue surface can register one server against it
+// without the pack shipping six of them by default.
+const VALID_PROFILES = new Set(["all", "workflow", "artist", "creator", "marketing", "consumer", ...SPECIALTY_KEYS]);
+const PROFILE_SPECIALTIES = Object.fromEntries(SPECIALTY_KEYS.map((key) => [key, [key]]));
 const PROFILE_AREAS = {
-  workflow: ["workflow"],
+  workflow: ["workflow", "consumer"],
   artist: ["artist", "creator"],
   creator: ["artist", "creator"],
   marketing: ["marketing"],
@@ -28,7 +35,7 @@ const AREA_ENUM = ["all", "workflow", "artist", "creator", "marketing", "consume
 // `area` decides which plugin bundle and MCP profile ships a skill; `specialty`
 // decides how a human browses the pack. They are deliberately separate axes:
 // re-cutting the browse structure must never move a skill between bundles.
-const SPECIALTY_ENUM = ["all", "ship", "craft", "found", "earn", "position"];
+const SPECIALTY_ENUM = ["all", "ship", "craft", "found", "demand", "revenue", "position"];
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -81,14 +88,36 @@ function boundedString(value, fallback = "") {
 }
 
 function profileCatalog() {
+  const specialties = profileSpecialties(profile);
+  if (specialties) {
+    const wanted = new Set(specialties);
+    const skills = catalog.skills.filter((skill) => wanted.has(skill.specialty));
+    // A specialty cuts across bundles, so keep whichever plugins actually ship
+    // its skills rather than pinning one bundle per profile.
+    const shipping = new Set(
+      catalog.plugins.filter((plugin) => plugin.skills.some((name) => skills.some((s) => s.name === name)))
+        .map((plugin) => plugin.name)
+    );
+    return {
+      ...catalog,
+      specialties: catalog.specialties.filter((entry) => wanted.has(entry.key)),
+      plugins: catalog.plugins.filter((plugin) => shipping.has(plugin.name)),
+      skills
+    };
+  }
   const areas = PROFILE_AREAS[profile];
   if (!areas) return catalog;
   const pluginNames = new Set(PROFILE_PLUGINS[profile] || []);
   const areaSet = new Set(areas);
+  const skills = catalog.skills.filter((skill) => areaSet.has(skill.area));
+  const present = new Set(skills.map((skill) => skill.specialty));
   return {
     ...catalog,
+    // Only advertise specialities this profile can actually serve, so a client
+    // does not see a group it can never list.
+    specialties: (catalog.specialties || []).filter((entry) => present.has(entry.key)),
     plugins: catalog.plugins.filter((plugin) => pluginNames.has(plugin.name)),
-    skills: catalog.skills.filter((skill) => areaSet.has(skill.area))
+    skills
   };
 }
 
@@ -153,6 +182,13 @@ function scopeByArea(skills, area) {
   if (!area || area === "all") return skills;
   const wanted = new Set(AREA_ALIASES[area] || [area]);
   return skills.filter((skill) => wanted.has(skill.area));
+}
+
+// A specialty profile narrows the whole server, the same way an area profile
+// does — so `--profile revenue` and `list_suede_skills` with no arguments
+// return the revenue surface rather than all 73.
+function profileSpecialties(profile) {
+  return PROFILE_SPECIALTIES[profile] ?? null;
 }
 
 function scopeBySpecialty(skills, specialty) {
@@ -480,6 +516,12 @@ const tools = [
     }
   },
   {
+    name: "list_suede_specialties",
+    title: "List Suede Specialties",
+    description: "List the pack's specialities, their sub-lanes, and how many skills each holds. Call this first to pick a specialty, then pass it to list_suede_skills or search_suede_skills.",
+    inputSchema: { type: "object", properties: {} }
+  },
+  {
     name: "search_suede_skills",
     title: "Search Suede Skills",
     description: "Rank Suede skills against a task description and return the best-matching routes.",
@@ -609,8 +651,35 @@ const scoredSkillOutputSchema = {
   required: [...skillOutputSchema.required, "score"]
 };
 
+const specialtyOutputSchema = {
+  type: "object",
+  properties: {
+    key: { type: "string" },
+    label: { type: "string" },
+    summary: { type: "string" },
+    count: { type: "number" },
+    lanes: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { label: { type: "string" }, count: { type: "number" } },
+        required: ["label", "count"],
+        additionalProperties: false
+      }
+    }
+  },
+  required: ["key", "label", "summary", "count", "lanes"],
+  additionalProperties: false
+};
+
 const nullableString = { type: ["string", "null"] };
 const toolOutputSchemas = {
+  list_suede_specialties: {
+    type: "object",
+    properties: { specialties: { type: "array", items: specialtyOutputSchema } },
+    required: ["specialties"],
+    additionalProperties: false
+  },
   list_suede_skills: {
     type: "object",
     properties: { skills: { type: "array", items: skillOutputSchema } },
@@ -692,6 +761,13 @@ const resources = [
     name: "catalog",
     title: "Suede Skill And Install Catalog",
     description: "Structured Suede skill, install, MCP, and public link catalog.",
+    mimeType: "application/json"
+  },
+  {
+    uri: "suede://specialties",
+    name: "specialties",
+    title: "Suede Skill Specialties",
+    description: "The pack's specialities, their sub-lanes, and skill counts.",
     mimeType: "application/json"
   },
   {
@@ -826,6 +902,16 @@ function callTool(name, args = {}) {
   const tool = tools.find((item) => item.name === name);
   if (!tool) throw rpcError(`Unknown tool: ${name}`);
   validateToolArguments(tool, args);
+  if (name === "list_suede_specialties") {
+    const specialties = data.specialties || [];
+    const human = specialties
+      .map((spec) => {
+        const lanes = spec.lanes.map((lane) => `  - ${lane.label} (${lane.count})`).join("\n");
+        return `## ${spec.label} — ${spec.count} skills\n${spec.summary}\n${lanes}`;
+      })
+      .join("\n\n");
+    return toolResult(human || "No specialities available in this profile.", { specialties });
+  }
   if (name === "list_suede_skills") {
     const scoped = scopeBySpecialty(scopeByArea(data.skills, args.area), args.specialty);
     return toolResult(asMarkdownSkillList({ skills: scoped }), {
@@ -898,6 +984,9 @@ function callTool(name, args = {}) {
 
 function readResource(uri) {
   const data = profileCatalog();
+  if (uri === "suede://specialties") {
+    return { contents: [{ uri, mimeType: "application/json", text: JSON.stringify(profileCatalog().specialties || [], null, 2) }] };
+  }
   if (uri === "suede://catalog") {
     return { uri, mimeType: "application/json", text: JSON.stringify(data, null, 2) };
   }

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1067,7 +1067,11 @@ const countChecks = [
   // "six disciplines"-era lane math) while the guarded phrases said 71 —
   // every count a visitor can read must be pinned, not just the meta tags.
   { file: "docs/index.html", label: "hero subline skill count", re: /(\d+) open-source skills that read every diff/, expected: totalSkillCount },
-  { file: "docs/index.html", label: "lanes sub skill count", re: /Five specialities, (\d+) skills, one install/, expected: totalSkillCount },
+  // Keyed to the stable half of the sentence. Anchoring on the leading word
+  // ("Seven disciplines" -> "Five specialities" -> "Six specialities") made an
+  // ordinary copy edit break the guard three times; the count is what this
+  // check is actually about.
+  { file: "docs/index.html", label: "lanes sub skill count", re: /specialities, (\d+) skills, one install/, expected: totalSkillCount },
   { file: "docs/index.html", label: "catalog headline skill count", re: /All (\d+) skills\./, expected: totalSkillCount },
   { file: "docs/index.html", label: "stats band public skills count", re: /data-count="(\d+)"/, expected: totalSkillCount },
   { file: "docs/index.html", label: "router headline command count", re: /memorize (\d+) commands/, expected: totalSkillCount },
@@ -1404,6 +1408,27 @@ for (const check of countChecks) {
     }
   } else {
     fail.push("docs/skills/index.html is missing — the docs catalog page cannot be validated");
+  }
+}
+
+// Dangling in-page anchor guard. Re-cutting the catalog twice left a button
+// pointing at #lane-marketing and then at #spec-earn after both ids were gone:
+// the link renders fine and silently does nothing. Every same-page href="#..."
+// must resolve to an id on that page.
+{
+  const anchorPages = ["docs/index.html", "docs/skills/index.html", "docs/guide.html", "docs/plugins.html"];
+  for (const page of anchorPages) {
+    const pagePath = path.join(repoRoot, page);
+    if (!fs.existsSync(pagePath)) continue;
+    const pageText = readText(pagePath);
+    const ids = new Set([...pageText.matchAll(/\sid="([^"]+)"/g)].map((m) => m[1]));
+    const targets = new Set(
+      [...pageText.matchAll(/href="#([^"]+)"/g)].map((m) => m[1]).filter((target) => target && target !== "main")
+    );
+    const dangling = [...targets].filter((target) => !ids.has(target));
+    if (dangling.length) {
+      fail.push(`${page} has in-page link(s) pointing at ids that do not exist: ${dangling.join(", ")}`);
+    }
   }
 }
 

--- a/skills/suede-mcp-qa/references/stdio-test-blocks.md
+++ b/skills/suede-mcp-qa/references/stdio-test-blocks.md
@@ -31,7 +31,7 @@ printf '%s\n' \
 
 The initialization result must report protocol `2025-06-18`, server version
 `0.13.0`, and explicit tools/resources/prompts capabilities. `tools/list` must
-return exactly the 8 tools above. Each tool must expose `inputSchema`,
+return exactly the 9 tools above. Each tool must expose `inputSchema`,
 `outputSchema`, and annotations with `readOnlyHint: true`,
 `destructiveHint: false`, `idempotentHint: true`, and `openWorldHint: false`.
 The successful call must return `structuredContent`; `content[0]` must be useful

--- a/tests/test_mcp_protocol.mjs
+++ b/tests/test_mcp_protocol.mjs
@@ -416,9 +416,39 @@ test("skill bodies are served from the pack and cannot escape skills/", async ()
   }, "workflow");
 });
 
+test("specialty profiles narrow the server and the specialties tool describes them", async () => {
+  await withSession(async (session) => {
+    await session.initialize();
+    const skills = await session.request("tools/call", { name: "list_suede_skills", arguments: {} });
+    const names = skills.result.structuredContent.skills.map((skill) => skill.name);
+    assert.ok(names.length > 0 && names.length < CATALOG.skills.length);
+    assert.ok(skills.result.structuredContent.skills.every((skill) => skill.specialty === "revenue"));
+
+    const specialties = await session.request("tools/call", { name: "list_suede_specialties", arguments: {} });
+    const listed = specialties.result.structuredContent.specialties;
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].key, "revenue");
+    assert.equal(listed[0].count, names.length);
+  }, "revenue");
+
+  await withSession(async (session) => {
+    await session.initialize();
+    const specialties = await session.request("tools/call", { name: "list_suede_specialties", arguments: {} });
+    const listed = specialties.result.structuredContent.specialties;
+    assert.equal(listed.length, CATALOG.specialties.length);
+    assert.equal(
+      listed.reduce((sum, spec) => sum + spec.count, 0),
+      CATALOG.skills.length
+    );
+    for (const spec of listed) {
+      assert.equal(spec.lanes.reduce((sum, lane) => sum + lane.count, 0), spec.count);
+    }
+  }, "all");
+});
+
 test("catalog, resources, prompts, and profile filters match the live server", async () => {
-  assert.equal(CATALOG.mcp.tools.length, 8);
-  assert.equal(CATALOG.mcp.resources.length, 6);
+  assert.equal(CATALOG.mcp.tools.length, 9);
+  assert.equal(CATALOG.mcp.resources.length, 7);
   assert.equal(CATALOG.mcp.prompts.length, 5);
 
   await withSession(async (session) => {
@@ -462,8 +492,15 @@ test("catalog, resources, prompts, and profile filters match the live server", a
       name: "list_suede_skills",
       arguments: { area: "all" }
     });
-    assert.ok(response.result.structuredContent.skills.every((skill) => skill.area === "workflow"));
+    // The workflow profile deliberately carries `consumer` too. Those two skills
+    // shipped in the catalog and on the site behind no registered server, so no
+    // MCP client could reach them; folding them in here beat running a fourth
+    // server for two skills.
+    assert.ok(
+      response.result.structuredContent.skills.every((skill) => ["workflow", "consumer"].includes(skill.area))
+    );
     assert.ok(response.result.structuredContent.skills.some((skill) => skill.name === "suede-full-send"));
+    assert.ok(response.result.structuredContent.skills.some((skill) => skill.name === "amazon-returns-recovery"));
 
     const fullSend = await session.request("tools/call", {
       name: "get_suede_skill",


### PR DESCRIPTION
## Six, not five

0.13.0's five-way cut left `Convert & earn` at 23 while every other bucket sat between 9 and 15. It splits on a real seam — reaching people who have not heard of you, versus converting and keeping the ones who have.

| Specialty | n | Sub-lanes |
|---|---|---|
| Ship | 15 | Orchestration & routing, Code review & CI, Apps |
| Craft | 9 | Design & copy, Creative assets |
| Get found | 12 | Search & AI visibility, Content & audience |
| **Demand channels** | **8** | Paid & outbound, Lifecycle messaging, Acquisition assets |
| **Revenue & retention** | **15** | Money & funnel, Measure & operate, Consumer recovery |
| Strategy & rights | 14 | Strategy & research, Creator toolkit |

Largest bucket 23 → 15.

## The MCP is now a way through the pack, not a filter on it

It could previously only be pointed at the three bundle areas.

- **`list_suede_specialties`** — returns the six specialities with sub-lanes and counts, so a client picks a group before asking for skills instead of paging through 73.
- **`suede://specialties`** — the same structure as a resource.
- **`--profile <specialty>`** for all six. A client that wants only the revenue surface runs one server against it. No new servers ship by default; the three registered ones are unchanged.
- Each profile now advertises **only the specialities it can serve** — the marketing profile no longer offers `ship`.

## A hole this closed

`amazon-returns-recovery` and `subscription-recovery` were in the catalog and on the site behind **no registered server**. `consumer` was a valid `--profile` value that `.mcp.json` never registered, so no MCP client could reach either skill. Folded into the workflow profile — the bundle `PROFILE_PLUGINS` already pointed `consumer` at — rather than running a fourth server for two skills.

Verified before and after: all three registered profiles returned zero matches for `amazon-returns-recovery`; the workflow profile now returns it, at 27 skills.

## Guards added

- **Dangling in-page anchors.** Two re-cuts left buttons pointing at `#lane-marketing` and then `#spec-earn`. The link renders and silently does nothing. Negative-tested.
- **The lanes-sub count guard re-keyed** off its leading word — "Seven disciplines" → "Five specialities" → "Six specialities" broke it three times, and the count is what it was actually checking.

Docs, catalog tool/resource lists, the `suede-mcp-qa` readback, and the protocol tests move to 9 tools / 7 resources together. The plugins-page diagram had already drifted to "7 tools" against the prose's "8"; both now read 9.

## Verification

`validate` green, MCP protocol 16/16 (two new cases covering specialty profiles and the specialties tool).

Version bump and changelog follow in a second PR — the changelog guard added in #93 requires entries to cite a commit reachable from `main`, which does not exist until this squashes.