### PR TITLE
Give the Cracked Devs door its own heat

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -143,3 +143,9 @@ footer { border-top: 1px solid var(--border); padding: 32px 0 48px; }
 .nav-disclosure > summary.nav-hamburger { display: none; }
 ::selection { background: #c8a96e; color: #080808; }
 [id] { scroll-margin-top: 84px; }
+
+/* Cracked Devs tab: the one hot door in the nav */
+.nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+.nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+@keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+@media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -60,7 +60,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
     </details>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -268,6 +268,12 @@
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
     <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -293,7 +299,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="../plugins.html" class="nav-cta">Install</a>
         </div>

--- a/docs/blog/memory-belongs-in-skills.html
+++ b/docs/blog/memory-belongs-in-skills.html
@@ -76,7 +76,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
     </details>

--- a/docs/blog/not-for-the-line-that-makes-a-pack-work.html
+++ b/docs/blog/not-for-the-line-that-makes-a-pack-work.html
@@ -75,7 +75,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
     </details>

--- a/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
+++ b/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
@@ -60,7 +60,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
     </details>

--- a/docs/blog/why-breadth-is-free.html
+++ b/docs/blog/why-breadth-is-free.html
@@ -75,7 +75,7 @@
           <a href="../book/">Book</a>
           <a href="./" aria-current="page">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
         </div>
     </details>

--- a/docs/book/anatomy-of-a-skill.html
+++ b/docs/book/anatomy-of-a-skill.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/design-and-copy-are-engineering.html
+++ b/docs/book/design-and-copy-are-engineering.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/evidence-or-it-did-not-ship.html
+++ b/docs/book/evidence-or-it-did-not-ship.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/front-matter.html
+++ b/docs/book/front-matter.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/full-send.html
+++ b/docs/book/full-send.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/getting-found.html
+++ b/docs/book/getting-found.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/grading-your-own-work.html
+++ b/docs/book/grading-your-own-work.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -192,7 +192,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/lanes-fleets-and-collisions.html
+++ b/docs/book/lanes-fleets-and-collisions.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/shipping-into-the-real-world.html
+++ b/docs/book/shipping-into-the-real-world.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/skill-index.html
+++ b/docs/book/skill-index.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/taste-judgment-and-stopping.html
+++ b/docs/book/taste-judgment-and-stopping.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/the-competence-gap.html
+++ b/docs/book/the-competence-gap.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/the-description-contract.html
+++ b/docs/book/the-description-contract.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/the-first-ninety-days.html
+++ b/docs/book/the-first-ninety-days.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/the-rules.html
+++ b/docs/book/the-rules.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/the-s-tier-ladder.html
+++ b/docs/book/the-s-tier-ladder.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/book/write-your-own.html
+++ b/docs/book/write-your-own.html
@@ -77,7 +77,7 @@
           <a href="./" aria-current="page">Book</a>
           <a href="../blog/">Blog</a>
           <a href="../copy.html">Copy Bank</a>
-          <a href="../cracked.html">Cracked Devs</a>
+          <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="../plugins.html" class="nav-cta">Install</a>
           </div>
         </details>

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -298,6 +298,12 @@
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
   <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -324,7 +330,7 @@
       <a href="./book/">Book</a>
       <a href="./blog/">Blog</a>
       <a href="./copy.html" aria-current="page">Copy Bank</a>
-      <a href="./cracked.html">Cracked Devs</a>
+      <a href="./cracked.html" class="nav-cracked">Cracked Devs</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="./plugins.html" class="nav-cta">Install</a>
     </div>

--- a/docs/cracked.html
+++ b/docs/cracked.html
@@ -429,6 +429,89 @@
     .formulation { border-left: 2px solid var(--red); padding-left: 18px; }
     .formulation + .formulation { margin-top: 18px; }
     .formulation h3 span { color: var(--red-text); font-family: var(--mono); font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; margin-left: 10px; }
+
+    /* ==== OVERDRIVE: the deved-out layer. Decoration only; every string in the
+       ticker restates a fact that already appears in the page body. ==== */
+    main { position: relative; }
+    main::before {
+      content: ""; position: absolute; top: 0; left: 0; right: 0; height: 760px;
+      z-index: 0; pointer-events: none;
+      background:
+        linear-gradient(rgba(200, 169, 110, 0.045) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(200, 169, 110, 0.045) 1px, transparent 1px);
+      background-size: 34px 34px;
+      -webkit-mask-image: radial-gradient(ellipse 90% 100% at 50% 0%, #000 30%, transparent 78%);
+      mask-image: radial-gradient(ellipse 90% 100% at 50% 0%, #000 30%, transparent 78%);
+    }
+    main::after {
+      content: ""; position: fixed; inset: 0; z-index: 40; pointer-events: none;
+      background: repeating-linear-gradient(0deg, rgba(255, 255, 255, 0.016) 0 1px, transparent 1px 3px);
+    }
+    .page-head { position: relative; z-index: 1; }
+    .page-head .eyebrow {
+      display: inline-flex; align-items: center; gap: 10px; font-family: var(--mono);
+      border: 1px solid rgba(198, 98, 90, 0.5); border-radius: 3px; padding: 6px 12px;
+      background: rgba(139, 26, 26, 0.12);
+    }
+    .page-head .eyebrow::before {
+      content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--red-text);
+      box-shadow: 0 0 10px var(--red-text); animation: cursor-blink 1.6s steps(1) infinite;
+    }
+    @keyframes crt-flicker { 0%, 93%, 100% { opacity: 1 } 94% { opacity: 0.84 } 95% { opacity: 1 } 97% { opacity: 0.91 } 98% { opacity: 1 } }
+    .page-head h1 { position: relative; animation: crt-flicker 7s steps(1) infinite; }
+    .glitch-ghost {
+      position: absolute; inset: 0; z-index: -1; color: var(--red-text);
+      opacity: 0; pointer-events: none; user-select: none;
+      animation: glitch-slice 7s steps(1) infinite;
+    }
+    @keyframes glitch-slice {
+      0%, 89%, 100% { opacity: 0; transform: none; clip-path: inset(0 0 100% 0); }
+      90% { opacity: 0.6; transform: translate(-4px, 2px); clip-path: inset(12% 0 58% 0); }
+      92% { opacity: 0.6; transform: translate(4px, -2px); clip-path: inset(64% 0 8% 0); }
+      94% { opacity: 0; }
+    }
+    .procmon {
+      overflow: hidden; border-bottom: 1px solid var(--hairline); background: #0a0a0a;
+      font-family: var(--mono); font-size: 12px; letter-spacing: 0.04em; color: var(--muted);
+    }
+    .procmon-track {
+      display: inline-flex; white-space: nowrap; padding: 9px 0;
+      animation: procmon-scroll 44s linear infinite; will-change: transform;
+    }
+    .procmon-track span { padding: 0 26px; border-right: 1px solid #1c1c1a; }
+    .procmon-track b { color: var(--red-text); font-weight: 600; }
+    .procmon-track i { color: var(--gold); font-style: normal; font-weight: 600; }
+    @keyframes procmon-scroll { from { transform: translateX(0) } to { transform: translateX(-50%) } }
+    .procmon:hover .procmon-track { animation-play-state: paused; }
+    .hazard {
+      height: 12px; margin-top: 64px; border-block: 1px solid #26261f; opacity: 0.55;
+      background: repeating-linear-gradient(-45deg, var(--gold) 0 16px, #0b0b0a 16px 32px);
+    }
+    .terminal-body pre::after {
+      content: "\258E"; margin-left: 6px; color: var(--gold);
+      animation: cursor-blink 1.1s steps(1) infinite;
+    }
+    @keyframes cursor-blink { 50% { opacity: 0 } }
+    .rx { border-top: 3px solid var(--red); }
+    .btn--red { box-shadow: 0 0 22px rgba(198, 98, 90, 0.22); }
+    .btn--red:hover { box-shadow: 0 0 30px rgba(198, 98, 90, 0.42); }
+    .nav-cracked {
+      font-family: var(--mono); color: var(--red-text);
+      border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px;
+      padding: 4px 9px; background: rgba(139, 26, 26, 0.1);
+      animation: cracked-breathe 2.8s ease-in-out infinite;
+    }
+    .nav-links a.nav-cracked[aria-current="page"] { color: var(--red-text); }
+    .nav-links a.nav-cracked:hover { color: #ffb3ab; border-color: var(--red-text); }
+    @keyframes cracked-breathe {
+      0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); }
+      50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .page-head h1, .glitch-ghost, .procmon-track, .terminal-body pre::after,
+      .page-head .eyebrow::before, .nav-cracked { animation: none !important; }
+      .glitch-ghost { opacity: 0 !important; }
+    }
   </style>
   <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -453,7 +536,7 @@
       <a href="./skills/">Skills</a>
       <a href="./guide.html">Guide</a>
       <a href="./copy.html">Copy Bank</a>
-      <a href="./cracked.html" aria-current="page">Cracked Devs</a>
+      <a href="./cracked.html" class="nav-cracked" aria-current="page">Cracked Devs</a>
       <a href="./book/">Book</a>
       <a href="./blog/">Blog</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
@@ -463,10 +546,29 @@
   </div>
 </nav>
 
+<div class="procmon" aria-hidden="true">
+  <div class="procmon-track">
+    <span><b>PID 01</b> suede-ship :: 35..150 agents :: research -&gt; lanes -&gt; refute -&gt; gate</span>
+    <span><b>PID 02</b> suede-agent-teams :: collision detection :: signed handoff</span>
+    <span><b>PID 03</b> suede-workflow-skills :: umbrella router :: every lane loads</span>
+    <span><b>PID 04</b> suede-recommend-next-action :: next move scored :: runnable prompt</span>
+    <span><i>IR</i> one continuous pass :: no check-ins</span>
+    <span><i>XR</i> the momentum loop :: never idles</span>
+    <span>adversarial review inside the run :: evidence at the close</span>
+    <span><b>PID 01</b> suede-ship :: 35..150 agents :: research -&gt; lanes -&gt; refute -&gt; gate</span>
+    <span><b>PID 02</b> suede-agent-teams :: collision detection :: signed handoff</span>
+    <span><b>PID 03</b> suede-workflow-skills :: umbrella router :: every lane loads</span>
+    <span><b>PID 04</b> suede-recommend-next-action :: next move scored :: runnable prompt</span>
+    <span><i>IR</i> one continuous pass :: no check-ins</span>
+    <span><i>XR</i> the momentum loop :: never idles</span>
+    <span>adversarial review inside the run :: evidence at the close</span>
+  </div>
+</div>
+
 <main id="main" tabindex="-1">
   <div class="shell page-head">
     <p class="eyebrow">Cracked devs only &middot; the unmarked door</p>
-    <h1>The Agentic Adderall Stack.</h1>
+    <h1>The Agentic Adderall Stack.<span class="glitch-ghost" aria-hidden="true">The Agentic Adderall Stack.</span></h1>
     <p class="lead">Four skills for supercharging your agent until it ships like it's late for something. Maximum useful effort, parallel lanes, adversarial review of its own work, and the next move scored before you finish asking. This is the corner of the pack we reach for when the deadline is real.</p>
 
     <div class="rx" role="img" aria-label="Prescription-style label for the Agentic Adderall Stack">
@@ -488,6 +590,8 @@
       <a class="btn btn--gold" href="./plugins.html">Install the pack</a>
     </div>
   </div>
+
+  <div class="hazard" aria-hidden="true"></div>
 
   <section class="shell" aria-labelledby="instant-release">
     <h2 id="instant-release">Instant release. No downtime, no intervals.</h2>
@@ -531,6 +635,8 @@ Evidence at the end.</pre>
     </div>
   </section>
 
+  <div class="hazard" aria-hidden="true"></div>
+
   <section class="shell" aria-labelledby="the-build">
     <h2 id="the-build">The Agentic Adderall build<span class="stack-count">4</span></h2>
     <p class="section-sub">The whole formulary. Each one is a plain-Markdown folder you can read on GitHub before you enable it; together they turn one polite assistant into a shipping organism.</p>
@@ -563,6 +669,8 @@ Evidence at the end.</pre>
       Obviously not medical advice, not an actual stimulant, and no pharmacy is involved &mdash; it's four Markdown folders. The only thing this stack doses is your token bill, and the skills say so on their own labels. Every folder is inspectable on <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener">GitHub</a> before you enable it; core local workflows do not upload by default or grant new authority.
     </div>
   </section>
+
+  <div class="hazard" aria-hidden="true"></div>
 
   <section class="ship-strip" aria-labelledby="ship-strip-h" style="margin-top:96px;">
     <div class="shell">

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -774,6 +774,12 @@
     }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
     <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -799,7 +805,7 @@
           <a href="./book/">Book</a>
           <a href="./blog/">Blog</a>
           <a href="./copy.html">Copy Bank</a>
-      <a href="./cracked.html">Cracked Devs</a>
+      <a href="./cracked.html" class="nav-cracked">Cracked Devs</a>
           <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="./plugins.html" class="nav-cta">Install</a>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3527,6 +3527,12 @@
       .tape-track li { padding: 8px 12px; }
       .tape-track li::after { content: none; }
     }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
 </head>
 <body>
@@ -3563,7 +3569,7 @@
       <a href="guide.html" class="nav-link">Guide</a>
       <a href="book/" class="nav-link">Book</a>
       <a href="blog/" class="nav-link">Blog</a>
-        <a href="cracked.html" class="nav-link">Cracked Devs</a>
+        <a href="cracked.html" class="nav-link nav-cracked">Cracked Devs</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="plugins.html" class="nav-cta">Install</a>
       <details class="nav-disclosure" id="nav-disclosure" open>
@@ -3579,7 +3585,7 @@
         <a href="guide.html" class="nav-mobile-link" role="menuitem">Guide</a>
         <a href="book/" class="nav-mobile-link" role="menuitem">Book</a>
         <a href="blog/" class="nav-mobile-link" role="menuitem">Blog</a>
-        <a href="cracked.html" class="nav-mobile-link" role="menuitem">Cracked Devs</a>
+        <a href="cracked.html" class="nav-mobile-link nav-cracked" role="menuitem">Cracked Devs</a>
         <a href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" class="nav-mobile-link" role="menuitem">Star on GitHub</a>
         <a href="plugins.html" class="nav-mobile-link nav-mobile-cta" role="menuitem">Install</a>
         </div>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -402,6 +402,12 @@
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
     [id] { scroll-margin-top: 84px; }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
   <link rel="preload" href="assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -426,7 +432,7 @@
       <a href="./skills/">Skills</a>
       <a href="./guide.html">Guide</a>
       <a href="./copy.html">Copy Bank</a>
-      <a href="./cracked.html">Cracked Devs</a>
+      <a href="./cracked.html" class="nav-cracked">Cracked Devs</a>
       <a href="./book/">Book</a>
       <a href="./blog/">Blog</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -458,37 +458,37 @@
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/memory-belongs-in-skills.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/not-for-the-line-that-makes-a-pack-work.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/why-breadth-is-free.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -513,6 +513,12 @@
     }
     ::selection { background: #c8a96e; color: #080808; }
     html { scrollbar-color: #2e2c28 #0a0a0a; }
+
+    /* Cracked Devs tab: the one hot door in the nav */
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
+    @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
+    @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
   </style>
   <link rel="preload" href="../assets/fonts/fraunces-var.woff2" as="font" type="font/woff2" crossorigin>
 </head>
@@ -540,7 +546,7 @@
       <a href="../book/">Book</a>
       <a href="../blog/">Blog</a>
       <a href="../copy.html">Copy Bank</a>
-      <a href="../cracked.html">Cracked Devs</a>
+      <a href="../cracked.html" class="nav-cracked">Cracked Devs</a>
       <a class="nav-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub"><svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" class="nav-star-icon"><path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"/></svg><span class="nav-star-label">Star</span><span class="nav-star-count" data-star-count hidden></span></a>
       <a href="../plugins.html" class="nav-cta">Install</a>
     </div>

--- a/scripts/build-book-site.mjs
+++ b/scripts/build-book-site.mjs
@@ -87,7 +87,7 @@ ${JSON.stringify(jsonLd, null, 2)}
           <a href="./" aria-current="page">Book</a>
           <a href="${up}blog/">Blog</a>
           <a href="${up}copy.html">Copy Bank</a>
-          <a href="${up}cracked.html">Cracked Devs</a>
+          <a href="${up}cracked.html" class="nav-cracked">Cracked Devs</a>
           <a href="${up}plugins.html" class="nav-cta">Install</a>
           </div>
         </details>


### PR DESCRIPTION
Makes the Cracked Devs tab the one intense element in every nav (red mono chip, breathing glow — homepage, skills, guide, plugins, copy bank, blog, and all generated book pages via the shared sheet), and gives cracked.html the deved-out layer: PID ticker of real stack facts, phosphor grid + CRT scanlines, glitch-slice headline ghost, live warning chip, hazard-tape section dividers, blinking terminal cursors, red-glow IR button.

- All motion is transform/opacity with `prefers-reduced-motion` off switches.
- Ticker content restates facts already in the page body — nothing invented.
- Validator-pinned stack markup (rows, badge, JSON-LD) untouched by the styling layer.
- Render-verified at 1280 and 390 (hero, full page, mobile).

Validation: `npm test` green end to end.