### PR TITLE
Make the sitemap dirty-file date fallback use local time like git

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -100,9 +100,21 @@ function isNoindex(absPath) {
   return !!match && /noindex/i.test(match[1]);
 }
 
+// Fallback date for files git can't date yet (dirty, untracked, or no repo).
+// This must be the LOCAL date, not toISOString()'s UTC date: `git log
+// --date=short` prints each commit's date in its recorded local offset, so
+// between 00:00 UTC and local midnight the two disagree by a day. A sitemap
+// regenerated pre-commit would stamp "tomorrow", the commit would record
+// "today", and CI's clean-tree --check would fail on the mismatch.
+function localToday() {
+  const now = new Date();
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
 function lastCommitDate(relPath) {
   if (!hasOwnGitHistory) {
-    return new Date().toISOString().slice(0, 10);
+    return localToday();
   }
   const status = spawnSync(
     "git",
@@ -110,7 +122,7 @@ function lastCommitDate(relPath) {
     { encoding: "utf8" }
   );
   if (status.status === 0 && status.stdout.trim()) {
-    return new Date().toISOString().slice(0, 10);
+    return localToday();
   }
   const result = spawnSync(
     "git",
@@ -121,7 +133,7 @@ function lastCommitDate(relPath) {
   if (date) return date;
   // Uncommitted or untracked (new page not yet committed): fall back to
   // today so the generated sitemap is still a well-formed date, not blank.
-  return new Date().toISOString().slice(0, 10);
+  return localToday();
 }
 
 function listSkillFiles() {


### PR DESCRIPTION
## What

`lastCommitDate()` in `scripts/generate-sitemap.mjs` stamped dirty/untracked files with `new Date().toISOString().slice(0, 10)` — the **UTC** date — while committed files get `git log -1 --format=%ad --date=short`, which prints the commit's recorded **local-offset** date (US-Eastern here).

Between 00:00 UTC and local midnight those disagree by a day: a sitemap regenerated pre-commit stamps "tomorrow", the commit then records "today", and CI's clean-tree `--check` fails with `docs/sitemap.xml is out of date` (lastmod newer than Git → flagged as a hand edit). This bit #101 on 2026-08-19.

## Fix

All three fallback sites now go through one `localToday()` helper that formats the date in the process's local timezone — the same date git will record at commit time — with a comment explaining why UTC is wrong here.

## Verification

- Reproduced pre-fix: dirty `docs/index.html` stamped `2026-08-19` (UTC) while git's date for a commit made then was `2026-08-18` (Eastern) — the exact #101 failure window.
- Post-fix with the same dirty file: machine TZ stamps `2026-08-18`; `TZ=Etc/GMT+12` stamps `2026-08-18`; `TZ=Pacific/Kiritimati` stamps `2026-08-19` — each matching `date +%F` in that zone.
- Regenerated sitemap on a clean tree is byte-identical; `--check` passes.
- `npm test`: 47 tests, OK.