### PR TITLE
Pin the worktree verifier's realpath to the macOS /bin path

### DIFF
--- a/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+++ b/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
@@ -897,9 +897,12 @@ evidence.worktree = scout.worktreePath
 evidence.baseSha = scout.baseSha
 evidence.hazards = scout.hazards
 const candidatePathAuditCommand = `${helperCommand('candidate-audit.cjs')} ${REPO_SHELL} ${WORKTREE_SHELL} '${encodeBase64(JSON.stringify(scout.candidateFiles))}'`
+// macOS ships realpath at /bin/realpath, not the Linux /usr/bin path — and this
+// workflow is macOS-only (scout-setup probes /usr/bin/sandbox-exec first), so the
+// /usr/bin pin exited 127 on every supported host and failed each attestation closed.
 const worktreeAuditCommands = [
-  `/usr/bin/realpath ${REPO_SHELL}`,
-  `/usr/bin/realpath ${WORKTREE_SHELL}`,
+  `/bin/realpath ${REPO_SHELL}`,
+  `/bin/realpath ${WORKTREE_SHELL}`,
   `git -C ${REPO_SHELL} worktree list --porcelain`,
   `git -C ${REPO_SHELL} rev-parse --path-format=absolute --git-common-dir`,
   `git -C ${WORKTREE_SHELL} rev-parse --path-format=absolute --git-common-dir`,


### PR DESCRIPTION
## What

The ScoutVerify Bash clamp pinned `/usr/bin/realpath`, but macOS ships `realpath` at `/bin/realpath` — `/usr/bin` is the Linux location. Since this workflow is macOS-only by construction (scout-setup probes `/usr/bin/sandbox-exec` before anything else), the pinned path exited 127 on every host the workflow can actually run on. The verifier correctly refused to assume and reported `realPathWithinAllowedFamily: false`, so **every run halted at `invalid scout worktree`** with 2 of its budgeted calls spent.

## Evidence

Found live 2026-08-23 running the workflow against `~/sing` on Darwin 25.6.0:

- `/usr/bin/realpath` → exit 127, `no such file or directory`
- `/bin/realpath` on the same host resolves both paths, byte-identical to their literals (no symlinks anywhere in the chain)
- Every other attestation check passed: registered worktree, matching common dirs, HEAD = origin/main = expected SHA, clean porcelain, empty `unsafeCandidateFiles`

## Scope

Two command strings plus an explanatory comment. The verifier's prompt/instruction text is untouched, the fail-closed semantics are untouched, and the bundled test suite (10 tests driving the real script) passes.