### PR TITLE
Bound the prepared ship-log stamp instead of pinning it to a moving tip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ venv/
 release-lint-output/
 suede-transfer-package/
 *.tmp
-node_modules/
+node_modules
 
 # Internal working documents — never publish
 audits/

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1189,7 +1189,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span style="height:67%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1a905bb</b></span>
+              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
               <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
               <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
             </span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3662,7 +3662,7 @@
             <span style="height:67%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1a905bb</b></span>
+            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
             <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
             <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
           </span>
@@ -3839,7 +3839,7 @@
           <p class="clog-meta">
             <span class="clog-date">2026-08-21</span>
             <span class="clog-tag">Orchestration</span>
-            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1a905bb" target="_blank" rel="noopener" aria-label="View base commit 1a905bb on GitHub">base 1a905bb</a>
+            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1626d1c" target="_blank" rel="noopener" aria-label="View base commit 1626d1c on GitHub">base 1626d1c</a>
           </p>
           <h3 class="clog-title">Graph search replaces the fixed shipping DAG</h3>
           <p class="clog-detail">Version 0.15.0 replaces <code>suede-graph-flo-xr</code>'s fixed single-plan DAG with a bounded Graph-of-Thoughts search. It generates competing plans, scores and prunes them, adversarially refutes and improves survivors, aggregates compatible lanes, then builds, reviews, and gates only the selected plan. Light, standard, and deep stop at 55, 110, and 200 total agent calls. Production access remains read-only; the skill never deploys.</p>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -574,7 +574,7 @@
         <span style="height:67%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1a905bb</b></span>
+        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
         <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
         <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
       </span>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "validate": "node scripts/validate-skill-pack.mjs --strict && node scripts/validate-trigger-routing.mjs && node scripts/build-book-site.mjs --check && node scripts/build-book.mjs --check",
     "build:book": "node scripts/build-book.mjs && node scripts/build-book-pdf.mjs && node scripts/build-book-site.mjs",
+    "build:shiplog": "node scripts/build-shiplog.mjs",
     "test:mcp": "node --test tests/test_mcp_protocol.mjs",
     "test:contributions": "node --test tests/test_contribution_ledger.mjs",
     "test:validator-runtime": "node --test tests/test_validator_runtime.mjs",

--- a/scripts/build-shiplog.mjs
+++ b/scripts/build-shiplog.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Writes the ship-log stamp into the four places that carry it: the newest
+// #changelog entry on docs/index.html, and the tiny #hero-shiplog card on the
+// homepage, the skills catalog, and the guide.
+//
+// It exists because those four were hand-copied. The prepared entry's base
+// commit went stale the moment anything merged, and the fix was three or four
+// identical edits in three files — so in practice it was refreshed late, or in
+// one file and not the others, and the validator caught the drift after the
+// fact instead of the build preventing it.
+//
+// Two sources feed the stamp, and they are NOT the same source. The base commit
+// comes from git (`merge-base HEAD origin/main`). Everything else — status,
+// date, title — comes from the hand-authored newest entry in docs/index.html
+// and is only propagated outward. In particular the date is the changelog
+// ENTRY date, not the base commit's date: the entry is prose about a release,
+// written on the day it was written, and the validator checks it against the
+// entry. Deriving it from the commit instead looks equivalent and fails.
+//
+// Usage:
+//   node scripts/build-shiplog.mjs            rewrite the stamp in place
+//   node scripts/build-shiplog.mjs --check    report drift, exit 1 if stale
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const checkOnly = process.argv.includes("--check");
+const MONTHS_SHORT = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const MONTHS_LONG = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+];
+
+function die(message) {
+  console.error(`build-shiplog: ${message}`);
+  process.exit(1);
+}
+
+function git(...args) {
+  const result = spawnSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  if (result.error) die(`could not run git (${result.error.code || result.error.message})`);
+  if (result.status !== 0) die(`git ${args.join(" ")} failed: ${result.stderr.trim()}`);
+  return result.stdout.trim();
+}
+
+// Read the newest #changelog entry. This is the hand-authored source of truth
+// for status, date and title; the generator never invents any of them.
+const indexPath = path.join(repoRoot, "docs", "index.html");
+const indexText = fs.readFileSync(indexPath, "utf8");
+const newestItem = indexText.match(/<li class="clog-item"([^>]*)>([\s\S]*?)<\/li>/);
+if (!newestItem) die("docs/index.html has no .clog-item entries — the #changelog markup changed");
+
+const status = newestItem[1].match(/\bdata-status="([^"]+)"/)?.[1] ?? "released";
+if (status !== "prepared" && status !== "released") die(`unsupported newest entry data-status ${JSON.stringify(status)}`);
+const entryDate = newestItem[2].match(/class="clog-date">(\d{4}-\d{2}-\d{2})</)?.[1];
+if (!entryDate) die("newest changelog entry has no YYYY-MM-DD .clog-date");
+const title = newestItem[2].match(/class="clog-title">([^<]+)</)?.[1]?.trim();
+if (!title) die("newest changelog entry has no .clog-title");
+
+// The commit the stamp cites: git decides it for a prepared entry, the entry's
+// own landing hash decides it for a released one.
+let stamp;
+if (status === "prepared") {
+  git("rev-parse", "--verify", "--quiet", "origin/main^{commit}");
+  stamp = git("rev-parse", "--short=7", git("merge-base", "HEAD", "origin/main"));
+} else {
+  stamp = newestItem[2].match(/class="clog-hash"[^>]*>([0-9a-f]{7,40})</)?.[1];
+  if (!stamp) die("newest changelog entry is released but carries no .clog-hash landing commit");
+}
+
+const [year, month, day] = entryDate.split("-").map(Number);
+const shortDate = `${MONTHS_SHORT[month - 1]} ${day}`;
+const longDate = `${MONTHS_LONG[month - 1]} ${day}, ${year}`;
+const statusWord = status === "prepared" ? "Prepared" : "Released";
+// The aria-label reads as a sentence, so the title needs terminal punctuation —
+// but only if it does not already end in some.
+const spokenTitle = /[.!?]$/.test(title) ? title : `${title}.`;
+const citation = status === "prepared" ? `base ${stamp}` : stamp;
+
+// Every rewrite is anchored on markup that must already exist. A silently
+// unmatched replace would leave a page stale while the run reported success,
+// so each one asserts it changed exactly the region it aimed at.
+const edits = [];
+function rewrite(file, label, pattern, replacer) {
+  const matches = [...file.text.matchAll(new RegExp(pattern, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`))];
+  if (matches.length !== 1) {
+    die(`${file.relative}: expected exactly one ${label}, found ${matches.length} — the markup changed`);
+  }
+  file.text = file.text.replace(pattern, replacer);
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function loadPage(relative) {
+  const absolute = path.join(repoRoot, relative);
+  return { relative, absolute, text: fs.readFileSync(absolute, "utf8"), original: fs.readFileSync(absolute, "utf8") };
+}
+
+const pages = ["docs/index.html", "docs/skills/index.html", "docs/guide.html"].map(loadPage);
+
+// 1. The changelog entry's own base anchor, on the homepage only.
+if (status === "prepared") {
+  const home = pages[0];
+  rewrite(
+    home,
+    'prepared .clog-base anchor',
+    /(<a class="clog-hash clog-base" href="[^"]*\/commit\/)[0-9a-f]{7,40}("[^>]*aria-label="View base commit )[0-9a-f]{7,40}( on GitHub">base )[0-9a-f]{7,40}(<\/a>)/,
+    (_, hrefLead, ariaLead, textLead, tail) => `${hrefLead}${stamp}${ariaLead}${stamp}${textLead}${stamp}${tail}`
+  );
+}
+
+// 2. The tiny card on all three pages. Its aria-label tail differs per page
+//    ("Jump to the full changelog." / "Jump to the changelog." / "Read the full
+//    changelog on the homepage."), so only the sentence carrying the stamp is
+//    rewritten and the tail is preserved.
+for (const page of pages) {
+  rewrite(
+    page,
+    'hero-shiplog data-status',
+    /(<a id="hero-shiplog"[^>]*?\bdata-status=")[^"]*(")/,
+    (_, lead, tail) => `${lead}${status}${tail}`
+  );
+  // Anchored on the title the card currently shows, not on the first ". " in
+  // the label: each page ends the label with its own sentence ("Jump to the
+  // full changelog.", "Read the full changelog on the homepage."), and a title
+  // containing a period would otherwise cut the match short and leave a
+  // mangled label behind. Requiring the exact previous title also means a card
+  // whose label and heading have already drifted apart fails loudly here
+  // instead of being half-rewritten.
+  const previousTitle = page.text.match(/class="hero-shiplog-title">([^<]*)</)?.[1] ?? "";
+  rewrite(
+    page,
+    'hero-shiplog aria-label',
+    new RegExp(`(<a id="hero-shiplog"[^>]*\\baria-label=")Ship log\\. (?:Prepared|Released) entry [^:]*: ${escapeRegExp(previousTitle)}\\.?`),
+    (_, lead) => `${lead}Ship log. ${statusWord} entry ${longDate}: ${spokenTitle}`
+  );
+  rewrite(
+    page,
+    'hero-shiplog-top line',
+    /(<span class="hero-shiplog-top">)(?:Released|Prepared) [A-Z][a-z]{2} \d{1,2} <b>&middot; (?:base )?[0-9a-f]{7,40}(<\/b>)/,
+    (_, lead, tail) => `${lead}${statusWord} ${shortDate} <b>&middot; ${citation}${tail}`
+  );
+  rewrite(
+    page,
+    'hero-shiplog-title line',
+    /(<span class="hero-shiplog-title">)[^<]*(<\/span>)/,
+    (_, lead, tail) => `${lead}${title}${tail}`
+  );
+  if (page.text !== page.original) edits.push(page);
+}
+
+if (checkOnly) {
+  if (edits.length === 0) {
+    console.log(`Ship-log stamp is current: ${statusWord} ${shortDate} · ${citation}.`);
+    process.exit(0);
+  }
+  console.error(`build-shiplog --check: the ship-log stamp is not current in ${edits.map((p) => p.relative).join(", ")}.`);
+  console.error(`Expected ${statusWord} ${shortDate} · ${citation}. Run \`npm run build:shiplog\`.`);
+  // Deliberately stricter than CI. `npm run validate` only asks whether the
+  // stamp has fallen badly behind; this asks whether it is exactly current,
+  // which is a release-prep question. A non-zero exit here is a prompt to
+  // refresh, not a broken build, which is why it is not wired into validate.
+  process.exit(1);
+}
+
+for (const page of edits) fs.writeFileSync(page.absolute, page.text);
+if (edits.length === 0) {
+  console.log(`Ship-log stamp already current: ${statusWord} ${shortDate} · ${citation}.`);
+} else {
+  console.log(`Ship-log stamp set to ${statusWord} ${shortDate} · ${citation} in ${edits.map((p) => p.relative).join(", ")}.`);
+}

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1751,9 +1751,16 @@ if (indexJsonLdItemMatches.length !== totalSkillCount) {
 }
 
 // Ship-log guard: released entries cite their reachable landing commits. One
-// newest prepared entry may instead cite the current origin/main merge base,
-// but it must remain visibly unreleased. A fabricated hash, stale version pill,
-// or out-of-order entry would make the page lie about its history.
+// newest prepared entry may instead cite a recent origin/main commit as its
+// base, but it must remain visibly unreleased. A fabricated hash, stale version
+// pill, or out-of-order entry would make the page lie about its history.
+//
+// How far behind origin/main a prepared base may fall before the ship log
+// counts as stale. Observed release cycles in this repo run 3 to 22 commits, so
+// 40 is roughly two of the longest ones: wide enough that an ordinary cycle
+// never trips it, narrow enough that a genuinely abandoned stamp does. Refresh
+// with `npm run build:shiplog`.
+const PREPARED_BASE_MAX_DRIFT = 40;
 const clogItemMatches = [...docsRootText.matchAll(/<li class="clog-item"([^>]*)>([\s\S]*?)<\/li>/g)];
 const clogItems = clogItemMatches.map((match) => match[2]);
 if (clogItems.length === 0) {
@@ -1835,25 +1842,19 @@ if (clogItems.length === 0) {
         fail.push("docs/index.html prepared changelog validation requires origin/main in a full-history checkout");
         continue;
       }
-      const mergeBaseProbe = spawnSync(
-        "git",
-        ["-C", repoRoot, "merge-base", "HEAD", "origin/main"],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
-      );
       const baseProbe = spawnSync(
         "git",
         ["-C", repoRoot, "rev-parse", `${entry.base}^{commit}`],
         { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
       );
-      if (mergeBaseProbe.status !== 0 || baseProbe.status !== 0) {
+      if (baseProbe.status !== 0) {
         fail.push("docs/index.html could not resolve the prepared changelog merge base");
         continue;
       }
-      const expectedBase = mergeBaseProbe.stdout.trim();
-      const citedBase = baseProbe.stdout.trim();
-      if (citedBase !== expectedBase) {
-        fail.push(`docs/index.html prepared changelog base ${entry.base} does not match current branch merge-base ${expectedBase.slice(0, 7)} with origin/main`);
-      }
+      // Published, first. A base that is not on origin/main is the failure that
+      // actually misleads a reader: the commit link either 404s or points at a
+      // pre-squash branch object nobody else can see. Nothing downstream is
+      // meaningful until this holds, so stop here when it does not.
       const reachable = spawnSync(
         "git",
         ["-C", repoRoot, "merge-base", "--is-ancestor", entry.base, "origin/main"],
@@ -1861,6 +1862,42 @@ if (clogItems.length === 0) {
       );
       if (reachable.status !== 0) {
         fail.push(`docs/index.html prepared changelog base ${entry.base} is not reachable from origin/main`);
+        continue;
+      }
+      // The entry claims the prepared work sits on top of this commit, so the
+      // checkout under validation has to contain it. On main and on the merge
+      // ref CI builds for a pull request this is free; on a feature branch it
+      // means the stamp cannot jump ahead to a commit the branch was not cut
+      // from.
+      const onThisBranch = spawnSync(
+        "git",
+        ["-C", repoRoot, "merge-base", "--is-ancestor", entry.base, "HEAD"],
+        { stdio: "ignore" }
+      );
+      if (onThisBranch.status !== 0) {
+        fail.push(`docs/index.html prepared changelog base ${entry.base} is not an ancestor of HEAD — the prepared entry does not sit on the commit it cites`);
+      }
+      // Staleness, not equality. This check used to require the cited base to
+      // equal `merge-base HEAD origin/main`, which on main is main's own tip —
+      // so the first merge after any ship-log refresh turned main red, and
+      // every branch cut from it inherited the failure whether or not it
+      // touched docs. It could not hold on a repo that takes more than one pull
+      // request between refreshes, and the repo shipping the check could not
+      // pass it. What the guard is really for is that the ship log is not badly
+      // stale, which is a commit-distance question and only ever changes when
+      // something merges. A calendar bound is deliberately absent: it would
+      // turn main red on a date with no change behind it, which is the same
+      // self-breaking shape in slower clothing.
+      const driftProbe = spawnSync(
+        "git",
+        ["-C", repoRoot, "rev-list", "--count", `${entry.base}..origin/main`],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+      );
+      const drift = driftProbe.status === 0 ? Number.parseInt(driftProbe.stdout.trim(), 10) : Number.NaN;
+      if (!Number.isInteger(drift)) {
+        fail.push(`docs/index.html could not measure how far prepared changelog base ${entry.base} is behind origin/main`);
+      } else if (drift > PREPARED_BASE_MAX_DRIFT) {
+        fail.push(`docs/index.html prepared changelog base ${entry.base} is ${drift} commits behind origin/main (limit ${PREPARED_BASE_MAX_DRIFT}) — refresh the ship log with \`npm run build:shiplog\``);
       }
     }
   } else if (gitHistory.state === "packaged" || gitHistory.state === "shallow") {

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -583,6 +583,40 @@ function commitsBehindOriginMain(checkoutRoot, revision) {
   return Number.parseInt(probe.stdout.trim(), 10);
 }
 
+// `HEAD~N` is N commits behind HEAD only when the history is linear. GitHub
+// builds a pull request from a MERGE ref, so in CI HEAD is a merge commit:
+// HEAD~1 is main's tip, and reaching HEAD from it costs the merge commit plus
+// every commit on the branch. `HEAD~1` measured 2 behind and `HEAD~41` measured
+// 42, and both fixtures below failed on every pull request while passing on a
+// linear local checkout.
+//
+// Nor can a fixture demand a literal distance: no ancestor of a merge commit is
+// exactly 1 behind it, because dropping either parent still leaves the other
+// reachable. So ask for the nearest commit at least this far back, and let the
+// test assert against the distance it actually got.
+function baseBehindOriginMain(checkoutRoot, minimum) {
+  const listing = spawnSync(
+    "git",
+    ["-C", checkoutRoot, "rev-list", "--topo-order", "origin/main"],
+    { encoding: "utf8" }
+  );
+  assert.equal(listing.status, 0, listing.stderr);
+  const commits = listing.stdout.trim().split("\n").filter(Boolean);
+  // Topological order lists a commit before every one of its ancestors, and
+  // distance to origin/main only grows as you walk back, so the first candidate
+  // that clears the minimum is the closest one worth using.
+  for (const candidate of commits) {
+    const distance = commitsBehindOriginMain(checkoutRoot, candidate);
+    if (distance >= minimum) {
+      return { rev: shortRev(checkoutRoot, candidate), distance };
+    }
+  }
+  assert.fail(
+    `no commit sits at least ${minimum} commits behind origin/main ` +
+    `(${commits.length} reachable) — the fixture cannot exercise this distance`
+  );
+}
+
 function shortRev(checkoutRoot, revision) {
   const probe = spawnSync(
     "git",
@@ -611,10 +645,13 @@ test("validator accepts a prepared changelog anchored to the current merge base"
 // moved past is normal, not a defect, and must pass.
 test("validator accepts a prepared changelog base that origin/main has moved past", completeSourceHistoryTest, (t) => {
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-behind-");
-  const overtaken = shortRev(checkoutRoot, "HEAD~1");
-  assert.notEqual(overtaken, shortRev(checkoutRoot, "origin/main"));
-  assert.equal(commitsBehindOriginMain(checkoutRoot, overtaken), 1);
-  restampPreparedBase(checkoutRoot, overtaken);
+  const overtaken = baseBehindOriginMain(checkoutRoot, 1);
+  assert.notEqual(overtaken.rev, shortRev(checkoutRoot, "origin/main"));
+  assert.ok(
+    overtaken.distance >= 1 && overtaken.distance <= 40,
+    `fixture must sit behind origin/main but inside the bound (${overtaken.distance})`
+  );
+  restampPreparedBase(checkoutRoot, overtaken.rev);
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -625,20 +662,23 @@ test("validator rejects a prepared changelog base that has fallen far behind ori
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-stale-");
   const depth = spawnSync(
     "git",
-    ["-C", checkoutRoot, "rev-list", "--count", "HEAD"],
+    ["-C", checkoutRoot, "rev-list", "--count", "origin/main"],
     { encoding: "utf8" }
   );
   assert.equal(depth.status, 0, depth.stderr);
   const available = Number.parseInt(depth.stdout.trim(), 10);
   assert.ok(available > 41, `history is too short to exercise the drift bound (${available} commits)`);
-  const stale = shortRev(checkoutRoot, "HEAD~41");
-  assert.equal(commitsBehindOriginMain(checkoutRoot, stale), 41, "fixture must sit exactly one past the limit");
-  restampPreparedBase(checkoutRoot, stale);
+  const stale = baseBehindOriginMain(checkoutRoot, 41);
+  assert.ok(stale.distance > 40, `fixture must sit past the limit (${stale.distance})`);
+  restampPreparedBase(checkoutRoot, stale.rev);
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
   assert.notEqual(validation.status, 0, diagnostics);
-  assert.match(validation.stderr, /is 41 commits behind origin\/main \(limit 40\)/);
+  assert.match(
+    validation.stderr,
+    new RegExp(`is ${stale.distance} commits behind origin/main \\(limit 40\\)`)
+  );
 });
 
 test("validator rejects a prepared changelog base unreachable from origin/main", completeSourceHistoryTest, (t) => {

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -520,140 +520,161 @@ test(
   }
 );
 
-test("validator accepts a prepared changelog anchored to the current merge base", completeSourceHistoryTest, (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-prepared-"));
+// The prepared base the site currently advertises. Tests poison THIS value
+// rather than whatever `merge-base HEAD origin/main` resolves to: the two are
+// no longer required to be equal, so deriving the search string from git would
+// make these fixtures silently match nothing the first time the site's stamp
+// and the merge base diverged.
+function preparedBaseIn(checkoutRoot) {
+  const docs = fs.readFileSync(path.join(checkoutRoot, "docs", "index.html"), "utf8");
+  const base = docs.match(/class="[^"]*\bclog-base\b[^"]*"[^>]*>base ([0-9a-f]{7,40})</)?.[1];
+  assert.ok(base, "docs/index.html must advertise a prepared .clog-base commit");
+  return base;
+}
+
+// Idempotent on purpose: a fixture may ask for the base the pages already
+// advertise. The post-condition, not the presence of a diff, is what proves the
+// fixture landed.
+function restampPreparedBase(checkoutRoot, replacement) {
+  const current = preparedBaseIn(checkoutRoot);
+  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
+    const file = path.join(checkoutRoot, relative);
+    const original = fs.readFileSync(file, "utf8");
+    const restamped = current === replacement ? original : original.replaceAll(current, replacement);
+    if (current !== replacement) {
+      assert.notEqual(restamped, original, `test fixture must replace the prepared base in ${relative}`);
+    }
+    assert.ok(restamped.includes(replacement), `test fixture must stamp ${replacement} into ${relative}`);
+    fs.writeFileSync(file, restamped);
+  }
+  assert.equal(preparedBaseIn(checkoutRoot), replacement, "test fixture must leave the pages advertising the new base");
+}
+
+// Points the fixture's origin/main at its own HEAD, which is the state these
+// tests are about: main, just after something merged. Deriving it from the real
+// remote instead makes the fixtures depend on a branch other people are pushing
+// to — `origin/main~1` stops being an ancestor of the checkout the moment two
+// pull requests land while the suite is running, and the test fails for a
+// reason that has nothing to do with the validator. That happened.
+function checkoutWithOriginMainAtHead(t, prefix) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
 
   const checkoutRoot = path.join(tempRoot, "checkout");
   cloneWithCurrentValidator(checkoutRoot);
-  const sourceOriginMain = spawnSync(
-    "git",
-    ["-C", repoRoot, "rev-parse", "origin/main^{commit}"],
-    { encoding: "utf8" }
-  );
-  assert.equal(sourceOriginMain.status, 0, sourceOriginMain.stderr);
+  const head = spawnSync("git", ["-C", checkoutRoot, "rev-parse", "HEAD^{commit}"], { encoding: "utf8" });
+  assert.equal(head.status, 0, head.stderr);
   const alignOriginMain = spawnSync(
     "git",
-    ["-C", checkoutRoot, "update-ref", "refs/remotes/origin/main", sourceOriginMain.stdout.trim()],
+    ["-C", checkoutRoot, "update-ref", "refs/remotes/origin/main", head.stdout.trim()],
     { encoding: "utf8" }
   );
   assert.equal(alignOriginMain.status, 0, alignOriginMain.stderr);
-  const mergeBase = spawnSync(
+  return checkoutRoot;
+}
+
+function commitsBehindOriginMain(checkoutRoot, revision) {
+  const probe = spawnSync(
     "git",
-    ["-C", checkoutRoot, "merge-base", "HEAD", "origin/main"],
+    ["-C", checkoutRoot, "rev-list", "--count", `${revision}..origin/main`],
     { encoding: "utf8" }
   );
-  assert.equal(mergeBase.status, 0, mergeBase.stderr);
-  const baseHash = mergeBase.stdout.trim().slice(0, 7);
+  assert.equal(probe.status, 0, probe.stderr);
+  return Number.parseInt(probe.stdout.trim(), 10);
+}
 
-  const docsPath = path.join(checkoutRoot, "docs", "index.html");
-  const docs = fs.readFileSync(docsPath, "utf8");
-  let prepared = docs;
-  if (!prepared.includes('class="clog-item" data-type="new" data-status="prepared"')) {
-    prepared = prepared.replace(
-      '<li class="clog-item" data-type="new">',
-      '<li class="clog-item" data-type="new" data-status="prepared">'
-    );
-  }
-  if (!/class="[^"]*\bclog-base\b[^"]*"/.test(prepared)) {
-    prepared = prepared.replace(
-      '<span class="clog-tag">Orchestration</span>',
-      `<span class="clog-tag">Orchestration</span>\n            <a class="clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/${baseHash}">base ${baseHash}</a>`
-    );
-  }
-  assert.match(prepared, /data-status="prepared"/);
-  assert.match(prepared, new RegExp(`class="[^"]*\\bclog-base\\b[^"]*"[^>]*>base ${baseHash}<`));
-  fs.writeFileSync(docsPath, prepared);
+function shortRev(checkoutRoot, revision) {
+  const probe = spawnSync(
+    "git",
+    ["-C", checkoutRoot, "rev-parse", "--short=7", revision],
+    { encoding: "utf8" }
+  );
+  assert.equal(probe.status, 0, probe.stderr);
+  return probe.stdout.trim();
+}
+
+test("validator accepts a prepared changelog anchored to the current merge base", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-");
+  // Exactly what `npm run build:shiplog` writes: the merge base, which in this
+  // fixture is HEAD itself. Drift is zero, the strictest case the guard allows.
+  restampPreparedBase(checkoutRoot, shortRev(checkoutRoot, "HEAD"));
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
   assert.equal(validation.status, 0, diagnostics);
 });
 
-test("validator rejects a prepared changelog anchored before the current merge base", completeSourceHistoryTest, (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-prepared-base-"));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+// The regression this whole guard was rebuilt around. The check used to demand
+// the cited base equal `merge-base HEAD origin/main`, which on main is main's
+// own tip — so the first merge after any ship-log refresh turned main red and
+// every branch cut from it inherited the failure. A base origin/main has since
+// moved past is normal, not a defect, and must pass.
+test("validator accepts a prepared changelog base that origin/main has moved past", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-behind-");
+  const overtaken = shortRev(checkoutRoot, "HEAD~1");
+  assert.notEqual(overtaken, shortRev(checkoutRoot, "origin/main"));
+  assert.equal(commitsBehindOriginMain(checkoutRoot, overtaken), 1);
+  restampPreparedBase(checkoutRoot, overtaken);
 
-  const checkoutRoot = path.join(tempRoot, "checkout");
-  cloneWithCurrentValidator(checkoutRoot);
-  const sourceOriginMain = spawnSync(
-    "git",
-    ["-C", repoRoot, "rev-parse", "origin/main^{commit}"],
-    { encoding: "utf8" }
-  );
-  assert.equal(sourceOriginMain.status, 0, sourceOriginMain.stderr);
-  const alignOriginMain = spawnSync(
-    "git",
-    ["-C", checkoutRoot, "update-ref", "refs/remotes/origin/main", sourceOriginMain.stdout.trim()],
-    { encoding: "utf8" }
-  );
-  assert.equal(alignOriginMain.status, 0, alignOriginMain.stderr);
+  const validation = runValidator(checkoutRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.equal(validation.status, 0, diagnostics);
+});
 
-  const mergeBase = spawnSync(
+test("validator rejects a prepared changelog base that has fallen far behind origin/main", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-stale-");
+  const depth = spawnSync(
     "git",
-    ["-C", checkoutRoot, "merge-base", "HEAD", "origin/main"],
+    ["-C", checkoutRoot, "rev-list", "--count", "HEAD"],
     { encoding: "utf8" }
   );
-  assert.equal(mergeBase.status, 0, mergeBase.stderr);
-  const currentBase = mergeBase.stdout.trim().slice(0, 7);
-  const priorBase = spawnSync(
-    "git",
-    ["-C", checkoutRoot, "rev-parse", "origin/main^"],
-    { encoding: "utf8" }
-  );
-  assert.equal(priorBase.status, 0, priorBase.stderr);
-  const wrongBase = priorBase.stdout.trim().slice(0, 7);
-  assert.notEqual(wrongBase, currentBase);
-
-  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
-    const file = path.join(checkoutRoot, relative);
-    const original = fs.readFileSync(file, "utf8");
-    const poisoned = original.replaceAll(currentBase, wrongBase);
-    assert.notEqual(poisoned, original, `test fixture must replace the prepared base in ${relative}`);
-    fs.writeFileSync(file, poisoned);
-  }
+  assert.equal(depth.status, 0, depth.stderr);
+  const available = Number.parseInt(depth.stdout.trim(), 10);
+  assert.ok(available > 41, `history is too short to exercise the drift bound (${available} commits)`);
+  const stale = shortRev(checkoutRoot, "HEAD~41");
+  assert.equal(commitsBehindOriginMain(checkoutRoot, stale), 41, "fixture must sit exactly one past the limit");
+  restampPreparedBase(checkoutRoot, stale);
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
   assert.notEqual(validation.status, 0, diagnostics);
-  assert.match(validation.stderr, /does not match current branch merge-base/);
+  assert.match(validation.stderr, /is 41 commits behind origin\/main \(limit 40\)/);
+});
+
+test("validator rejects a prepared changelog base unreachable from origin/main", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-unreachable-");
+  const tree = spawnSync(
+    "git",
+    ["-C", checkoutRoot, "rev-parse", "HEAD^{tree}"],
+    { encoding: "utf8" }
+  );
+  assert.equal(tree.status, 0, tree.stderr);
+  const unreachable = spawnSync(
+    "git",
+    ["-C", checkoutRoot, "commit-tree", tree.stdout.trim(), "-m", "unreachable prepared base fixture"],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_EMAIL: "validator@example.invalid",
+        GIT_AUTHOR_NAME: "Validator Fixture",
+        GIT_COMMITTER_EMAIL: "validator@example.invalid",
+        GIT_COMMITTER_NAME: "Validator Fixture"
+      }
+    }
+  );
+  assert.equal(unreachable.status, 0, unreachable.stderr);
+  restampPreparedBase(checkoutRoot, unreachable.stdout.trim().slice(0, 7));
+
+  const validation = runValidator(checkoutRoot);
+  const diagnostics = `${validation.stdout}\n${validation.stderr}`;
+  assert.notEqual(validation.status, 0, diagnostics);
+  assert.match(validation.stderr, /prepared changelog base [0-9a-f]{7} is not reachable from origin\/main/);
 });
 
 test("validator rejects an unresolvable prepared changelog base", completeSourceHistoryTest, (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-prepared-missing-"));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
-
-  const checkoutRoot = path.join(tempRoot, "checkout");
-  cloneWithCurrentValidator(checkoutRoot);
-  const sourceOriginMain = spawnSync(
-    "git",
-    ["-C", repoRoot, "rev-parse", "origin/main^{commit}"],
-    { encoding: "utf8" }
-  );
-  assert.equal(sourceOriginMain.status, 0, sourceOriginMain.stderr);
-  const alignOriginMain = spawnSync(
-    "git",
-    ["-C", checkoutRoot, "update-ref", "refs/remotes/origin/main", sourceOriginMain.stdout.trim()],
-    { encoding: "utf8" }
-  );
-  assert.equal(alignOriginMain.status, 0, alignOriginMain.stderr);
-
-  const mergeBase = spawnSync(
-    "git",
-    ["-C", checkoutRoot, "merge-base", "HEAD", "origin/main"],
-    { encoding: "utf8" }
-  );
-  assert.equal(mergeBase.status, 0, mergeBase.stderr);
-  const currentBase = mergeBase.stdout.trim().slice(0, 7);
-  const missingBase = "0000001";
-
-  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
-    const file = path.join(checkoutRoot, relative);
-    const original = fs.readFileSync(file, "utf8");
-    const poisoned = original.replaceAll(currentBase, missingBase);
-    assert.notEqual(poisoned, original, `test fixture must replace the prepared base in ${relative}`);
-    fs.writeFileSync(file, poisoned);
-  }
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-missing-");
+  restampPreparedBase(checkoutRoot, "0000001");
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -661,24 +682,96 @@ test("validator rejects an unresolvable prepared changelog base", completeSource
   assert.match(validation.stderr, /changelog cites commit 0000001 which does not resolve to a commit in this repo/);
 });
 
-test("validator rejects an existing released hash unreachable from the default branch", completeSourceHistoryTest, (t) => {
-  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "suede-validator-released-unreachable-"));
-  t.after(() => fs.rmSync(tempRoot, { recursive: true, force: true }));
+// The ship-log generator. These assertions are deliberately markup-level rather
+// than a validator round trip: the point is that one hand edit to the newest
+// changelog entry propagates to all three cards intact, which is the step that
+// used to be four hand edits and drifted.
+test("build-shiplog propagates one changelog edit to every ship-log card", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-build-shiplog-");
+  const indexPath = path.join(checkoutRoot, "docs", "index.html");
 
-  const checkoutRoot = path.join(tempRoot, "checkout");
-  cloneWithCurrentValidator(checkoutRoot);
-  const sourceOriginMain = spawnSync(
+  // A title carrying an internal period, because the card's aria-label reads as
+  // a sentence and a naive anchor on the first ". " truncates it there.
+  const newTitle = "Ship logs stop chasing main. Again";
+  const source = fs.readFileSync(indexPath, "utf8");
+  const dated = source.replace(/(<span class="clog-date">)\d{4}-\d{2}-\d{2}(<)/, "$12026-09-04$2");
+  assert.notEqual(dated, source, "fixture must restamp the newest entry date");
+  const retitled = dated.replace(/(<h3 class="clog-title">)[^<]*(<\/h3>)/, `$1${newTitle}$2`);
+  assert.notEqual(retitled, dated, "fixture must retitle the newest entry");
+  fs.writeFileSync(indexPath, retitled);
+
+  const build = spawnSync(process.execPath, [path.join(checkoutRoot, "scripts", "build-shiplog.mjs")], {
+    cwd: checkoutRoot,
+    encoding: "utf8"
+  });
+  assert.equal(build.status, 0, `${build.stdout}\n${build.stderr}`);
+
+  const mergeBase = spawnSync(
     "git",
-    ["-C", repoRoot, "rev-parse", "origin/main^{commit}"],
+    ["-C", checkoutRoot, "merge-base", "HEAD", "origin/main"],
     { encoding: "utf8" }
   );
-  assert.equal(sourceOriginMain.status, 0, sourceOriginMain.stderr);
-  const alignOriginMain = spawnSync(
-    "git",
-    ["-C", checkoutRoot, "update-ref", "refs/remotes/origin/main", sourceOriginMain.stdout.trim()],
-    { encoding: "utf8" }
+  assert.equal(mergeBase.status, 0, mergeBase.stderr);
+  const expectedBase = shortRev(checkoutRoot, mergeBase.stdout.trim());
+
+  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
+    const text = fs.readFileSync(path.join(checkoutRoot, relative), "utf8");
+    const card = text.match(/id="hero-shiplog"[\s\S]*?<\/a>/)?.[0];
+    assert.ok(card, `${relative} must still carry a ship-log card`);
+    assert.match(card, new RegExp(`class="hero-shiplog-top">Prepared Sep 4 <b>&middot; base ${expectedBase}</b>`));
+    assert.match(card, new RegExp(`class="hero-shiplog-title">${newTitle}<`));
+    // The date is the changelog ENTRY date, not the base commit's date.
+    assert.match(card, new RegExp(`aria-label="Ship log\\. Prepared entry September 4, 2026: ${newTitle}\\.`));
+    // Each page keeps its own closing sentence.
+    assert.match(card, /aria-label="[^"]*(Jump to the full changelog\.|Jump to the changelog\.|Read the full changelog on the homepage\.)"/);
+    // No doubled terminal punctuation from appending a period to a title.
+    assert.doesNotMatch(card, /\.\.\s/, `${relative} aria-label must not double the sentence period`);
+  }
+
+  // The homepage entry itself must now advertise the generated base.
+  assert.equal(preparedBaseIn(checkoutRoot), expectedBase);
+
+  // Idempotent: a second run changes nothing and --check agrees.
+  const before = ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]
+    .map((relative) => fs.readFileSync(path.join(checkoutRoot, relative), "utf8"));
+  const rerun = spawnSync(process.execPath, [path.join(checkoutRoot, "scripts", "build-shiplog.mjs")], {
+    cwd: checkoutRoot,
+    encoding: "utf8"
+  });
+  assert.equal(rerun.status, 0, `${rerun.stdout}\n${rerun.stderr}`);
+  const after = ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]
+    .map((relative) => fs.readFileSync(path.join(checkoutRoot, relative), "utf8"));
+  assert.deepEqual(after, before, "a second build-shiplog run must be a no-op");
+
+  const checked = spawnSync(
+    process.execPath,
+    [path.join(checkoutRoot, "scripts", "build-shiplog.mjs"), "--check"],
+    { cwd: checkoutRoot, encoding: "utf8" }
   );
-  assert.equal(alignOriginMain.status, 0, alignOriginMain.stderr);
+  assert.equal(checked.status, 0, `${checked.stdout}\n${checked.stderr}`);
+});
+
+// Loud failure is the whole safety model: the generator rewrites by anchoring on
+// markup, so an anchor that stops matching must abort rather than silently leave
+// a page stale.
+test("build-shiplog refuses to run when a ship-log card is missing", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-build-shiplog-missing-");
+  const guidePath = path.join(checkoutRoot, "docs", "guide.html");
+  const guide = fs.readFileSync(guidePath, "utf8");
+  const stripped = guide.replace('id="hero-shiplog"', 'id="hero-shiplog-renamed"');
+  assert.notEqual(stripped, guide, "fixture must break the guide's card anchor");
+  fs.writeFileSync(guidePath, stripped);
+
+  const build = spawnSync(process.execPath, [path.join(checkoutRoot, "scripts", "build-shiplog.mjs")], {
+    cwd: checkoutRoot,
+    encoding: "utf8"
+  });
+  assert.notEqual(build.status, 0, `${build.stdout}\n${build.stderr}`);
+  assert.match(build.stderr, /docs\/guide\.html: expected exactly one .*found 0 — the markup changed/);
+});
+
+test("validator rejects an existing released hash unreachable from the default branch", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-released-unreachable-");
 
   const tree = spawnSync(
     "git",


### PR DESCRIPTION
## The bug

`scripts/validate-skill-pack.mjs` required the base commit cited in `docs/index.html`, `docs/skills/index.html` and `docs/guide.html` to equal `git merge-base HEAD origin/main`.

On `main`, that expression *is* `main`'s own tip. So the check could only hold until the next merge: the moment anything landed, the tip moved, the stamp stopped matching, and `main` went red — and every branch cut from `main` inherited the failure whether or not it touched docs. On a pull request it was worse: CI builds the merge ref, so `merge-base HEAD origin/main` is the tip too, and an open PR had to chase a target that moved whenever anything else merged.

The repo shipping the check could not pass it. Reproduced from a clean checkout of `origin/main` at `d8a6ae8`:

```
- docs/index.html prepared changelog base f6250e1 does not match current branch merge-base d8a6ae8 with origin/main
```

`#105` updated the ship-log title for its own change but left the base on the commit before it. `#108` fixed the stamp by hand to unblock itself — and that fix went stale the moment `#108` merged. It happened again during this work: `origin/main` reached `5e1e20f` carrying `base d8a6ae8`, failing the same assertion. Twice in two days, from the same mechanism.

## The fix

Assert what the guard is actually for. A prepared base must:

1. resolve to a commit,
2. be reachable from `origin/main` — the guard that catches a fabricated or pre-squash hash,
3. be an ancestor of `HEAD` — the prepared entry sits on the commit it cites,
4. sit no more than **40 commits** behind `origin/main`.

Observed release cycles here run 3–22 commits, so 40 is roughly two of the longest: wide enough that an ordinary cycle never trips it, narrow enough that an abandoned stamp does. It can only be crossed by merging something, which is actionable and attributable.

**No calendar bound.** A "within N days" rule would turn `main` red on a date with no change behind it — the same self-breaking shape in slower clothing. Staleness here is a commit-distance question.

## Refreshing is now one command

`scripts/build-shiplog.mjs` (`npm run build:shiplog`) writes the stamp into all four places that carry it. It takes the base commit from git, and status/date/title from the newest hand-authored changelog entry — the date is the changelog **entry** date, not the commit date, which is the source the validator checks it against. Bumping the two together was a trap; the generator can't fall into it.

Every rewrite is anchored on markup that must already exist and aborts loudly if an anchor stops matching, so a markup change can't leave a page silently stale.

It is deliberately **not** wired into `npm run validate`. A `--check` gate on every run would reintroduce exactly the coupling this PR removes; `--check` answers the stricter release-prep question ("is the stamp exactly current?") and is a prompt to refresh, not a broken build.

## Verification

Simulating the real failure, from a clean checkout with `origin/main` tracking it:

| State | Old check | New check |
|---|---|---|
| clean `main`, nothing merged | fail | **pass** |
| after 1 merge | fail | **pass** |
| after 5 merges | fail | **pass** |
| stamp 40 commits behind (at limit) | fail | **pass** |
| stamp 41 commits behind | fail | **fail**, naming the fix command |
| after `npm run build:shiplog` | — | **pass** |

The old validator was extracted from git and run against the same tree as a control — it fails where the new one passes, confirming the simulation exercises the real bug rather than a rearranged one.

Test coverage rewritten for the new contract: a base `origin/main` has moved past is accepted, a base past the bound is rejected, unreachable and unresolvable bases still fail, and the generator is covered for propagation, idempotency, and loud failure on missing markup.

The fixtures took two rounds to get right, and both failures are worth recording because they are the same *class* of mistake as the bug being fixed — an assertion that encodes an assumption about its environment.

1. **They derived commits from the live `origin/main`.** A test failed mid-run when `#110` and `#111` merged and `origin/main~1` stopped being an ancestor of the branch. Each fixture now points its own `origin/main` at its own `HEAD`, which models "main, just after a merge" and cannot be moved by anyone else.
2. **They assumed a linear history.** CI checks out the pull request's *merge ref*, so `HEAD` is a two-parent merge commit and `HEAD~1` walks only the first parent — the branch's own commits are still ahead of it, making the drift 2 where a local clone measures 1. Confirmed against a scratch repo built with that shape. Both fixtures now measure the drift and assert the property (`>= 1 and <= 40`, `> 40`) rather than a literal number.

The validator change itself was unaffected by either: `validate` ran the real check successfully on the first CI attempt, and the generator tests passed both times.

## Also

`.gitignore`'s `node_modules/` → `node_modules`. The trailing slash matches directories only, so the symlink worktrees use showed up as untracked in `git status`.
