### PR TITLE
Reconcile the #proof-tape numbers with the page and the real artifacts

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1202,7 +1202,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span class="note-date">Aug 2026</span>
               <span class="note-copy">
                 <span class="note-title">Why breadth is free now, and what that changes</span>
-                <span class="note-hook">The economics of a 71-skill pack</span>
+                <span class="note-hook">The economics of a big pack</span>
               </span>
               <span class="note-arrow" aria-hidden="true">-&gt;</span>
             </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3596,23 +3596,21 @@
   <div class="tape-inner">
     <ul class="tape-track">
       <li><b>73</b> skills, MIT licensed</li>
-      <li><b>270</b> commits in 10 weeks</li>
+      <li><b>282</b> commits in 10 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
       <li><b>33</b> changelog entries, each a real commit</li>
-      <li><b>18</b>-chapter builder&rsquo;s book, free</li>
-      <li><b>29,102</b> words of documentation</li>
+      <li><b>14</b>-chapter builder&rsquo;s book, free</li>
     </ul>
     <ul class="tape-track" aria-hidden="true">
       <li><b>73</b> skills, MIT licensed</li>
-      <li><b>270</b> commits in 10 weeks</li>
+      <li><b>282</b> commits in 10 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
       <li><b>33</b> changelog entries, each a real commit</li>
-      <li><b>18</b>-chapter builder&rsquo;s book, free</li>
-      <li><b>29,102</b> words of documentation</li>
+      <li><b>14</b>-chapter builder&rsquo;s book, free</li>
     </ul>
   </div>
 </div>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -734,7 +734,7 @@ codex plugin add suede-skills@suede-codex</code></pre>
         <span class="note-date">Aug 2026</span>
         <span class="note-copy">
           <span class="note-title">Why breadth is free now, and what that changes</span>
-          <span class="note-hook">Why installing all 71 is not the cost you think it is</span>
+          <span class="note-hook">Why installing all of them is not the cost you think it is</span>
         </span>
         <span class="note-arrow" aria-hidden="true">-&gt;</span>
       </a>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -846,7 +846,7 @@
 
   <section class="shell" aria-labelledby="field-notes">
     <h2 id="field-notes">Field notes</h2>
-    <p class="section-sub">Why the pack is shaped this way: how 71 skills stay cheap to carry, how they route without colliding, and what the ship DAG is actually doing.</p>
+    <p class="section-sub">Why the pack is shaped this way: how 73 skills stay cheap to carry, how they route without colliding, and what the ship DAG is actually doing.</p>
     <div class="notes">
       <a class="note-row" href="../blog/progressive-disclosure-ship-dag-and-mcp.html">
         <span class="note-date">Aug 2026</span>
@@ -860,7 +860,7 @@
         <span class="note-date">Aug 2026</span>
         <span class="note-copy">
           <span class="note-title">Why breadth is free now, and what that changes</span>
-          <span class="note-hook">The economics of a 71-skill pack</span>
+          <span class="note-hook">The economics of a big pack</span>
         </span>
         <span class="note-arrow" aria-hidden="true">-&gt;</span>
       </a>

--- a/tests/test_proof_tape_claims.py
+++ b/tests/test_proof_tape_claims.py
@@ -1,0 +1,236 @@
+"""The #proof-tape strip makes a promise about itself, in an HTML comment right
+above it: "every number on this strip appears, sourced, further down the page."
+
+It then shipped three numbers that broke that promise, each invisible on the
+strip itself and only catchable by measuring the strip against the rest of the
+page and the real artifacts it describes:
+
+  1. "270 commits" while the ship log elsewhere on the same page said 282 (twice).
+  2. "18-chapter book" while the /book/ artifact enumerates 14 chapters
+     (book/01..14, and llms.txt says "14 chapters").
+  3. "29,102 words of documentation" -- a figure that appears nowhere else on the
+     page and counts nothing a reader can verify. An orphan.
+
+These assertions are on the CLAIM, not on the fixed strings a grep found:
+
+  * the strip's commit count equals the ship log's commit count in the same page;
+  * the strip's chapter count equals the real book artifact, cross-checked
+    against llms.txt -- add a 15th chapter file and the strip must move with it;
+  * EVERY number on the strip is sourced: restated elsewhere on the page, or
+    equal to a countable collection the page/artifact actually contains (the
+    changelog's entries, the book's chapters). A number backed by neither -- the
+    class the "29,102 words" figure belongs to -- fails as an orphan;
+  * the pack size is stated as the true skill count wherever a page describes the
+    CURRENT pack. The only "71"s left standing are the fixed essay headline
+    ("71 skills installed. Your agent reads almost none of them.") and one
+    past-tense changelog line ("41 of 71 skills were in the catalog"). A stale
+    "71 skills stay cheap to carry" / "71-skill pack" / "installing all 71" is
+    the same false claim in different wording, and is what this guards.
+
+Each test names, in a comment, the edit that makes it fail -- the non-vacuous
+proof was run by hand (revert the fix, watch it go red, restore, watch it pass).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+BOOK = ROOT / "book"
+SKILLS = ROOT / "skills"
+INDEX = DOCS / "index.html"
+
+# The pages that describe the CURRENT pack size in prose. Every one is served at
+# skills.suedeai.ai; each drifted to a stale "71" independently.
+PACK_PAGES = (
+    INDEX,
+    DOCS / "skills" / "index.html",
+    DOCS / "guide.html",
+    DOCS / "plugins.html",
+)
+
+# The only two contexts in which a literal "71" is honest: a fixed, dated essay
+# headline (a proper noun -- the title of a specific published post), and a
+# past-tense changelog entry describing the pack when it genuinely had 71.
+ESSAY_HEADLINE_71 = "71 skills installed. Your agent reads almost none of them."
+HISTORICAL_71 = re.compile(r"\d+ of 71 skills")
+
+# The shapes a stale CURRENT-pack "71" takes. Not the specific fixed strings --
+# the defect class: a number-71 used as a live count of skills.
+STALE_71 = re.compile(r"71[\s-]skills?\b|all 71\b")
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def true_skill_count() -> int:
+    """The real pack size: skills/*/SKILL.md on disk. Same definition the
+    validator and the book-facts module use."""
+    return sum(1 for d in SKILLS.iterdir() if d.is_dir() and (d / "SKILL.md").is_file())
+
+
+def true_chapter_count() -> int:
+    """The real book: numbered chapter files, excluding the 00 front matter and
+    the letter-prefixed appendices (A1, A2). Add book/15-*.md and this grows."""
+    return sum(
+        1
+        for f in BOOK.glob("*.md")
+        if re.match(r"^\d\d-", f.name) and not f.name.startswith("00-")
+    )
+
+
+def proof_tape_block(html: str) -> str:
+    """The #proof-tape div, both marquee tracks included."""
+    m = re.search(r'<div id="proof-tape".*?</ul>\s*</div>\s*</div>', html, re.S)
+    assert m, "the #proof-tape strip is gone from index.html"
+    return m.group(0)
+
+
+def tape_items(block: str):
+    """(raw, label) for each <li>, deduped -- the two tracks are identical."""
+    items = []
+    seen = set()
+    for li in re.findall(r"<li>(.*?)</li>", block, re.S):
+        m = re.search(r"<b>(.*?)</b>(.*)", li, re.S)
+        assert m, f"proof-tape item has no bolded number: {li!r}"
+        raw = m.group(1).strip()
+        label = re.sub(r"<[^>]*>", "", m.group(2)).strip()
+        key = (raw, label)
+        if key not in seen:
+            seen.add(key)
+            items.append(key)
+    return items
+
+
+class ProofTapeStructure(unittest.TestCase):
+    """Discovery guards. Without these, a strip that stopped parsing would let
+    every claim test below pass while measuring nothing."""
+
+    def setUp(self):
+        self.html = read(INDEX)
+        self.block = proof_tape_block(self.html)
+        self.items = tape_items(self.block)
+
+    def test_the_strip_has_its_full_set_of_claims(self):
+        # Seven distinct claims after the "29,102 words" orphan was removed.
+        self.assertGreaterEqual(
+            len(self.items), 7, f"proof-tape parsed too few items: {self.items}"
+        )
+
+    def test_the_strip_still_carries_a_commit_and_a_chapter_claim(self):
+        labels = " ".join(label for _, label in self.items).lower()
+        self.assertIn("commits", labels)
+        self.assertIn("chapter", labels)
+
+
+class ProofTapeNumbersAreSourced(unittest.TestCase):
+    def setUp(self):
+        self.html = read(INDEX)
+        self.block = proof_tape_block(self.html)
+        self.items = tape_items(self.block)
+        # The rest of the page: the strip removed, so a number cannot "source"
+        # itself from its own <li>.
+        self.rest = self.html.replace(self.block, "")
+        self.chapters = true_chapter_count()
+        self.changelog_entries = self.html.count('class="clog-item"')
+
+    def test_commit_count_reconciles_with_the_ship_log(self):
+        # Fails if the strip says 270 again: the ship log elsewhere says 282.
+        tape = re.search(r"<b>(\d+)</b>\s*commits in 10 weeks", self.block)
+        self.assertIsNotNone(tape, "no commit count on the proof-tape")
+        shiplog = re.findall(r"(\d+)\s*commits\s*&middot;\s*10 weeks", self.rest)
+        self.assertTrue(
+            shiplog, "no ship-log commit count found elsewhere on the page to source it"
+        )
+        for n in shiplog:
+            self.assertEqual(
+                int(n),
+                int(tape.group(1)),
+                "proof-tape commit count disagrees with the ship log on the same page",
+            )
+
+    def test_chapter_count_equals_the_real_book(self):
+        # Fails if the strip says 18 again: book/ enumerates 14 chapters.
+        tape = re.search(r"<b>(\d+)</b>-chapter", self.block)
+        self.assertIsNotNone(tape, "no chapter count on the proof-tape")
+        self.assertEqual(self.chapters, 14, "book artifact no longer has 14 chapters")
+        self.assertEqual(
+            int(tape.group(1)),
+            self.chapters,
+            "proof-tape chapter count disagrees with the real book (book/NN-*.md)",
+        )
+        # Cross-check the other artifact that states it, so the two cannot drift.
+        llms = read(DOCS / "llms.txt")
+        stated = re.search(r"(\d+)\s*chapters", llms)
+        self.assertIsNotNone(stated, "llms.txt no longer states a chapter count")
+        self.assertEqual(int(stated.group(1)), self.chapters)
+
+    def test_no_number_on_the_strip_is_an_orphan(self):
+        # The strip's own promise, enforced generically. Fails if the
+        # "29,102 words of documentation" line (or any figure sourced by nothing)
+        # is on the strip: 29,102 appears nowhere else and counts nothing.
+        for raw, label in self.items:
+            low = label.lower()
+            if "chapter" in low:
+                self.assertEqual(
+                    int(re.sub(r"\D", "", raw)),
+                    self.chapters,
+                    f"{raw!r} ({label!r}) does not match the book's chapter count",
+                )
+            elif "changelog" in low:
+                self.assertEqual(
+                    int(re.sub(r"\D", "", raw)),
+                    self.changelog_entries,
+                    f"{raw!r} ({label!r}) does not match the page's changelog entry count",
+                )
+            else:
+                self.assertIn(
+                    raw,
+                    self.rest,
+                    f"proof-tape number {raw!r} ({label!r}) is an orphan: it is "
+                    f"restated nowhere else on index.html and counts no collection "
+                    f"on the page -- exactly the promise the strip makes about itself",
+                )
+
+
+class PackSizeIsCurrent(unittest.TestCase):
+    def test_stale_71_pack_descriptions_are_gone(self):
+        # Fails if "how 71 skills stay cheap to carry" (skills/index.html),
+        # "the economics of a 71-skill pack" (skills, guide), or "installing all
+        # 71" (plugins) comes back. The essay headline and the historical
+        # changelog line are allowed to keep their 71.
+        for page in PACK_PAGES:
+            text = read(page)
+            stripped = text.replace(ESSAY_HEADLINE_71, "")
+            stripped = HISTORICAL_71.sub("", stripped)
+            leftover = STALE_71.findall(stripped)
+            self.assertEqual(
+                leftover,
+                [],
+                f"{page.relative_to(ROOT)}: stale current-pack '71' reference(s) "
+                f"{leftover} -- the pack is {true_skill_count()}",
+            )
+
+    def test_stay_cheap_lines_state_the_true_count(self):
+        # The two "N skills stay cheap to carry" lines pin the number, so guard
+        # them against restaling to anything but the real pack size. Fails if the
+        # skills page (or the homepage) says any count other than the truth.
+        count = true_skill_count()
+        found = 0
+        for page in (INDEX, DOCS / "skills" / "index.html"):
+            for n in re.findall(r"how (\d+) skills stay cheap to carry", read(page)):
+                found += 1
+                self.assertEqual(
+                    int(n),
+                    count,
+                    f"{page.relative_to(ROOT)}: 'stay cheap to carry' says {n}, "
+                    f"pack is {count}",
+                )
+        self.assertGreaterEqual(found, 2, "expected the phrase on both pages")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Defect

The `#proof-tape` strip — the first element inside `<main>` on the homepage — carries its own promise in a source comment:

> every number on this strip appears, sourced, further down the page

It then published three numbers that broke it:

| Strip said | Reality | Evidence |
|---|---|---|
| `270` commits in 10 weeks | `282` everywhere else on the page | `docs/index.html` hero shiplog (`282 commits &middot; 10 weeks`) + changelog sparkline caption; also `guide.html`, `skills/index.html` |
| `18`-chapter book | `14` chapters | `/book/` enumerates Chapter 1–14; `book/01..14-*.md`; `llms.txt` says "14 chapters" |
| `29,102` words of documentation | appears **nowhere else**, counts nothing verifiable | real book is ~29,302 words (`build-book-site --check`), ~29,000 per `llms.txt` |

## Fix

- **Commits `270 → 282`.** 282 is the ship-log snapshot the rest of the page already sources (hero shiplog + sparkline caption). The number is a curated ship-log figure, not a literal `git rev-list` (which is 290 at the cited release `1e2d70e`, 293 at tip); the strip now agrees with the page instead of contradicting it.
- **Chapters `18 → 14`.** The `18` was the book *site's* page count (`build-book-site` reports "18 pages"), mistaken for chapters. The book is 14 chapters.
- **Removed `29,102 words of documentation`.** Unsourced on-page and inaccurate (real ≈ 29,302). The strip's own promise forbids an orphan number.

### Stale pack-size "71" stragglers → 73

The 0.14.0 release moved the pack 71 → 73. The canonical homepage was updated ("how **73** skills stay cheap to carry") and its sibling hook de-pinned ("the economics of a **big** pack"), but secondary pages lagged with the same false present-tense claim in different wording:

- `skills/index.html`: "how 71 skills stay cheap to carry" → **73**
- `skills/index.html` + `guide.html`: "the economics of a 71-skill pack" → **"a big pack"** (matches canonical homepage)
- `plugins.html`: "installing all 71" → "installing all of them"

**Left untouched** (honest about a past state, not the current pack): the fixed essay headline *"71 skills installed. Your agent reads almost none of them."* (a dated post title) and the changelog line *"41 of 71 skills were in the catalog."*

## Guard test — asserts the CLAIM, not remembered strings

`tests/test_proof_tape_claims.py` (auto-discovered by `npm run test:python`), per file:

1. **Commit reconciliation** — strip's commit count == the ship log's on the same page.
2. **Chapter count == real artifact** — strip == `book/NN-*.md` count (excludes `00-front-matter`, appendices), cross-checked against `llms.txt`. Add a 15th chapter file and the strip must move with it.
3. **No orphan number** — every strip number is either restated elsewhere on `index.html` or equals a countable on-page/artifact collection (changelog entries `.clog-item` = 33, book chapters = 14). A number backed by neither fails.
4. **Pack size is current** — no page states a stale current-pack "71" (allowing only the fixed headline and the historical changelog line); and the "stay cheap to carry" lines equal the true `skills/*/SKILL.md` count.

**Non-vacuous (verified by hand — revert, watch red, restore, watch green):**

| Reintroduced defect | Test that goes red |
|---|---|
| `282 → 270` | `test_commit_count_reconciles_with_the_ship_log` + `test_no_number_on_the_strip_is_an_orphan` |
| `14 → 18` | `test_chapter_count_equals_the_real_book` + orphan |
| `29,102 words` line back | `test_no_number_on_the_strip_is_an_orphan` |
| `71 skills stay cheap` | `test_stale_71_pack_descriptions_are_gone` + `test_stay_cheap_lines_state_the_true_count` |
| `73 → 72` on skills page | `test_stay_cheap_lines_state_the_true_count` |

Restoring the fixes returns all 7 to green.

## Validation

- `npm run validate` → "Validated 73 skills against 73 catalog entries" (exit 0).
- All 40 Python tests pass (incl. the 7 new).
- Content-only edits to hand-authored HTML + one isolated test; `build-book-site` writes only `docs/book/`, so the proof-tape is not regenerated. Marketplace wiring (`.claude/settings.json`) untouched.

## Flag for the orchestrator (not fixed here — out of lane)

The `book-announce` worktree (branch `docs/book-announcement`, uncommitted) is adding a book callout to `docs/skills/index.html` that reads **"Fourteen chapters, 29,102 words, MIT."** — a different section (no line conflict with this PR's field-notes edits), but it re-propagates the same `29,102` figure removed here. Real count is ~29,302; that card should be corrected before it ships.