### PR TITLE
Keep the 2026-08-21 plan and spec as suede-ship records

### DIFF
--- a/docs/superpowers/plans/2026-08-21-suede-ship-graph-of-thoughts.md
+++ b/docs/superpowers/plans/2026-08-21-suede-ship-graph-of-thoughts.md
@@ -1,23 +1,25 @@
-# Suede Graph Flo XR Graph-of-Thoughts Implementation Plan
+# Suede Ship Graph-of-Thoughts Implementation Plan
+
+*Historical record: written 2026-08-21, when this skill was named `suede-ship`. It was renamed to `suede-graph-flo-xr` (Suede Graph Flo XR) on 2026-08-23; the names below are preserved as written.*
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace `suede-graph-flo-xr`'s fixed single-plan DAG with a bounded Graph-of-Thoughts search that branches, scores, prunes, adversarially improves, aggregates, and selects a safe plan before any source mutation.
+**Goal:** Replace `suede-ship`'s fixed single-plan DAG with a bounded Graph-of-Thoughts search that branches, scores, prunes, adversarially improves, aggregates, and selects a safe plan before any source mutation.
 
 **Architecture:** Keep the workflow as one self-executing JavaScript file so its injected-global runner ABI remains intact. Adapt ETH Zurich's `Thought`, operation graph, readiness scheduler, `Generate`, `Score`, `KeepBestN`, `Improve`, and `Aggregate` concepts; add Suede `Refute`, deterministic plan validation, a total-call ledger, and winner-only mutation. Exercise the real workflow through its existing `AsyncFunction` harness rather than exposing test-only production APIs.
 
 **Tech Stack:** Node.js 22, JavaScript workflow scripts, `node:test`, JSON schemas, Markdown/HTML skill catalog, repository validation scripts.
 
-**Spec:** `docs/superpowers/specs/2026-08-21-suede-graph-flo-xr-graph-of-thoughts-design.md`
+**Spec:** `docs/superpowers/specs/2026-08-21-suede-ship-graph-of-thoughts-design.md`
 
 ## Global Constraints
 
-- Work only in the isolated task worktree on `codex/suede-graph-flo-xr-got-20260821`, based on `origin/main` at `b4d5970`.
+- Work only in the isolated task worktree on `codex/suede-ship-got-20260821`, based on `origin/main` at `b4d5970`.
 - Preserve the dirty sibling worktree for the setup task without reading, resetting, deleting, or reusing it.
 - Keep the workflow runner ABI: injected `args`, `agent`, `parallel`, `pipeline`, `phase`, `log`, `budget`, and `workflow` globals; no Python runtime and no new package dependency.
 - Preserve the invocation arguments `repo`, `scope`, `deploys`, `liveUrl`, `agentBudget`, and `vault`; add required `agentNamespace` because the Workflow VM exposes no Node `process` global for package discovery.
 - Support the bundled runner only in Claude Code on macOS with `sandbox-exec`
-  and registered Suede Graph Flo XR agent profiles. Probe `sandbox-exec` as Scout's
+  and registered Suede Ship agent profiles. Probe `sandbox-exec` as Scout's
   first subprocess, before fetch or worktree creation; Codex and generic skill
   installs retain the orchestration contract only.
 - Search remains read-only; only the selected plan can reach Build or mutate source.
@@ -64,7 +66,7 @@ of calling the run host-certified.
 
 **Files:**
 - Modify: `tests/test_ship_workflow_cost.mjs`
-- Modify: `skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js`
+- Modify: `skills/suede-ship/workflows/suede-ship.js`
 
 **Interfaces:**
 - Consumes: the current workflow `AsyncFunction` harness and injected agent runtime.
@@ -206,7 +208,7 @@ Run:
 
 ```bash
 node --test tests/test_ship_workflow_cost.mjs
-node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
+node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-ship/workflows/suede-ship.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
 ```
 
 Expected: all Task 1 behavior tests pass and syntax check exits 0.
@@ -214,7 +216,7 @@ Expected: all Task 1 behavior tests pass and syntax check exits 0.
 - [ ] **Step 6: Commit the independently working search core**
 
 ```bash
-git add tests/test_ship_workflow_cost.mjs skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+git add tests/test_ship_workflow_cost.mjs skills/suede-ship/workflows/suede-ship.js
 git commit -m "feat: add suede ship thought graph core"
 ```
 
@@ -224,7 +226,7 @@ git commit -m "feat: add suede ship thought graph core"
 
 **Files:**
 - Modify: `tests/test_ship_workflow_cost.mjs`
-- Modify: `skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js`
+- Modify: `skills/suede-ship/workflows/suede-ship.js`
 
 **Interfaces:**
 - Consumes: Task 1 operation graph and scored candidate thoughts.
@@ -321,7 +323,7 @@ Run two distinct adversary prompts per kept candidate. Pass `authority: 'read-on
 
 ```bash
 node --test tests/test_ship_workflow_cost.mjs
-node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
+node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-ship/workflows/suede-ship.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
 ```
 
 Expected: all graph and existing workflow behaviors pass.
@@ -329,7 +331,7 @@ Expected: all graph and existing workflow behaviors pass.
 - [ ] **Step 6: Commit the adversarial convergence path**
 
 ```bash
-git add tests/test_ship_workflow_cost.mjs skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+git add tests/test_ship_workflow_cost.mjs skills/suede-ship/workflows/suede-ship.js
 git commit -m "feat: select plans through adversarial graph search"
 ```
 
@@ -339,7 +341,7 @@ git commit -m "feat: select plans through adversarial graph search"
 
 **Files:**
 - Modify: `tests/test_ship_workflow_cost.mjs`
-- Modify: `skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js`
+- Modify: `skills/suede-ship/workflows/suede-ship.js`
 
 **Interfaces:**
 - Consumes: selected thought and existing Scout/Build/Review/Gate/Release flow.
@@ -451,7 +453,7 @@ Expected: all ship and ship-copy cost tests pass; no stale `~115` comment remain
 - [ ] **Step 5: Commit the bounded safety and evidence contract**
 
 ```bash
-git add tests/test_ship_workflow_cost.mjs skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+git add tests/test_ship_workflow_cost.mjs skills/suede-ship/workflows/suede-ship.js
 git commit -m "test: enforce graph search safety and budgets"
 ```
 
@@ -460,8 +462,8 @@ git commit -m "test: enforce graph search safety and budgets"
 ### Task 4: Skill contract, trigger routing, catalog metadata, and upstream licensing
 
 **Files:**
-- Modify: `skills/suede-graph-flo-xr/SKILL.md`
-- Modify: `skills/suede-graph-flo-xr/agents/openai.yaml`
+- Modify: `skills/suede-ship/SKILL.md`
+- Modify: `skills/suede-ship/agents/openai.yaml`
 - Modify: `mcp/catalog.json`
 - Modify: `tests/fixtures/trigger-routing.json`
 - Modify: `NOTICE.md`
@@ -478,17 +480,17 @@ Add cases that distinguish graph search from nearby skills:
 
 ```json
 {
-  "id": "suede-graph-flo-xr-graph-positive",
+  "id": "suede-ship-graph-positive",
   "mode": "positive",
   "prompt": "Search several implementation plans, score and prune them, have adversarial agents attack the survivors, aggregate the best lanes, then build and gate the winner.",
-  "expected": "suede-graph-flo-xr"
+  "expected": "suede-ship"
 },
 {
-  "id": "suede-graph-flo-xr-findings-negative",
+  "id": "suede-ship-findings-negative",
   "mode": "negative",
   "prompt": "Review this existing diff and report findings, but do not change code.",
   "expected": "suede-code-review",
-  "forbidden": ["suede-graph-flo-xr"]
+  "forbidden": ["suede-ship"]
 }
 ```
 
@@ -500,10 +502,10 @@ Keep frontmatter trigger-only and move operation details into the body. The desc
 
 - ask for missing repo/scope and the `light|standard|deep` budget;
 - state exact ceilings `55|110|200` before launch;
-- route to `workflows/suede-graph-flo-xr.js`;
+- route to `workflows/suede-ship.js`;
 - describe Generate, Score, KeepBestN, Refute, Improve, Aggregate, Select, and winner-only mutation;
 - preserve halt and deployment boundaries;
-- require writing `.suede-graph-flo-xr/${runKey}/handoff.md`, where `runKey` is the workflow's returned validated `ship-<UUID>` worktree leaf;
+- require writing `.suede-ship/${runKey}/handoff.md`, where `runKey` is the workflow's returned validated `ship-<UUID>` worktree leaf;
 - route bulk work to `suede-codex-fleet`, findings-only review to `suede-code-review`, CI wiring to `suede-ci-gate`, and copy to `suede-ship-copy`.
 
 Update `agents/openai.yaml` and the `mcp/catalog.json` description/default prompt with the same contract and no stale “roughly fifty” claim.
@@ -526,7 +528,7 @@ Add this header at the top of the adapted workflow:
 ```bash
 npm run test:triggers
 node scripts/validate-skill-pack.mjs --strict
-python3 ~/.agents/skills/suede-skill-forge/scripts/lint_skill_estate.py skills/suede-graph-flo-xr
+python3 ~/.agents/skills/suede-skill-forge/scripts/lint_skill_estate.py skills/suede-ship
 git diff --check
 ```
 
@@ -535,7 +537,7 @@ Expected: trigger cases route correctly, strict validation exits 0, the skill li
 - [ ] **Step 5: Commit the public skill and license contract**
 
 ```bash
-git add skills/suede-graph-flo-xr mcp/catalog.json tests/fixtures/trigger-routing.json NOTICE.md licenses/graph-of-thoughts-BSD.txt COPY.md
+git add skills/suede-ship mcp/catalog.json tests/fixtures/trigger-routing.json NOTICE.md licenses/graph-of-thoughts-BSD.txt COPY.md
 git commit -m "docs: redefine suede ship as graph search"
 ```
 
@@ -549,7 +551,7 @@ git commit -m "docs: redefine suede ship as graph search"
 - Modify: `book/05-lanes-fleets-and-collisions.md`
 - Modify: `book/06-evidence-or-it-didnt-ship.md`
 - Modify: `book/A1-skill-index.md`
-- Modify: `docs/skills/suede-graph-flo-xr.html`
+- Modify: `docs/skills/suede-ship.html`
 - Modify: `docs/skills/suede-ship-copy.html`
 - Modify: `docs/skills/index.html`
 - Modify: `docs/llms.txt`
@@ -574,7 +576,7 @@ git commit -m "docs: redefine suede ship as graph search"
 
 - [ ] **Step 1: Replace current-architecture claims without rewriting history**
 
-Every current description must say that `suede-graph-flo-xr` searches multiple plans and mutates only the winner. Replace old fixed-DAG and “roughly fifty agents” claims with the exact range:
+Every current description must say that `suede-ship` searches multiple plans and mutates only the winner. Replace old fixed-DAG and “roughly fifty agents” claims with the exact range:
 
 ```text
 Graph-of-Thoughts shipping search: generate competing plans, score and prune them,
@@ -586,7 +588,7 @@ Leave historical changelog entries about the earlier DAG intact. Add a new 2026-
 
 - [ ] **Step 2: Update the public skill page and related cross-references**
 
-Revise metadata, JSON-LD description, terminal demo, architecture bullets, prompt example, cost disclosure, and no-deploy boundary in `docs/skills/suede-graph-flo-xr.html`. In `docs/skills/suede-ship-copy.html`, change only current cross-references that incorrectly call it “the same graph”; do not redesign the copy skill.
+Revise metadata, JSON-LD description, terminal demo, architecture bullets, prompt example, cost disclosure, and no-deploy boundary in `docs/skills/suede-ship.html`. In `docs/skills/suede-ship-copy.html`, change only current cross-references that incorrectly call it “the same graph”; do not redesign the copy skill.
 
 - [ ] **Step 3: Bump every pack version to `0.15.0`**
 
@@ -616,7 +618,7 @@ git commit -m "docs: publish suede ship graph search contract"
 ### Task 6: Full verification and durable handoff
 
 **Files:**
-- Create: `<memory-vault>/05_handoffs/2026-08-21-codex-suede-graph-flo-xr-graph-of-thoughts.md`
+- Create: `<memory-vault>/05_handoffs/2026-08-21-codex-suede-ship-graph-of-thoughts.md`
 
 **Interfaces:**
 - Consumes: the complete branch diff.
@@ -633,7 +635,7 @@ Expected: exit 0 with the lockfile unchanged.
 - [ ] **Step 2: Run focused workflow, routing, MCP, and syntax checks**
 
 ```bash
-node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
+node -e "const fs=require('node:fs'); const AsyncFunction=Object.getPrototypeOf(async function(){}).constructor; const source=fs.readFileSync('skills/suede-ship/workflows/suede-ship.js','utf8').replace('export const meta','const meta'); new AsyncFunction('agent','parallel','pipeline','phase','log','args','budget','workflow',source); console.log('AsyncFunction parse OK')"
 npm run test:ship-cost
 npm run test:triggers
 npm run test:mcp
@@ -657,14 +659,14 @@ Expected: all commands exit 0. If one fails, record the exact failure and repair
 ```bash
 sandbox_root="$(mktemp -d /tmp/suede-skills-install.XXXXXX)"
 env HOME="$sandbox_root" bash install.sh
-test -f "$sandbox_root/.claude/skills/suede-graph-flo-xr/SKILL.md"
-test -f "$sandbox_root/.claude/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-scout.md"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-code-reader.md"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-web-reader.md"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-patch-author.md"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-applier.md"
-test -f "$sandbox_root/.claude/agents/suede-graph-flo-xr-verifier.md"
+test -f "$sandbox_root/.claude/skills/suede-ship/SKILL.md"
+test -f "$sandbox_root/.claude/skills/suede-ship/workflows/suede-ship.js"
+test -f "$sandbox_root/.claude/agents/suede-ship-scout.md"
+test -f "$sandbox_root/.claude/agents/suede-ship-code-reader.md"
+test -f "$sandbox_root/.claude/agents/suede-ship-web-reader.md"
+test -f "$sandbox_root/.claude/agents/suede-ship-patch-author.md"
+test -f "$sandbox_root/.claude/agents/suede-ship-applier.md"
+test -f "$sandbox_root/.claude/agents/suede-ship-verifier.md"
 ```
 
 Expected: installer exits 0, both skill files exist, and all six bare user-agent
@@ -686,11 +688,11 @@ Check every design-spec verification bullet against a test result or diff locati
 The handoff must record:
 
 ```markdown
-# Suede Graph Flo XR Graph-of-Thoughts Rewrite
+# Suede Ship Graph-of-Thoughts Rewrite
 
 - Target: repository root
 - Worktree: isolated task worktree
-- Branch: codex/suede-graph-flo-xr-got-20260821
+- Branch: codex/suede-ship-got-20260821
 - Remote: https://github.com/JasonColapietro/suede-creator-skills.git
 - Base: origin/main at b4d5970
 - Files changed: summarize every path printed by `git diff --name-status origin/main...HEAD`, grouped by runtime, tests, skill contract, licensing, and public docs

--- a/docs/superpowers/specs/2026-08-21-suede-ship-graph-of-thoughts-design.md
+++ b/docs/superpowers/specs/2026-08-21-suede-ship-graph-of-thoughts-design.md
@@ -1,16 +1,18 @@
-# Suede Graph Flo XR Graph-of-Thoughts Design
+# Suede Ship Graph-of-Thoughts Design
+
+*Historical record: written 2026-08-21, when this skill was named `suede-ship`. It was renamed to `suede-graph-flo-xr` (Suede Graph Flo XR) on 2026-08-23; the names below are preserved as written.*
 
 **Date:** 2026-08-21
 
 **Status:** Approved
 
-**Target:** `skills/suede-graph-flo-xr`
+**Target:** `skills/suede-ship`
 
 **Upstream:** ETH Zurich `spcl/graph-of-thoughts` at `3d9d9dbd8937d47a4441f681b8b40e3c5b054f16`
 
 ## Goal
 
-Replace `suede-graph-flo-xr`'s fixed, single-plan orchestration DAG with a real
+Replace `suede-ship`'s fixed, single-plan orchestration DAG with a real
 Graph-of-Thoughts search that generates competing execution plans, scores and
 prunes them, subjects survivors to adversarial refutation, improves them, and
 aggregates compatible strengths before any source file is changed.
@@ -33,7 +35,7 @@ authority, evidence requirements, and release-state boundaries.
 
 ## Preserved Public Contract
 
-- Invocation remains `$suede-graph-flo-xr` with absolute `repo`, `scope`, `deploys`, `liveUrl`,
+- Invocation remains `$suede-ship` with absolute `repo`, `scope`, `deploys`, `liveUrl`,
   `agentBudget`, `vault`, and `agentNamespace` arguments.
 - The workflow continues to use injected `agent`, `parallel`, `pipeline`,
   `phase`, `log`, `args`, `budget`, and `workflow` globals.
@@ -45,13 +47,13 @@ authority, evidence requirements, and release-state boundaries.
 - Production reads remain read-only. The workflow never deploys and cannot
   claim `deployed`, `verified live`, or `released`.
 - The workflow returns a structured result and writes an evidence handoff to
-  `.suede-graph-flo-xr/<runKey>/handoff.md` through the calling agent. `runKey` is the
+  `.suede-ship/<runKey>/handoff.md` through the calling agent. `runKey` is the
   validated unique `ship-<UUID>` leaf of the workflow-created worktree; the
   Workflow VM does not expose the host run ID. If Scout returns an invalid path
   before that key can be validated, the caller reports the halt without
   writing a run-keyed handoff.
 - The JavaScript runner is supported in Claude Code on macOS. It requires
-  registered Suede Graph Flo XR agent profiles and `sandbox-exec`. Scout's exact setup
+  registered Suede Ship agent profiles and `sandbox-exec`. Scout's exact setup
   command probes `sandbox-exec` before fetch or worktree creation. If invoked
   and rejected, it exits before repo mutation. The structured Scout response is
   a model attestation, not a host receipt. Codex and generic skill-only installs
@@ -78,7 +80,7 @@ The entry file is organized in this order:
 7. winner-only build, review, repair, gate, release check, and handoff.
 
 Plugin installs resolve qualified agent names such as
-`suede-skills:suede-graph-flo-xr-verifier`; the focused workflow plugin uses its own
+`suede-skills:suede-ship-verifier`; the focused workflow plugin uses its own
 namespace. Because the Workflow VM does not expose Node `process`, the full
 and focused callers explicitly pass `agentNamespace: "suede-skills"` or
 `agentNamespace: "suede-agent-workflows"`. The clone installer copies the same


### PR DESCRIPTION
PR #112 renamed `suede-ship` to `suede-graph-flo-xr` under a policy of renaming live product surfaces while leaving dated historical records — blog posts, changelog entries — with their original wording. Two dated documents were swept by mistake:

- `docs/superpowers/plans/2026-08-21-suede-ship-graph-of-thoughts.md`
- `docs/superpowers/specs/2026-08-21-suede-ship-graph-of-thoughts-design.md`

Both are dated 2026-08-21 and had been rewritten to say "Suede Graph Flo XR", a name that did not exist until the rename landed on 2026-08-23.

## What the sweep broke

- **Redundant H1s.** "Suede Graph Flo XR Graph-of-Thoughts Implementation Plan" and "Suede Graph Flo XR Graph-of-Thoughts Design".
- **A dangling cross-reference.** The plan's `**Spec:**` line was rewritten to `docs/superpowers/specs/2026-08-21-suede-graph-flo-xr-graph-of-thoughts-design.md`, but the spec's filename still carries the original slug, so the link pointed at a file that does not exist. Restoring the wording repairs it.
- **Filename/content mismatch.** Both filenames kept `suede-ship` while the bodies said otherwise.

## What this does

Restores the pre-rename wording in these two files only, and adds one line under each H1 recording that the skill was later renamed, so the dated record stays accurate without confusing a reader who arrives from the new name.

## Scope

Only the two dated documents are touched. `git diff b2440ef HEAD -- docs/superpowers/` shows the sole difference from the pre-rename originals is the added note line — every one of the 52 restored strings matches what was written on 2026-08-21.

No live surface changes: `skills/suede-graph-flo-xr/`, the catalog, the skill pages, and the changelog keep the new name.

## Verification

`npm test` green on this branch, rebased onto `2654e98`:

| Suite | Result |
|---|---|
| `validate` (71 skills, trigger routing, both book checks) | pass |
| `test:validator-runtime` | 26/26 |
| `test:mcp` | 16/16 |
| `test:triggers` | 76/76 |
| `test:ship-cost` | 110/110 |
| `test:contributions` | 28/28 |
| `test:python` | 47, OK |

An earlier run failed `test_validator_runtime.mjs` on the prepared-changelog-base check, which required the cited base to equal `merge-base HEAD origin/main` exactly and so went red whenever main moved a single commit. #114 landed mid-review and replaced that with published / ancestor-of-HEAD / drift bounds, which resolves it; no changelog edit is needed here.