### PR TITLE
JSON-clone thought state: the Workflow VM provides no structuredClone

### DIFF
--- a/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+++ b/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
@@ -481,9 +481,13 @@ const deepFreeze = value => {
   return Object.freeze(value)
 }
 
+// Not structuredClone: the Workflow VM does not provide it, and thought state is
+// always JSON-shaped (it comes from schema-validated agent output).
+const jsonClone = value => value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+
 const createThought = ({ id, parentIds = [], operationId, operation, depth, state, score = null, status = 'active' }) =>
   Object.freeze({ id, parentIds: Object.freeze([...parentIds]), operationId, operation, depth,
-    state: deepFreeze(structuredClone(state)), score: score && deepFreeze({ ...score }), status })
+    state: deepFreeze(jsonClone(state)), score: score && deepFreeze({ ...score }), status })
 
 const createOperation = ({ id, type, predecessorIds = [], execute }) => ({
   id, type, predecessorIds: [...predecessorIds], successorIds: [], execute,


### PR DESCRIPTION
`createThought` runs for every thought in the graph, and it calls `structuredClone` on the state. **The Workflow VM does not provide that global**, so the first `Generate` call throws and takes the whole run with it.

This is not theoretical. The fix was written in the personal repo as `11cc1cd`, after exactly that:

> First Generate call crashed the whole run after 18 agents of evidence.

## Why it's missing here

[#120](https://github.com/JasonColapietro/suede-creator-skills/pull/120) bundled the helpers and the chunked applier when the personal dev copy was retired, and it got the important parts right — the helper contract came across, and this pack's safety pass survived intact (`gateVerified` 3, `pathKey` 16, `UNVERIFIED` 3, unchanged from before the merge).

But `git log --all -S 'jsonClone'` in this repo returns **zero commits**. This one line stayed behind, in a repo whose copy has since been stubbed to a thin route ([suede-personal-skills#25](https://github.com/JasonColapietro/suede-personal-skills/pull/25)). It now exists only in that repo's git history.

## The change

JSON round-trip cloning is equivalent for this value: thought state is always JSON-shaped, because it comes from schema-validated agent output.

Restored verbatim from `11cc1cd`, comment included, so the next person reading `createThought` learns the constraint instead of reaching for `structuredClone` again.

## Verification

`node scripts/validate-skill-pack.mjs` passes; `npm run ci` run locally. No `structuredClone(` call sites remain — the only surviving occurrence of the word is the explanatory comment.

## Also dropped in that merge, not fixed here

`cacheEpoch` is at 0 occurrences in this pack. It's a resume cache-buster that re-runs the Gate live (e.g. after a sandbox-profile fix) without redoing earlier stages. Not a crash, and it touches Gate caching, so it doesn't belong in a one-line bugfix — flagging it rather than bundling it.

The general lesson: when a dev copy is retired into the pack, diff the retired copy against the pack **before** deleting it.
