### PR TITLE
Normalize constraint identity before the provenance-audit match

### DIFF
--- a/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+++ b/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
@@ -1146,9 +1146,20 @@ An over-broad constraint invented from a real file is still a misread.`,
     )
   : null
 
+// The skeptic re-cites each constraint from the file it actually opened, so the same
+// source arrives spelled through the worktree or the repo root, with or without :line
+// suffixes — two of three live runs halted here on that spelling drift alone. Match on
+// a spelling-normalized identity; the original claimed constraint objects, not these
+// keys, are what survive into evidence, and strings equal before normalization remain
+// equal after it.
+const normalizeProvenancePart = value => String(value)
+  .split(scout.worktreePath + '/').join('')
+  .split(REPO + '/').join('')
+  .replace(/:\d+(?:[-,]\d+)*(?!\w)/g, '')
+  .trim().toLowerCase().replace(/\s+/g, ' ')
 const constraintIdentity = item => item && [item.rule, item.source, item.breakingItMeans]
   .every(value => typeof value === 'string')
-  ? `${item.rule}\u0000${item.source}\u0000${item.breakingItMeans}`
+  ? [item.rule, item.source, item.breakingItMeans].map(normalizeProvenancePart).join('\u0000')
   : null
 const identityCounts = items => {
   const counts = new Map()


### PR DESCRIPTION
## What

The constraint provenance audit matched claimed vs audited records on the exact `rule\0source\0breakingItMeans` string. The skeptic is instructed to open each cited source in the run's worktree, so it legitimately re-cites the same source spelled through the worktree path instead of the repo root, or with a `:line` suffix on one side only. Exact-string matching then declares the audit incomplete and halts the run.

## Evidence — two of three live runs killed by spelling drift alone

Running against `~/sing` on 2026-08-23, identical constraint text both times:

- `wf_90edb95b-c5f`: `lib/audio/frame-clock.ts:32` vs `lib/audio/frame-clock.ts`
- `wf_fb9c322c-78c`: `/Users/.../sing/components/warmups/exercise-player.test.ts:1-11` vs `/Users/.../sing.worktrees/ship-cb1b1260-.../components/warmups/exercise-player.test.ts:1-11`

## Fix

Normalize identity parts before matching: strip the run-worktree and repo path prefixes, strip `:N`/`:N-N`/`:N,N` line suffixes, collapse whitespace, casefold — the same treatment `normalizeDefectPart` already applies to refutation-defect matching in this file. The multiset count logic is unchanged; strings equal before normalization remain equal after; the original claimed constraint objects (never the normalized keys) are what flow into evidence and bind the planner.

Verified against both live-run fixtures (now match) and URL/plain-text sources (untouched). Bundled suite: 10/10 pass.