### PR TITLE
Correct the MCP surface counts to 9 tools and 7 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For a user-level install, copy into `~/.claude/skills/` instead. Claude.ai and o
 node mcp/suede-skills-mcp.mjs --profile all
 ```
 
-Exposes 7 tools (`list_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist`), 6 resources, and 5 prompts over JSON-RPC.
+Exposes 9 tools (`list_suede_skills`, `list_suede_specialties`, `search_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist`), 7 resources, and 5 prompts over JSON-RPC.
 
 </details>
 
@@ -229,9 +229,9 @@ The repo ships a dependency-free stdio MCP server at [`mcp/`](mcp/). It implemen
 node mcp/suede-skills-mcp.mjs --profile all
 ```
 
-| Tools (7) | Resources (6) | Prompts (5) |
+| Tools (9) | Resources (7) | Prompts (5) |
 |---|---|---|
-| `list_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist` | catalog, plugins, copy-seo-audit, visibility-grade, code-grade, qa-checklist | discovery and audit prompts |
+| `list_suede_skills`, `list_suede_specialties`, `search_suede_skills`, `get_suede_skill`, `suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`, `suede_qa_checklist` | catalog, specialties, plugins, copy-seo-audit, visibility-grade, code-grade, qa-checklist | discovery and audit prompts |
 
 ## Safety
 

--- a/book/STYLE.md
+++ b/book/STYLE.md
@@ -44,7 +44,7 @@ future is exciting.
 - Install: `/plugin marketplace add JasonColapietro/suede-creator-skills` then
   `/plugin install suede-skills@suede`. Also `install.sh`, `npx skills add`,
   and a Codex-native plugin.
-- The MCP server at `mcp/` exposes 8 tools, 6 resources, 5 prompts.
+- The MCP server at `mcp/` exposes 9 tools, 7 resources, 5 prompts.
 - Author: Jason Colapietro, founder of Suede Labs AI. Solo founder. The pack came
   out of watching hired marketing firms skip fundamentals on his own products.
 - House line of `suede-full-send`: "Never end your allocation above zero." It is

--- a/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
+++ b/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
@@ -98,7 +98,7 @@
       <p><code>suede-clip-to-guide</code> turns a video moment into a long-form asset, with rights routing, moment scoring, a clip brief, exact post copy, and a publishing sequence that requires visible-identity approval before anything goes out.</p>
 
       <h2>Seven read-only MCP tools, optional</h2>
-      <p>The pack ships an optional MCP server. It's read-only by design and it exists for the moments when structure beats prose: <code>list_suede_skills</code> and <code>get_suede_skill</code> for discovery, <code>suede_install_options</code> for install paths, then <code>suede_code_grade</code>, <code>suede_visibility_grade</code>, <code>suede_copy_seo_audit</code>, and <code>suede_qa_checklist</code> for scaffolded audits.</p>
+      <p>The pack ships an optional MCP server. It's read-only by design and it exists for the moments when structure beats prose: <code>list_suede_skills</code>, <code>list_suede_specialties</code>, <code>search_suede_skills</code>, and <code>get_suede_skill</code> for discovery, <code>suede_install_options</code> for install paths, then <code>suede_code_grade</code>, <code>suede_visibility_grade</code>, <code>suede_copy_seo_audit</code>, and <code>suede_qa_checklist</code> for scaffolded audits.</p>
       <p>You don't need it. The skills work on their own, with no accounts, API keys, or configuration. Add the MCP when you want a catalog, a checklist, or an audit scaffold returned as data instead of paragraphs.</p>
 
       <h2>Design, code, and a refund Amazon already denied</h2>

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -91,7 +91,7 @@
         </div>
         <div class="skill-term-body">
           <span class="t-line"><span class="t-warn">$ </span><span class="t-cmd">/suede-mcp-qa run the gauntlet</span></span>
-          <span class="t-line">7 tools probed &middot; schemas validated</span>
+          <span class="t-line">9 tools probed &middot; schemas validated</span>
           <span class="t-line">error paths: malformed input handled</span>
           <span class="t-line"><span class="term-grade">MCP QA: PASSED &middot; SMOKE TESTS GREEN</span><span class="term-cursor" aria-hidden="true"></span></span>
         </div>

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -37,9 +37,10 @@ The server is dependency-free and speaks newline-delimited JSON-RPC over stdio.
 It supports `initialize`, `ping`, `tools/list`, `tools/call`,
 `resources/list`, `resources/read`, `prompts/list`, and `prompts/get`.
 
-Current surface: 7 tools (`list_suede_skills`, `get_suede_skill`,
-`suede_install_options`, `suede_copy_seo_audit`, `suede_visibility_grade`,
-`suede_code_grade`, `suede_qa_checklist`), 6 resources (`suede://catalog`,
+Current surface: 9 tools (`list_suede_skills`, `list_suede_specialties`,
+`search_suede_skills`, `get_suede_skill`, `suede_install_options`,
+`suede_copy_seo_audit`, `suede_visibility_grade`, `suede_code_grade`,
+`suede_qa_checklist`), 7 resources (`suede://catalog`, `suede://specialties`,
 `suede://plugins`, `suede://copy-seo-audit`, `suede://visibility-grade`,
 `suede://code-grade`, `suede://qa-checklist`), and 5 prompts
 (`suede-copy-seo-audit`, `suede-plugin-install`, `suede-visibility-grade`,


### PR DESCRIPTION
The public copy still described the MCP server's pre-specialty surface. Ground truth in `mcp/suede-skills-mcp.mjs` and `mcp/catalog.json` is **9 tools, 7 resources, 5 prompts**.

## What changed

- **README.md** — the "More install routes" MCP subsection and the MCP server table both said 7 tools / 6 resources. Both now list all nine tool names (adding `list_suede_specialties` and `search_suede_skills`) and the `specialties` resource.
- **mcp/README.md** — same 7/6 surface description updated to the full 9-tool / 7-resource lists, including `suede://specialties`.
- **book/STYLE.md** — the verified-facts list said 8 tools, 6 resources; now 9 and 7.
- **docs/skills/suede-mcp-qa.html** — sample-session line "7 tools probed" is now "9 tools probed".
- **docs/blog/progressive-disclosure-ship-dag-and-mcp.html** — the discovery enumeration now names the two newer discovery tools.

A repo-wide sweep for stale 6/7/8 tool-and-resource counts comes back empty after these edits (`docs/plugins.html` was already correct with "The 9 tools").

## Verification

- `npm run validate` (strict validator + trigger routing + book checks): **passes** with the new copy.
- `test:mcp` 16/16, `test:triggers` 71/71, `test:ship-cost` 9/9, `test:contributions` 28/28, `test:python` 47/47 — all pass locally.
- `test:validator-runtime` fails 13/14 locally with `Cannot find module 'js-yaml'` inside the temp checkouts it creates — confirmed identical on the clean tree (stash → run → pop), so it pre-exists this change and is a local environment issue, not a copy pin.