### PR TITLE
Generate the ship-log commit count, week span and sparkline from git

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -443,8 +443,15 @@
         transition: border-color 0.15s ease, background 0.15s ease;
       }
       #hero-shiplog:hover { border-color: var(--gold); background: #141414; }
-      .hero-spark { display: flex; align-items: flex-end; gap: 3px; height: 34px; flex-shrink: 0; }
-      .hero-spark span { width: 5px; min-height: 2px; border-radius: 1px; background: var(--gold); opacity: 0.45; }
+      /* Fixed track, flexible bars: build-shiplog emits one bar per week of
+         history, so the fixed 5px bar this used to draw would have widened the
+         card every week until it crowded out the text beside it. The bars now
+         share a 100px track and thin as weeks accrue. Their separator rides on
+         each bar as a transparent border rather than sitting in a flex gap, so
+         that it shrinks along with them -- but it still floors at 2px, so the
+         track holds to roughly 50 weeks and wants a rethink after that. */
+      .hero-spark { display: flex; align-items: flex-end; height: 34px; width: 100px; flex-shrink: 0; }
+      .hero-spark span { flex: 1 1 0; min-width: 0; min-height: 2px; border-right: 2px solid transparent; border-radius: 1px; background: var(--gold); background-clip: padding-box; opacity: 0.45; }
       .hero-spark span:last-child { opacity: 1; }
       .hero-shiplog-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
       .hero-shiplog-top {
@@ -1177,21 +1184,25 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
           <p class="section-sub">The design decisions behind the pack, written up in full: what a skill costs, how routing avoids collisions, and where memory actually belongs.</p>
           <a id="hero-shiplog" data-status="prepared" href="./#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Read the full changelog on the homepage.">
             <span class="hero-spark" aria-hidden="true">
+              <span style="height:8%"></span>
+              <span style="height:0%"></span>
               <span style="height:2%"></span>
+              <span style="height:3%"></span>
               <span style="height:100%"></span>
-              <span style="height:98%"></span>
-              <span style="height:51%"></span>
-              <span style="height:51%"></span>
-              <span style="height:51%"></span>
-              <span style="height:88%"></span>
+              <span style="height:39%"></span>
+              <span style="height:52%"></span>
+              <span style="height:28%"></span>
+              <span style="height:30%"></span>
+              <span style="height:45%"></span>
+              <span style="height:42%"></span>
+              <span style="height:50%"></span>
               <span style="height:56%"></span>
-              <span style="height:63%"></span>
-              <span style="height:67%"></span>
+              <span style="height:33%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
+              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
               <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-              <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+              <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
             </span>
           </a>
           <div class="notes">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2888,8 +2888,15 @@
       transition: border-color 0.15s ease, background 0.15s ease;
     }
     #hero-shiplog:hover { border-color: #c8a96e; background: #141414; }
-    .hero-spark { display: flex; align-items: flex-end; gap: 3px; height: 34px; flex-shrink: 0; }
-    .hero-spark span { width: 5px; min-height: 2px; border-radius: 1px; background: #c8a96e; opacity: 0.45; }
+    /* Fixed track, flexible bars: build-shiplog emits one bar per week of
+       history, so the fixed 5px bar this used to draw would have widened the
+       card every week until it crowded out the text beside it. The bars now
+       share a 100px track and thin as weeks accrue. Their separator rides on
+       each bar as a transparent border rather than sitting in a flex gap, so
+       that it shrinks along with them -- but it still floors at 2px, so the
+       track holds to roughly 50 weeks and wants a rethink after that. */
+    .hero-spark { display: flex; align-items: flex-end; height: 34px; width: 100px; flex-shrink: 0; }
+    .hero-spark span { flex: 1 1 0; min-width: 0; min-height: 2px; border-right: 2px solid transparent; border-radius: 1px; background: #c8a96e; background-clip: padding-box; opacity: 0.45; }
     .hero-spark span:last-child { opacity: 1; }
     .hero-shiplog-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
     .hero-shiplog-top {
@@ -3602,7 +3609,7 @@
   <div class="tape-inner">
     <ul class="tape-track">
       <li><b>71</b> skills, open source</li>
-      <li><b>282</b> commits in 10 weeks</li>
+      <li><b>312</b> commits in 14 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -3611,7 +3618,7 @@
     </ul>
     <ul class="tape-track" aria-hidden="true">
       <li><b>71</b> skills, open source</li>
-      <li><b>282</b> commits in 10 weeks</li>
+      <li><b>312</b> commits in 14 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -3650,21 +3657,25 @@
 
         <a id="hero-shiplog" class="hero-anim" data-status="prepared" href="#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the full changelog.">
           <span class="hero-spark" aria-hidden="true">
+            <span style="height:8%"></span>
+            <span style="height:0%"></span>
             <span style="height:2%"></span>
+            <span style="height:3%"></span>
             <span style="height:100%"></span>
-            <span style="height:98%"></span>
-            <span style="height:51%"></span>
-            <span style="height:51%"></span>
-            <span style="height:51%"></span>
-            <span style="height:88%"></span>
+            <span style="height:39%"></span>
+            <span style="height:52%"></span>
+            <span style="height:28%"></span>
+            <span style="height:30%"></span>
+            <span style="height:45%"></span>
+            <span style="height:42%"></span>
+            <span style="height:50%"></span>
             <span style="height:56%"></span>
-            <span style="height:63%"></span>
-            <span style="height:67%"></span>
+            <span style="height:33%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
+            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
             <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-            <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+            <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
           </span>
         </a>
       </div>
@@ -3809,7 +3820,10 @@
 
       <p class="clog-fresh reveal reveal-d2">Version 0.15.0 prepared Aug 21, 2026 <span id="clog-fresh-rel" data-iso="2026-08-21"></span></p>
 
-      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last ten weeks, oldest to newest: 2, 64, 25, 33, 18, 19, 29, 27, 32, and 33 commits.">
+      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last fourteen weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, 29, 27, 32, 36, and 21 commits.">
+        <span style="height:8%"></span>
+        <span style="height:0%"></span>
+        <span style="height:2%"></span>
         <span style="height:3%"></span>
         <span style="height:100%"></span>
         <span style="height:39%"></span>
@@ -3819,9 +3833,10 @@
         <span style="height:45%"></span>
         <span style="height:42%"></span>
         <span style="height:50%"></span>
-        <span style="height:52%"></span>
+        <span style="height:56%"></span>
+        <span style="height:33%"></span>
       </div>
-      <p class="clog-spark-caption reveal reveal-d2">282 commits &middot; 10 weeks &middot; newest on the right</p>
+      <p class="clog-spark-caption reveal reveal-d2">312 commits &middot; 14 weeks &middot; newest on the right</p>
 
       <div class="clog-filters reveal reveal-d2" role="group" aria-label="Filter changelog entries by type">
         <button class="clog-filter" type="button" data-filter="all" aria-pressed="true">All</button>
@@ -3839,7 +3854,7 @@
           <p class="clog-meta">
             <span class="clog-date">2026-08-21</span>
             <span class="clog-tag">Orchestration</span>
-            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1626d1c" target="_blank" rel="noopener" aria-label="View base commit 1626d1c on GitHub">base 1626d1c</a>
+            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1280b11" target="_blank" rel="noopener" aria-label="View base commit 1280b11 on GitHub">base 1280b11</a>
           </p>
           <h3 class="clog-title">Graph search replaces the fixed shipping DAG</h3>
           <p class="clog-detail">Version 0.15.0 replaces <code>suede-graph-flo-xr</code>'s fixed single-plan DAG with a bounded Graph-of-Thoughts search. It generates competing plans, scores and prunes them, adversarially refutes and improves survivors, aggregates compatible lanes, then builds, reviews, and gates only the selected plan. Light, standard, and deep stop at 55, 110, and 200 total agent calls. Production access remains read-only; the skill never deploys.</p>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -168,8 +168,15 @@
       transition: border-color 0.15s ease, background 0.15s ease;
     }
     #hero-shiplog:hover { border-color: var(--gold); background: #141414; }
-    .hero-spark { display: flex; align-items: flex-end; gap: 3px; height: 34px; flex-shrink: 0; }
-    .hero-spark span { width: 5px; min-height: 2px; border-radius: 1px; background: var(--gold); opacity: 0.45; }
+    /* Fixed track, flexible bars: build-shiplog emits one bar per week of
+       history, so the fixed 5px bar this used to draw would have widened the
+       card every week until it crowded out the text beside it. The bars now
+       share a 100px track and thin as weeks accrue. Their separator rides on
+       each bar as a transparent border rather than sitting in a flex gap, so
+       that it shrinks along with them -- but it still floors at 2px, so the
+       track holds to roughly 50 weeks and wants a rethink after that. */
+    .hero-spark { display: flex; align-items: flex-end; height: 34px; width: 100px; flex-shrink: 0; }
+    .hero-spark span { flex: 1 1 0; min-width: 0; min-height: 2px; border-right: 2px solid transparent; border-radius: 1px; background: var(--gold); background-clip: padding-box; opacity: 0.45; }
     .hero-spark span:last-child { opacity: 1; }
     .hero-shiplog-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
     .hero-shiplog-top {
@@ -562,21 +569,25 @@
 
     <a id="hero-shiplog" data-status="prepared" href="#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
+        <span style="height:8%"></span>
+        <span style="height:0%"></span>
         <span style="height:2%"></span>
+        <span style="height:3%"></span>
         <span style="height:100%"></span>
-        <span style="height:98%"></span>
-        <span style="height:51%"></span>
-        <span style="height:51%"></span>
-        <span style="height:51%"></span>
-        <span style="height:88%"></span>
+        <span style="height:39%"></span>
+        <span style="height:52%"></span>
+        <span style="height:28%"></span>
+        <span style="height:30%"></span>
+        <span style="height:45%"></span>
+        <span style="height:42%"></span>
+        <span style="height:50%"></span>
         <span style="height:56%"></span>
-        <span style="height:63%"></span>
-        <span style="height:67%"></span>
+        <span style="height:33%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1626d1c</b></span>
+        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
         <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-        <span class="hero-shiplog-more">282 commits &middot; 10 weeks &middot; read the full ship log -&gt;</span>
+        <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
       </span>
     </a>
 

--- a/scripts/build-shiplog.mjs
+++ b/scripts/build-shiplog.mjs
@@ -17,6 +17,13 @@
 // written on the day it was written, and the validator checks it against the
 // entry. Deriving it from the commit instead looks equivalent and fails.
 //
+// It also writes the commit-activity series -- the advertised commit count, the
+// week span, and the sparkline bars -- everywhere the page repeats it, which is
+// more places than the stamp: the three hero cards, the #changelog chart with
+// its caption and its spoken aria-label, and both marquee copies of the
+// #proof-tape claim. Those were hand-copied numbers with no common source, so
+// they did not merely go stale together, they disagreed. See the block below.
+//
 // Usage:
 //   node scripts/build-shiplog.mjs            rewrite the stamp in place
 //   node scripts/build-shiplog.mjs --check    report drift, exit 1 if stale
@@ -82,16 +89,97 @@ const statusWord = status === "prepared" ? "Prepared" : "Released";
 const spokenTitle = /[.!?]$/.test(title) ? title : `${title}.`;
 const citation = status === "prepared" ? `base ${stamp}` : stamp;
 
+// ---- Commit activity -------------------------------------------------------
+// The advertised commit count, the week span, and the sparkline bars above them
+// are one measurement -- not three numbers that happen to sit near each other.
+// Hand-copied, they did not just go stale, they disagreed: the cards read
+// "282 commits, 10 weeks" against a repo that had shipped 308 over 14, and the
+// ten bars had been fitted to that caption by dropping the three quiet opening
+// weeks and adding their six commits onto the newest bar so the aria-label
+// would still sum to 282. A chart contradicting its own label is the failure
+// this section removes -- bars, count and span now leave one function together
+// or not at all.
+const HISTORY_REF = ["origin/main", "main", "HEAD"].find((ref) =>
+  spawnSync("git", ["-C", repoRoot, "rev-parse", "--verify", "--quiet", `${ref}^{commit}`], { stdio: "ignore" }).status === 0
+);
+if (!HISTORY_REF) die("no origin/main, main or HEAD to measure commit activity from");
+
+const NUMBER_WORDS = [
+  "zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+  "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen",
+  "eighteen", "nineteen", "twenty"
+];
+
+function measureCommitActivity(ref) {
+  const log = git("log", "--reverse", "--pretty=format:%cI", ref);
+  const stamps = log ? log.split("\n") : [];
+  if (stamps.length === 0) die(`${ref} has no commits to measure`);
+  // Bucket on the commit's own calendar date -- the date `git log --date=short`
+  // prints. Parsing to a timestamp first would re-bin every commit by UTC and
+  // walk evening commits west of Greenwich into the following week.
+  const dayOf = (iso) => {
+    const [y, m, d] = iso.slice(0, 10).split("-").map(Number);
+    return Date.UTC(y, m - 1, d) / 86400000;
+  };
+  const days = stamps.map(dayOf);
+  const newest = days[days.length - 1];
+  const weeks = Math.floor((newest - days[0]) / 7) + 1;
+  const perWeek = new Array(weeks).fill(0);
+  // Seven-day windows counted back from the newest commit, so the last bar is
+  // always the current week and the partial window is the oldest one.
+  for (const day of days) perWeek[weeks - 1 - Math.floor((newest - day) / 7)] += 1;
+  const busiest = Math.max(...perWeek);
+  return {
+    total: stamps.length,
+    weeks,
+    perWeek,
+    // Normalized to the busiest week, so the tallest bar is always full height
+    // and the shape reads the same whatever the absolute volume. A quiet week
+    // can round to 0; CSS min-height still draws it as a stub, which is the
+    // honest mark for "nothing shipped".
+    heights: perWeek.map((n) => Math.round((n / busiest) * 100))
+  };
+}
+
+const activity = measureCommitActivity(HISTORY_REF);
+const activityLine = `${activity.total} commits &middot; ${activity.weeks} weeks`;
+
+function sparkAriaLabel() {
+  const counts = activity.perWeek;
+  const list = counts.length === 1
+    ? `${counts[0]}`
+    : `${counts.slice(0, -1).join(", ")}, and ${counts[counts.length - 1]}`;
+  const span = NUMBER_WORDS[activity.weeks] ?? String(activity.weeks);
+  return `Commit activity per week over the last ${span} weeks, oldest to newest: ${list} commits.`;
+}
+
+// Rewrites a bar column that sits between an opening tag on its own line and a
+// closing tag on its own line, reusing whatever indentation the first existing
+// bar carries -- the three pages nest this markup at three different depths.
+function rewriteBars(page, label, pattern) {
+  rewrite(page, label, pattern, (_, open, body, close) => {
+    const indent = body.match(/^[ \t]*/)?.[0] ?? "";
+    const bars = activity.heights.map((height) => `${indent}<span style="height:${height}%"></span>`);
+    return `${open}${bars.join("\n")}${close}`;
+  });
+}
+
 // Every rewrite is anchored on markup that must already exist. A silently
 // unmatched replace would leave a page stale while the run reported success,
 // so each one asserts it changed exactly the region it aimed at.
 const edits = [];
-function rewrite(file, label, pattern, replacer) {
-  const matches = [...file.text.matchAll(new RegExp(pattern, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`))];
-  if (matches.length !== 1) {
-    die(`${file.relative}: expected exactly one ${label}, found ${matches.length} — the markup changed`);
+// `expected` is the number of copies the markup is known to carry. It is almost
+// always one, but the proof-tape marquee duplicates its whole track so the strip
+// can scroll seamlessly, and both copies state the claim. Asserting the count
+// rather than replacing blindly is what makes a markup change fail loudly here
+// instead of leaving one copy of a number silently behind.
+function rewrite(file, label, pattern, replacer, expected = 1) {
+  const global = new RegExp(pattern, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
+  const matches = [...file.text.matchAll(global)];
+  if (matches.length !== expected) {
+    die(`${file.relative}: expected exactly ${expected === 1 ? "one" : expected} ${label}, found ${matches.length} — the markup changed`);
   }
-  file.text = file.text.replace(pattern, replacer);
+  file.text = file.text.replace(global, replacer);
 }
 
 function escapeRegExp(value) {
@@ -116,7 +204,39 @@ if (status === "prepared") {
   );
 }
 
-// 2. The tiny card on all three pages. Its aria-label tail differs per page
+// 2. The commit-activity sparkline and its caption, on the homepage only. The
+//    aria-label restates the same series in words for screen readers, so it is
+//    regenerated from the same numbers instead of being left to hand-editing --
+//    it was the surface that had drifted furthest.
+{
+  const home = pages[0];
+  rewriteBars(home, 'clog-spark bar column', /(<div class="clog-spark[^>]*>\n)([\s\S]*?)(\n[ \t]*<\/div>)/);
+  rewrite(
+    home,
+    'clog-spark aria-label',
+    /(<div class="clog-spark[^"]*"[^>]*\baria-label=")[^"]*(")/,
+    (_, lead, tail) => `${lead}${sparkAriaLabel()}${tail}`
+  );
+  rewrite(
+    home,
+    'clog-spark caption',
+    /(<p class="clog-spark-caption[^"]*">)\d+ commits &middot; \d+ weeks( &middot; [^<]*<\/p>)/,
+    (_, lead, tail) => `${lead}${activityLine}${tail}`
+  );
+  // The #proof-tape strip states the same claim again, in its own wording, and
+  // promises in a comment above itself that every number on it is sourced from
+  // further down the page. It was the surface that gave this away: it still read
+  // "282 commits in 10 weeks" with nothing on the page left to source it.
+  rewrite(
+    home,
+    'proof-tape commit claim',
+    /(<li><b>)\d+(<\/b> commits in )\d+( weeks<\/li>)/,
+    (_, lead, middle, tail) => `${lead}${activity.total}${middle}${activity.weeks}${tail}`,
+    2
+  );
+}
+
+// 3. The tiny card on all three pages. Its aria-label tail differs per page
 //    ("Jump to the full changelog." / "Jump to the changelog." / "Read the full
 //    changelog on the homepage."), so only the sentence carrying the stamp is
 //    rewritten and the tail is preserved.
@@ -152,6 +272,14 @@ for (const page of pages) {
     'hero-shiplog-title line',
     /(<span class="hero-shiplog-title">)[^<]*(<\/span>)/,
     (_, lead, tail) => `${lead}${title}${tail}`
+  );
+  rewriteBars(page, 'hero-spark bar column', /(<span class="hero-spark"[^>]*>\n)([\s\S]*?)(\n[ \t]*<\/span>)/);
+  // The trailing call to action differs per page, so only the two numbers move.
+  rewrite(
+    page,
+    'hero-shiplog-more line',
+    /(<span class="hero-shiplog-more">)\d+ commits &middot; \d+ weeks( &middot; [^<]*<\/span>)/,
+    (_, lead, tail) => `${lead}${activityLine}${tail}`
   );
   if (page.text !== page.original) edits.push(page);
 }

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1761,6 +1761,23 @@ if (indexJsonLdItemMatches.length !== totalSkillCount) {
 // never trips it, narrow enough that a genuinely abandoned stamp does. Refresh
 // with `npm run build:shiplog`.
 const PREPARED_BASE_MAX_DRIFT = 40;
+// How far the advertised commit count may sit from `git rev-list --count` on
+// the default branch. A tolerance, not equality, on purpose: the count moves
+// on every single merge, so pinning it exactly would turn main red the next
+// time anything landed -- the failure mode PREPARED_BASE_MAX_DRIFT above was
+// introduced to remove. 40 matches that bound for the same reason, roughly two
+// of the longest release cycles seen here.
+//
+// It is deliberately symmetric. The tempting asymmetry -- "may lag, never
+// overstate" -- reads well but assumes the reference count only ever grows
+// relative to the page, and which commit `origin/main` names depends on the
+// shape of the checkout: a pull request builds a merge ref, and a test fixture
+// repoints origin/main at its own HEAD, so a branch that sits while main
+// advances legitimately measures a count BELOW the one the page was generated
+// from. Failing that direction on sight would break honest branches and the
+// fixtures alike, which is the self-breaking shape this file keeps growing out
+// of. A fabricated number is off by far more than a release cycle either way.
+const ADVERTISED_COMMIT_MAX_DRIFT = 40;
 const clogItemMatches = [...docsRootText.matchAll(/<li class="clog-item"([^>]*)>([\s\S]*?)<\/li>/g)];
 const clogItems = clogItemMatches.map((match) => match[2]);
 if (clogItems.length === 0) {
@@ -1975,7 +1992,11 @@ if (clogItems.length === 0) {
     const cardStatus = box[0].match(/\bdata-status="([^"]+)"/)?.[1] ?? "released";
     const top = box[0].match(/class="hero-shiplog-top">(Released|Prepared) ([A-Z][a-z]{2} \d{1,2}) <b>&middot; (?:(base) )?([0-9a-f]{7,40})<\/b>/);
     const title = (box[0].match(/class="hero-shiplog-title">([^<]+)</) || [])[1]?.trim() ?? null;
-    const commits = (box[0].match(/class="hero-shiplog-more">(\d+) commits/) || [])[1] ?? null;
+    const more = box[0].match(/class="hero-shiplog-more">(\d+) commits &middot; (\d+) weeks/);
+    const commits = more ? more[1] : null;
+    const weeks = more ? more[2] : null;
+    const heroBars = (box[0].match(/<span class="hero-spark"[\s\S]*?<\/span>\s*<\/span>/) || [])[0];
+    const heroBarCount = heroBars ? (heroBars.match(/style="height:\d+%"/g) || []).length : null;
     if (!top) {
       fail.push(`${page.file}: tiny ship-log box header is malformed`);
     } else {
@@ -2000,17 +2021,97 @@ if (clogItems.length === 0) {
       fail.push(`${page.file}: tiny ship-log box title ("${title}") does not match the newest changelog entry title ("${newestClogTitle}")`);
     }
     if (!commits) {
-      fail.push(`${page.file}: tiny ship-log box is missing its "N commits" line`);
+      fail.push(`${page.file}: tiny ship-log box is missing its "N commits &middot; N weeks" line`);
     } else {
-      boxCounts.push({ file: page.file, commits });
+      boxCounts.push({ file: page.file, commits, weeks });
+    }
+    // The sparkline draws one bar per week, so a caption claiming more weeks
+    // than there are bars is a chart contradicting its own label. That is
+    // exactly how this drifted: the cards advertised ten weeks over ten bars
+    // while the repo had shipped fourteen, and refreshing only the sentence
+    // would have left the picture arguing with it. Refresh both together with
+    // `npm run build:shiplog`.
+    if (heroBarCount === null) {
+      fail.push(`${page.file}: tiny ship-log box is missing its .hero-spark bar column`);
+    } else if (weeks && heroBarCount !== Number(weeks)) {
+      fail.push(`${page.file}: tiny ship-log sparkline draws ${heroBarCount} bars but the card advertises ${weeks} weeks — run \`npm run build:shiplog\``);
     }
   }
   if (boxCounts.length > 1 && new Set(boxCounts.map((b) => b.commits)).size > 1) {
     fail.push(`Tiny ship-log boxes disagree on the commit count: ${boxCounts.map((b) => `${b.file}=${b.commits}`).join(", ")}`);
   }
-  const sparkCaption = (docsRootText.match(/class="clog-spark-caption[^"]*">(\d+) commits/) || [])[1] ?? null;
+  if (boxCounts.length > 1 && new Set(boxCounts.map((b) => b.weeks)).size > 1) {
+    fail.push(`Tiny ship-log boxes disagree on the week span: ${boxCounts.map((b) => `${b.file}=${b.weeks}`).join(", ")}`);
+  }
+  const caption = docsRootText.match(/class="clog-spark-caption[^"]*">(\d+) commits &middot; (\d+) weeks/);
+  const sparkCaption = caption ? caption[1] : null;
+  const sparkCaptionWeeks = caption ? caption[2] : null;
   if (sparkCaption && boxCounts[0] && sparkCaption !== boxCounts[0].commits) {
     fail.push(`docs/index.html sparkline caption says ${sparkCaption} commits but the tiny ship-log boxes say ${boxCounts[0].commits}`);
+  }
+  if (sparkCaptionWeeks && boxCounts[0] && sparkCaptionWeeks !== boxCounts[0].weeks) {
+    fail.push(`docs/index.html sparkline caption says ${sparkCaptionWeeks} weeks but the tiny ship-log boxes say ${boxCounts[0].weeks}`);
+  }
+
+  // The changelog sparkline states its own series twice: as bars, and as a
+  // spoken list in the aria-label a screen reader gets. Both have to agree
+  // with the caption above them, or sighted and unsighted readers are handed
+  // different histories. The old markup failed this: three opening weeks had
+  // been dropped from the chart and their six commits folded onto the newest
+  // bar so the spoken list would still total the advertised 282.
+  const clogSpark = docsRootText.match(/<div class="clog-spark[^>]*>[\s\S]*?<\/div>/);
+  if (!clogSpark) {
+    fail.push("docs/index.html: the #changelog commit-activity sparkline (.clog-spark) is missing");
+  } else {
+    const clogBars = (clogSpark[0].match(/style="height:\d+%"/g) || []).length;
+    if (sparkCaptionWeeks && clogBars !== Number(sparkCaptionWeeks)) {
+      fail.push(`docs/index.html sparkline draws ${clogBars} bars but its caption says ${sparkCaptionWeeks} weeks — run \`npm run build:shiplog\``);
+    }
+    const spoken = clogSpark[0].match(/\baria-label="[^"]*oldest to newest: ([^"]*?) commits\."/);
+    if (!spoken) {
+      fail.push("docs/index.html sparkline is missing its per-week aria-label series");
+    } else {
+      const weekly = spoken[1].split(/,\s*(?:and\s*)?/).map((n) => Number(n.trim()));
+      if (weekly.some((n) => !Number.isInteger(n) || n < 0)) {
+        fail.push(`docs/index.html sparkline aria-label series is not a list of week counts: ${JSON.stringify(spoken[1])}`);
+      } else {
+        if (weekly.length !== clogBars) {
+          fail.push(`docs/index.html sparkline aria-label lists ${weekly.length} weeks but the chart draws ${clogBars} bars`);
+        }
+        const spokenTotal = weekly.reduce((sum, n) => sum + n, 0);
+        if (sparkCaption && spokenTotal !== Number(sparkCaption)) {
+          fail.push(`docs/index.html sparkline aria-label totals ${spokenTotal} commits but the caption advertises ${sparkCaption} — run \`npm run build:shiplog\``);
+        }
+      }
+    }
+  }
+
+  // Finally, bound the whole advertised claim against the repository it
+  // describes. Everything above only proves the four surfaces agree with each
+  // other; they agreed with each other at 282 while main stood at 308, which
+  // is why this drifted in silence for four weeks.
+  if (gitHistory.state === "complete" && sparkCaption) {
+    const shipped = spawnSync(
+      "git",
+      ["-C", repoRoot, "rev-list", "--count", defaultBranchRef],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    );
+    if (shipped.status !== 0) {
+      warn.push("Advertised commit-count check skipped — could not count commits on the default branch");
+    } else {
+      const actual = Number.parseInt(shipped.stdout.trim(), 10);
+      const advertised = Number(sparkCaption);
+      const drift = actual - advertised;
+      if (!Number.isInteger(actual)) {
+        warn.push("Advertised commit-count check skipped — the default branch commit count was unreadable");
+      } else if (Math.abs(drift) > ADVERTISED_COMMIT_MAX_DRIFT) {
+        fail.push(
+          drift > 0
+            ? `The ship log advertises ${advertised} commits and ${defaultBranchRef} carries ${actual} — ${drift} behind, past the ${ADVERTISED_COMMIT_MAX_DRIFT} tolerance. Run \`npm run build:shiplog\``
+            : `The ship log advertises ${advertised} commits but ${defaultBranchRef} carries only ${actual} — ${-drift} more than have shipped, past the ${ADVERTISED_COMMIT_MAX_DRIFT} tolerance. Run \`npm run build:shiplog\``
+        );
+      }
+    }
   }
 
   const versionClogItem = clogItems.find((item) => item.includes(`Version ${catalog.version}`));

--- a/tests/test_proof_tape_claims.py
+++ b/tests/test_proof_tape_claims.py
@@ -10,6 +10,12 @@ page and the real artifacts it describes:
      (book/01..14, and llms.txt says "14 chapters").
   3. "29,102 words of documentation" -- a figure that appears nowhere else on the
      page and counts nothing a reader can verify. An orphan.
+  4. "282 commits in 10 weeks" left standing after the repo reached 14 weeks --
+     and this file's own assertion pinned "10 weeks" as a literal, so once the
+     ship log moved on the pattern matched nothing and the failure surfaced as
+     "no ship-log commit count found elsewhere on the page" rather than as the
+     drift it was. The claim is now read as (commits, weeks) on both sides.
+     `npm run build:shiplog` writes the strip along with the rest of the stamp.
 
 These assertions are on the CLAIM, not on the fixed strings a grep found:
 
@@ -142,18 +148,26 @@ class ProofTapeNumbersAreSourced(unittest.TestCase):
         self.changelog_entries = self.html.count('class="clog-item"')
 
     def test_commit_count_reconciles_with_the_ship_log(self):
-        # Fails if the strip says 270 again: the ship log elsewhere says 282.
-        tape = re.search(r"<b>(\d+)</b>\s*commits in 10 weeks", self.block)
+        # Fails if the strip says 270 again while the ship log says something
+        # else. Both halves of the claim are read as variables, never as the
+        # literal span that happened to be true when this was written: pinning
+        # "10 weeks" into the pattern made the test go silent-then-red the first
+        # time the repo outgrew ten weeks -- it stopped finding a ship log at
+        # all and reported that as "nothing to source it from", which is a very
+        # different failure from the drift it exists to catch. The week span is
+        # part of the claim, so it is asserted, not assumed.
+        tape = re.search(r"<b>(\d+)</b>\s*commits in (\d+) weeks", self.block)
         self.assertIsNotNone(tape, "no commit count on the proof-tape")
-        shiplog = re.findall(r"(\d+)\s*commits\s*&middot;\s*10 weeks", self.rest)
+        shiplog = re.findall(r"(\d+)\s*commits\s*&middot;\s*(\d+) weeks", self.rest)
         self.assertTrue(
             shiplog, "no ship-log commit count found elsewhere on the page to source it"
         )
-        for n in shiplog:
+        for commits, weeks in shiplog:
             self.assertEqual(
-                int(n),
-                int(tape.group(1)),
-                "proof-tape commit count disagrees with the ship log on the same page",
+                (int(commits), int(weeks)),
+                (int(tape.group(1)), int(tape.group(2))),
+                "proof-tape commit claim disagrees with the ship log on the same "
+                "page -- run `npm run build:shiplog`",
             )
 
     def test_chapter_count_equals_the_real_book(self):

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -810,6 +810,164 @@ test("build-shiplog refuses to run when a ship-log card is missing", completeSou
   assert.match(build.stderr, /docs\/guide\.html: expected exactly one .*found 0 — the markup changed/);
 });
 
+function originMainCommitCount(checkoutRoot) {
+  const probe = spawnSync("git", ["-C", checkoutRoot, "rev-list", "--count", "origin/main"], { encoding: "utf8" });
+  assert.equal(probe.status, 0, probe.stderr);
+  return Number.parseInt(probe.stdout.trim(), 10);
+}
+
+// Restates the whole advertised claim at `total` while keeping the four
+// surfaces agreeing with each other, so that a validator failure can only come
+// from the comparison against git and not from one of the internal
+// cross-checks. The delta lands on the busiest week because that is the one
+// with the headroom to absorb it without going negative.
+function restateAdvertisedTotal(checkoutRoot, total) {
+  const indexPath = path.join(checkoutRoot, "docs", "index.html");
+  let text = fs.readFileSync(indexPath, "utf8");
+  const spoken = text.match(/oldest to newest: ([^"]*?) commits\./);
+  assert.ok(spoken, "fixture must carry a spoken sparkline series");
+  const weekly = spoken[1].split(/,\s*(?:and\s*)?/).map(Number);
+  const busiest = weekly.indexOf(Math.max(...weekly));
+  weekly[busiest] += total - weekly.reduce((sum, n) => sum + n, 0);
+  assert.ok(weekly[busiest] >= 0, `cannot restate the series at ${total} commits`);
+  const series = `${weekly.slice(0, -1).join(", ")}, and ${weekly[weekly.length - 1]}`;
+  text = text.replace(spoken[0], `oldest to newest: ${series} commits.`);
+  fs.writeFileSync(indexPath, text.replace(/>\d+ commits &middot; (\d+) weeks/g, `>${total} commits &middot; $1 weeks`));
+  for (const relative of ["docs/skills/index.html", "docs/guide.html"]) {
+    const page = path.join(checkoutRoot, relative);
+    const card = fs.readFileSync(page, "utf8");
+    fs.writeFileSync(page, card.replace(/>\d+ commits &middot; (\d+) weeks/g, `>${total} commits &middot; $1 weeks`));
+  }
+}
+
+// The count, the week span and the bars were three hand-copied numbers with no
+// common source, so they did not merely go stale together -- they disagreed.
+// The cards read "282 commits, 10 weeks" against a repo that had shipped 308
+// over 14, above ten bars fitted to that caption by dropping three opening
+// weeks and folding their commits onto the newest bar. Generating all of it
+// from one measurement is the fix; this asserts the surfaces come out agreeing.
+test("build-shiplog regenerates the commit-activity series on every ship-log surface", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-activity-");
+  const indexPath = path.join(checkoutRoot, "docs", "index.html");
+
+  // Stale the fixture the way the real thing was found: a caption describing a
+  // repo that no longer exists, over a bar column matching neither.
+  const staleChart = fs.readFileSync(indexPath, "utf8").replace(
+    /(<div class="clog-spark[^>]*>)[\s\S]*?(\n[ \t]*<\/div>)/,
+    '$1\n        <span style="height:40%"></span>\n        <span style="height:100%"></span>$2'
+  );
+  assert.match(staleChart, /<span style="height:40%"><\/span>/, "fixture must shorten the chart");
+  fs.writeFileSync(indexPath, staleChart);
+  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
+    const page = path.join(checkoutRoot, relative);
+    const before = fs.readFileSync(page, "utf8");
+    const after = before.replace(/>\d+ commits &middot; \d+ weeks/g, ">282 commits &middot; 10 weeks");
+    assert.notEqual(after, before, `fixture must stale ${relative}`);
+    fs.writeFileSync(page, after);
+  }
+
+  const build = spawnSync(process.execPath, [path.join(checkoutRoot, "scripts", "build-shiplog.mjs")], {
+    cwd: checkoutRoot,
+    encoding: "utf8"
+  });
+  assert.equal(build.status, 0, `${build.stdout}\n${build.stderr}`);
+
+  const text = fs.readFileSync(indexPath, "utf8");
+  const caption = text.match(/class="clog-spark-caption[^"]*">(\d+) commits &middot; (\d+) weeks/);
+  assert.ok(caption, "the homepage caption must survive the rewrite");
+  const total = Number(caption[1]);
+  const weeks = Number(caption[2]);
+  assert.equal(total, originMainCommitCount(checkoutRoot), "the caption must advertise what origin/main carries");
+  assert.ok(weeks > 10, `the fixture's history should span more than the stale ten weeks (${weeks})`);
+
+  // The chart, the series a screen reader hears, and the caption are one claim.
+  const chart = text.match(/<div class="clog-spark[^>]*>[\s\S]*?<\/div>/)[0];
+  assert.equal((chart.match(/style="height:\d+%"/g) || []).length, weeks, "one bar per advertised week");
+  const spoken = chart.match(/oldest to newest: ([^"]*?) commits\./);
+  assert.ok(spoken, "the chart must restate its series for screen readers");
+  const weekly = spoken[1].split(/,\s*(?:and\s*)?/).map(Number);
+  assert.equal(weekly.length, weeks, "the spoken series must name every week");
+  assert.equal(weekly.reduce((sum, n) => sum + n, 0), total, "the spoken series must total the advertised count");
+  // Normalized to the busiest week, so exactly one bar reaches full height.
+  assert.equal((chart.match(/style="height:100%"/g) || []).length, 1);
+
+  for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
+    const card = fs.readFileSync(path.join(checkoutRoot, relative), "utf8").match(/id="hero-shiplog"[\s\S]*?<\/a>/)[0];
+    assert.match(card, new RegExp(`class="hero-shiplog-more">${total} commits &middot; ${weeks} weeks`));
+    const bars = card.match(/<span class="hero-spark"[\s\S]*?<\/span>\s*<\/span>/)[0];
+    assert.equal((bars.match(/style="height:\d+%"/g) || []).length, weeks, `${relative} must draw one bar per week`);
+  }
+
+  const validation = runValidator(checkoutRoot);
+  assert.equal(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+});
+
+test("validator rejects a sparkline drawing fewer bars than the weeks it advertises", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-bars-");
+  const guidePath = path.join(checkoutRoot, "docs", "guide.html");
+  const guide = fs.readFileSync(guidePath, "utf8");
+  const dropped = guide.replace(/[ \t]*<span style="height:\d+%"><\/span>\n/, "");
+  assert.notEqual(dropped, guide, "fixture must drop one bar");
+  fs.writeFileSync(guidePath, dropped);
+
+  const validation = runValidator(checkoutRoot);
+  assert.notEqual(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  assert.match(validation.stderr, /docs\/guide\.html: tiny ship-log sparkline draws \d+ bars but the card advertises \d+ weeks/);
+});
+
+test("validator rejects a spoken sparkline series that does not total the advertised count", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-spoken-");
+  const indexPath = path.join(checkoutRoot, "docs", "index.html");
+  const text = fs.readFileSync(indexPath, "utf8");
+  // Speak one week louder than it shipped. The bars still match the weeks, so
+  // only the total can catch this -- and a screen reader is the one reader who
+  // would be told the wrong history.
+  const skewed = text.replace(/(oldest to newest: )(\d+)/, (_, lead, first) => `${lead}${Number(first) + 7}`);
+  assert.notEqual(skewed, text, "fixture must skew the spoken series");
+  fs.writeFileSync(indexPath, skewed);
+
+  const validation = runValidator(checkoutRoot);
+  assert.notEqual(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  assert.match(validation.stderr, /sparkline aria-label totals \d+ commits but the caption advertises \d+/);
+});
+
+// The anti-regression control. The advertised count moves on every merge, so a
+// check that failed here would turn main red the next time anything landed --
+// which is the exact failure the prepared-base guard was rewritten to remove.
+// Sitting the fixture squarely ON the bound is the point: it must pass.
+test("validator accepts an advertised commit count the default branch has moved past", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-count-lag-");
+  const shipped = originMainCommitCount(checkoutRoot);
+  assert.ok(shipped > 41, `history is too short to exercise the tolerance (${shipped} commits)`);
+  restateAdvertisedTotal(checkoutRoot, shipped - 40);
+
+  const validation = runValidator(checkoutRoot);
+  assert.equal(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+});
+
+test("validator rejects an advertised commit count past the drift tolerance", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-count-stale-");
+  const shipped = originMainCommitCount(checkoutRoot);
+  assert.ok(shipped > 42, `history is too short to exercise the tolerance (${shipped} commits)`);
+  restateAdvertisedTotal(checkoutRoot, shipped - 41);
+
+  const validation = runValidator(checkoutRoot);
+  assert.notEqual(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  assert.match(validation.stderr, /41 behind, past the 40 tolerance/);
+});
+
+// The other direction of the same tolerance. A page may lag the branch it
+// describes; it may not describe a history that does not exist.
+test("validator rejects an advertised commit count far above what has shipped", completeSourceHistoryTest, (t) => {
+  const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-shiplog-count-invented-");
+  const shipped = originMainCommitCount(checkoutRoot);
+  restateAdvertisedTotal(checkoutRoot, shipped + 41);
+
+  const validation = runValidator(checkoutRoot);
+  assert.notEqual(validation.status, 0, `${validation.stdout}\n${validation.stderr}`);
+  assert.match(validation.stderr, /41 more than have shipped, past the 40 tolerance/);
+});
+
 test("validator rejects an existing released hash unreachable from the default branch", completeSourceHistoryTest, (t) => {
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-released-unreachable-");
 


### PR DESCRIPTION
## The bug

The three `#hero-shiplog` cards and the `#changelog` caption advertised **282 commits · 10 weeks** against a repo that has shipped **312 over 14**. Measured on `origin/main`:

```
$ git rev-list --count origin/main
312
$ git log --reverse --pretty=format:%cI origin/main | head -1
2026-05-23...          # 14 weekly windows back
```

The four surfaces agreed *with each other*, which is exactly why `scripts/validate-skill-pack.mjs` stayed green: it cross-checked the cards against one another and against the caption, and never against git.

## The sparkline is the part that shows how far it had gone

`.hero-spark` and `.clog-spark` draw one bar per week. The ten bars had been fitted to the caption after the fact — the repo's three quiet opening weeks were dropped from the series and their six commits added onto the newest bar, so the spoken `aria-label` would still total the advertised 282:

| | series | sum |
|---|---|---|
| what git says (first 13 windows) | `5, 0, 1, 2, 64, 25, 33, 18, 19, 29, 27, 32, 27` | 282 |
| what the page said | `2, 64, 25, 33, 18, 19, 29, 27, 32, 33` | 282 |

Nine buckets match verbatim; the leading `5, 0, 1` is gone and the last bar carries their 6. A screen reader was handed a history the repository never had.

So bumping the caption to 14 weeks alone would have left a ten-bar chart arguing with its own label. Bars, count and span have to move together.

## A sixth surface nobody had listed

`#proof-tape` promises, in a comment directly above itself, that every number on the strip is sourced further down the page. It still read `282 commits in 10 weeks` with nothing left on the page to source it — and the marquee duplicates its whole track, so the claim exists **twice**.

`tests/test_proof_tape_claims.py` was already guarding that reconciliation, but had pinned `10 weeks` as a literal in both halves of its pattern. Once the repo outgrew ten weeks it stopped finding a ship log at all and reported that as *"no ship-log commit count found elsewhere on the page to source it"* — a different failure from the drift it exists to catch. It now reads the claim as `(commits, weeks)` on both sides.

## The fix

`scripts/build-shiplog.mjs` (`npm run build:shiplog`) measures commit activity once — seven-day windows counted back from the newest commit on `origin/main`, bucketed on each commit's own calendar date so the boundaries match `git log --date=short` rather than re-binning by UTC — and writes **every** surface that repeats it from that one measurement:

- the three `#hero-shiplog` cards and their bar columns
- the `#changelog` chart, its caption, and its spoken `aria-label` series
- both marquee copies of the `#proof-tape` claim

`rewrite` now takes the number of copies the markup carries, so the duplicated marquee track fails loudly instead of being half-updated.

## Validator

Internal consistency first — cards must agree on the week span as well as the count, each bar column must have one bar per week it advertises, and the chart's spoken series must have one entry per bar and total the caption.

Those only prove the surfaces agree with each other, which they did at 282 while main stood at 308. So the advertised count is finally bounded against `git rev-list --count` on the default branch.

**A tolerance, not equality, and deliberately symmetric.** The count moves on every single merge, so pinning it exactly would turn `main` red the next time anything landed — the failure #114 removed from the prepared-base guard. Symmetric because which commit `origin/main` names depends on the shape of the checkout: CI builds a merge ref, and the test fixtures repoint `origin/main` at their own HEAD, so an honest branch can legitimately measure a count *below* the one the page was generated from. Failing that direction on sight would break honest branches and the fixtures alike. 40 matches the existing `PREPARED_BASE_MAX_DRIFT` for the same reason: roughly two of the longest release cycles seen here.

This was not hypothetical — `origin/main` moved three times mid-review (#114, #115, and two more), 309 → 312.

## Verification

Every new assertion was confirmed to fail on the drift it names, and the boundary was checked in both directions:

| State | Result |
|---|---|
| bar column one short of the advertised weeks | **fail**, naming the page |
| spoken series 13 entries against 14 bars | **fail** |
| spoken series not totalling the caption | **fail** |
| advertised count exactly 40 behind | **pass** ← must not go red |
| advertised count 41 behind | **fail**, naming the fix command |
| advertised count 41 above what shipped | **fail** |
| proof-tape commits drifting alone | **fail** — `(312, 14) != (270, 14)` |
| proof-tape weeks drifting alone | **fail** — `(312, 14) != (312, 10)` |
| one marquee copy of the claim removed | generator **aborts** |

`32/32` validator-runtime tests and `47/47` python tests pass; `validate`, `validate-trigger-routing`, and both book `--check` builds are green. The generator is idempotent and `--check` reports current.

## Also

`.hero-spark` gets a fixed 100px track with flexible bars. Generating one bar per week means the column now grows every week, and at the old fixed `5px` + `3px` gap it would have reached ~317px within six months and crowded out the text beside it. The separator rides on each bar as a transparent border rather than a flex gap so that it shrinks along with them — it still floors at 2px, so the track holds to roughly 50 weeks, and the comment says so rather than claiming more.