### PR TITLE
Rebuild the homepage hero around the company claim

### DIFF
--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -145,7 +145,7 @@ footer { border-top: 1px solid var(--border); padding: 32px 0 48px; }
 [id] { scroll-margin-top: 84px; }
 
 /* Cracked Devs tab: the one hot door in the nav */
-.nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+.nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
 .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
 @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
 @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -270,7 +270,7 @@
     [id] { scroll-margin-top: 84px; }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -300,7 +300,7 @@
     [id] { scroll-margin-top: 84px; }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/cracked.html
+++ b/docs/cracked.html
@@ -499,6 +499,7 @@
       font-family: var(--mono); color: var(--red-text);
       border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px;
       padding: 4px 9px; background: rgba(139, 26, 26, 0.1);
+      white-space: nowrap;
       animation: cracked-breathe 2.8s ease-in-out infinite;
     }
     .nav-links a.nav-cracked[aria-current="page"] { color: var(--red-text); }

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -776,7 +776,7 @@
     html { scrollbar-color: #2e2c28 #0a0a0a; }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/index.html
+++ b/docs/index.html
@@ -3529,7 +3529,7 @@
     }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }
@@ -3635,9 +3635,9 @@
       <div id="hero-copy">
         <span id="hero-eyebrow" class="hero-anim">Open source &middot; MIT<a href="#changelog" class="eyebrow-ship">&middot; Released Aug 16</a></span>
 
-        <h1 id="hero-headline" class="hero-anim">Your coding agent is fast, capable, and <em class="hh-risk">completely unsupervised</em>.</h1>
+        <h1 id="hero-headline" class="hero-anim">Your coding agent is one install away from <em class="hh-risk">being a company</em>.</h1>
 
-        <p id="hero-subline" class="hero-anim">This pack is the supervision. Open-source skills that read every diff like a senior engineer with a reputation to protect, then finish the parts nobody prompts for: design, copy, SEO, Instagram growth, and <strong>native iOS and Android shipping</strong>. One recovery skill argued Amazon out of <strong>$448.31</strong> in one sitting. Your agent just got taste.</p>
+        <p id="hero-subline" class="hero-anim">Suede is the operating doctrine for agents that ship. A build DAG that researches your repo, fans out disjoint lanes, and refutes its own review before anything lands. A blunt <strong>A-F ship grade</strong> that blocks the bad merge instead of complimenting it. Then the lanes nobody prompts for: design, copy, SEO, growth, and <strong>native iOS and Android shipping</strong>. One skill argued Amazon out of <strong>$448.31</strong>. It is the pettiest thing in the pack.</p>
 
         <div id="hero-ctas" class="hero-anim">
           <a id="hero-cta-star" href="https://github.com/JasonColapietro/suede-creator-skills" target="_blank" rel="noopener" aria-label="Star JasonColapietro/suede-creator-skills on GitHub">

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -404,7 +404,7 @@
     [id] { scroll-margin-top: 84px; }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -515,7 +515,7 @@
     html { scrollbar-color: #2e2c28 #0a0a0a; }
 
     /* Cracked Devs tab: the one hot door in the nav */
-    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); animation: cracked-breathe 2.8s ease-in-out infinite; }
+    .nav-cracked { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: #c6625a; border: 1px solid rgba(198, 98, 90, 0.45); border-radius: 3px; padding: 4px 9px; background: rgba(139, 26, 26, 0.1); white-space: nowrap; animation: cracked-breathe 2.8s ease-in-out infinite; }
     .nav-cracked:hover { color: #ffb3ab; border-color: #c6625a; }
     @keyframes cracked-breathe { 0%, 100% { box-shadow: 0 0 0 rgba(198, 98, 90, 0); } 50% { box-shadow: 0 0 14px rgba(198, 98, 90, 0.35); } }
     @media (prefers-reduced-motion: reduce) { .nav-cracked { animation: none; } }


### PR DESCRIPTION
First-screen copy rebuild: the headline moves from problem description to the mechanism claim ("one install away from being a company"), the subline leads with the ship DAG and the A-F merge gate, and the $448.31 Amazon recovery closes as deliberate understatement. Adds `white-space: nowrap` to the Cracked nav chip so it holds one line in every nav.

All claims restate facts already on the page (proof tape sourcing test passes). `npm test` green end to end.