### PR TITLE
seo-audit: check heading self-sufficiency and table markup in Lane 4

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1189,7 +1189,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span style="height:67%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base d8a6ae8</b></span>
+              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 5e1e20f</b></span>
               <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
               <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
             </span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3662,7 +3662,7 @@
             <span style="height:67%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base d8a6ae8</b></span>
+            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 5e1e20f</b></span>
             <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
             <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
           </span>
@@ -3839,7 +3839,7 @@
           <p class="clog-meta">
             <span class="clog-date">2026-08-21</span>
             <span class="clog-tag">Orchestration</span>
-            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/d8a6ae8" target="_blank" rel="noopener" aria-label="View base commit d8a6ae8 on GitHub">base d8a6ae8</a>
+            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/5e1e20f" target="_blank" rel="noopener" aria-label="View base commit 5e1e20f on GitHub">base 5e1e20f</a>
           </p>
           <h3 class="clog-title">Graph search replaces the fixed shipping DAG</h3>
           <p class="clog-detail">Version 0.15.0 replaces <code>suede-ship</code>'s fixed single-plan DAG with a bounded Graph-of-Thoughts search. It generates competing plans, scores and prunes them, adversarially refutes and improves survivors, aggregates compatible lanes, then builds, reviews, and gates only the selected plan. Light, standard, and deep stop at 55, 110, and 200 total agent calls. Production access remains read-only; the skill never deploys.</p>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -574,7 +574,7 @@
         <span style="height:67%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base d8a6ae8</b></span>
+        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 5e1e20f</b></span>
         <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
         <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
       </span>

--- a/skills/suede-seo-audit/references/lane-checklists.md
+++ b/skills/suede-seo-audit/references/lane-checklists.md
@@ -163,6 +163,55 @@ Blocks over limit: [count] of [total headings]
 Accordion/FAQ items marked up as headings: [yes/no — N items]
 ```
 
+**Heading self-sufficiency**
+- [ ] Every H2-H6 names its own subject. Discovery Engine carries the ancestor
+      headings alongside a chunk OPTIONALLY, so a chunk can arrive holding only
+      its own immediate heading. This is NOT the hierarchy check above: a page
+      can nest H1 > H2 > H3 perfectly and still have an H3 that identifies
+      nothing once detached.
+- [ ] No heading is a bare stock phrase — How it works, Pricing, Features,
+      Overview, Benefits, FAQ, Get started, Why us, Our process. An H3 reading
+      "Pricing" is meaningless away from the H2 that named the subject;
+      "How Suede Scan pricing works" survives alone.
+- [ ] Single-word headings get the hardest look, since they carry a subject only
+      by accident. A heading already holding a proper noun, an acronym, or the
+      page's primary subject passes — do not rewrite it.
+- [ ] Record each finding with its parent heading, so the fix (folding the
+      parent's subject into the child) is visible without opening the page.
+- [ ] Warn, never fail, and never drop a grade on this alone. It is a heuristic
+      about language. Where bare headings run through the whole page, report one
+      finding about the page rather than one per heading.
+
+Heading self-sufficiency output format:
+```
+Detached heading "[heading]" (H[n], under "[parent]") | [stock phrase/single word] | fix: "[rewritten heading]"
+Sub-headings not naming their own subject: [count] of [total]
+```
+
+**Table markup**
+- [ ] Comparison content uses `<table>`, not CSS grid or flex `<div>`s.
+      Discovery Engine parses tables as structured content; a grid-built table
+      reads as an undifferentiated run of text, so the row and column
+      relationships that make a comparison quotable are lost.
+- [ ] Structure carries the finding, never a class name: repeated sibling
+      elements with a consistent child count, holding short cell-sized text.
+      Confirm the content is genuinely tabular by eye before reporting it.
+- [ ] Class names are the weakest signal and prove nothing alone. `flex-row`,
+      `grid-rows-*`, `flex-col` and `grow-0` are layout utilities — measured
+      against live homepages on 2026-08-22, a substring match on grid|row|col
+      fired on four of five.
+- [ ] Report as an informational observation, never as a scored failure. CSS
+      grid is used for every kind of layout, and a false finding in a paid audit
+      costs more than a missing one.
+- [ ] A page that already ships a real `<table>` gets the benefit of the doubt:
+      the author knows the element, so a grid there is more likely deliberate.
+
+Table markup output format:
+```
+Unmarked table: [rows] rows x [columns] columns of <[tag] class="[class]"> | tabular by eye: [yes/no]
+Page uses <table> anywhere: [yes/no]
+```
+
 **Section coverage and order**
 - [ ] Opening: what the page is and who it serves
 - [ ] Evidence appears near the claims it supports


### PR DESCRIPTION
Adds the two retrieval-layer checklist items that Lane 4's **Retrieval chunking** block (#108) deliberately left out. Companion to the `suede-geo` endpoint change that implements the same two checks.

## Why these are not the heading-hierarchy check

Lane 4 already verifies that a heading hierarchy *exists*. That is a different question from whether each heading *identifies its own subject*. A page can nest H1 > H2 > H3 perfectly and still have an H3 that means nothing once detached — and Discovery Engine carries the ancestor headings alongside a chunk only **optionally**, so a chunk can arrive holding just its own immediate heading.

`Pricing` identifies nothing on its own. `How Suede Scan pricing works` survives alone.

## Both items warn; the table item is explicitly informational

CSS grid is used for every kind of layout, so the table item says outright that it is an observation and never a scored failure. A false finding in a paid audit costs more than a missing one.

The instruction not to trust class names is measured rather than theoretical. In the companion `suede-geo` change, the obvious first cut — a substring match on `grid|row|col` — fired on **four of five** live homepages: Tailwind's `flex-col` and `grid-cols-3` supply `col`, and `grow-0` supplies `row` inside the word `grow`. A second round found `flex-row` and `grid-rows-[repeat(3,...)]` on ycombinator.com. The checklist now tells the auditor that structure carries the finding and a class name never does.

## Copies stay byte-identical

`~/.claude/skills/suede-seo-audit/references/lane-checklists.md` and this file are identical (`md5 f791fcc7d0290090b0eae971018dde55`).

One note on that: the two copies looked divergent at the start of this work — the local `~/code` mirror appeared to be missing the whole Retrieval chunking block. It was not drift. This machine's mirror was stale, and a background `pull --ff-only` brought #108 in mid-session. The stale-mirror warning in CLAUDE.md is doing real work.