### PR TITLE
Release 0.15.0 in the ship log, and unstick the fixtures that assumed it hadn't

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,6 +11,7 @@ abstract: >-
   Instagram growth, artist-campaign tools, and creator rights utilities.
 type: software
 version: 0.15.0
+date-released: 2026-08-21
 authors:
   - family-names: Colapietro
     given-names: Jason

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1182,7 +1182,7 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
         <div class="shell">
           <h2 id="notes-headline">Field notes.</h2>
           <p class="section-sub">The design decisions behind the pack, written up in full: what a skill costs, how routing avoids collisions, and where memory actually belongs.</p>
-          <a id="hero-shiplog" data-status="prepared" href="./#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Read the full changelog on the homepage.">
+          <a id="hero-shiplog" data-status="released" href="./#changelog" aria-label="Ship log. Released entry August 21, 2026: Graph search replaces the fixed shipping DAG. Read the full changelog on the homepage.">
             <span class="hero-spark" aria-hidden="true">
               <span style="height:8%"></span>
               <span style="height:0%"></span>
@@ -1197,12 +1197,12 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
               <span style="height:42%"></span>
               <span style="height:50%"></span>
               <span style="height:56%"></span>
-              <span style="height:33%"></span>
+              <span style="height:45%"></span>
             </span>
             <span class="hero-shiplog-text">
-              <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
+              <span class="hero-shiplog-top">Released Aug 21 <b>&middot; d8a6ae8</b></span>
               <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-              <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+              <span class="hero-shiplog-more">320 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
             </span>
           </a>
           <div class="notes">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3609,7 +3609,7 @@
   <div class="tape-inner">
     <ul class="tape-track">
       <li><b>71</b> skills, open source</li>
-      <li><b>312</b> commits in 14 weeks</li>
+      <li><b>320</b> commits in 14 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -3618,7 +3618,7 @@
     </ul>
     <ul class="tape-track" aria-hidden="true">
       <li><b>71</b> skills, open source</li>
-      <li><b>312</b> commits in 14 weeks</li>
+      <li><b>320</b> commits in 14 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -3655,7 +3655,7 @@
           <a id="hero-cta-secondary" href="#scorecard">See the benchmarks</a>
         </div>
 
-        <a id="hero-shiplog" class="hero-anim" data-status="prepared" href="#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the full changelog.">
+        <a id="hero-shiplog" class="hero-anim" data-status="released" href="#changelog" aria-label="Ship log. Released entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the full changelog.">
           <span class="hero-spark" aria-hidden="true">
             <span style="height:8%"></span>
             <span style="height:0%"></span>
@@ -3670,12 +3670,12 @@
             <span style="height:42%"></span>
             <span style="height:50%"></span>
             <span style="height:56%"></span>
-            <span style="height:33%"></span>
+            <span style="height:45%"></span>
           </span>
           <span class="hero-shiplog-text">
-            <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
+            <span class="hero-shiplog-top">Released Aug 21 <b>&middot; d8a6ae8</b></span>
             <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-            <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+            <span class="hero-shiplog-more">320 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
           </span>
         </a>
       </div>
@@ -3818,9 +3818,9 @@
       <h2 id="changelog-headline" class="clog-headline reveal reveal-d1">A review pack had better survive its own review.</h2>
       <p class="clog-sub reveal reveal-d1">So the work ships in public. Released entries cite the commit that landed on <code>main</code>. A newest prepared entry is explicitly unreleased and cites only the current branch's merge base until review and merge provide a landing hash. No "various improvements."</p>
 
-      <p class="clog-fresh reveal reveal-d2">Version 0.15.0 prepared Aug 21, 2026 <span id="clog-fresh-rel" data-iso="2026-08-21"></span></p>
+      <p class="clog-fresh reveal reveal-d2">Version 0.15.0 released Aug 21, 2026 <span id="clog-fresh-rel" data-iso="2026-08-21"></span></p>
 
-      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last fourteen weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, 29, 27, 32, 36, and 21 commits.">
+      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last fourteen weeks, oldest to newest: 5, 0, 1, 2, 64, 25, 33, 18, 19, 29, 27, 32, 36, and 29 commits.">
         <span style="height:8%"></span>
         <span style="height:0%"></span>
         <span style="height:2%"></span>
@@ -3834,9 +3834,9 @@
         <span style="height:42%"></span>
         <span style="height:50%"></span>
         <span style="height:56%"></span>
-        <span style="height:33%"></span>
+        <span style="height:45%"></span>
       </div>
-      <p class="clog-spark-caption reveal reveal-d2">312 commits &middot; 14 weeks &middot; newest on the right</p>
+      <p class="clog-spark-caption reveal reveal-d2">320 commits &middot; 14 weeks &middot; newest on the right</p>
 
       <div class="clog-filters reveal reveal-d2" role="group" aria-label="Filter changelog entries by type">
         <button class="clog-filter" type="button" data-filter="all" aria-pressed="true">All</button>
@@ -3850,11 +3850,11 @@
     <div class="reveal reveal-d1">
       <ol class="clog-list" id="clog-list">
 
-        <li class="clog-item" data-type="new" data-status="prepared">
+        <li class="clog-item" data-type="new">
           <p class="clog-meta">
             <span class="clog-date">2026-08-21</span>
             <span class="clog-tag">Orchestration</span>
-            <a class="clog-hash clog-base" href="https://github.com/JasonColapietro/suede-creator-skills/commit/1280b11" target="_blank" rel="noopener" aria-label="View base commit 1280b11 on GitHub">base 1280b11</a>
+            <a class="clog-hash" href="https://github.com/JasonColapietro/suede-creator-skills/commit/d8a6ae8" target="_blank" rel="noopener" aria-label="View commit d8a6ae8 on GitHub">d8a6ae8</a>
           </p>
           <h3 class="clog-title">Graph search replaces the fixed shipping DAG</h3>
           <p class="clog-detail">Version 0.15.0 replaces <code>suede-graph-flo-xr</code>'s fixed single-plan DAG with a bounded Graph-of-Thoughts search. It generates competing plans, scores and prunes them, adversarially refutes and improves survivors, aggregates compatible lanes, then builds, reviews, and gates only the selected plan. Light, standard, and deep stop at 55, 110, and 200 total agent calls. Production access remains read-only; the skill never deploys.</p>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -567,7 +567,7 @@
     <h1>Every skill. One honest line each.</h1>
     <p class="lead">Every skill in the pack is a plain-Markdown <code>SKILL.md</code> folder you can read before an agent runs it. <strong>Six specialities:</strong> ship (13), craft (9), get found (12), demand channels (8), revenue &amp; retention (15), and strategy &amp; rights (14). Each one breaks down further into sub-lanes, so no bucket is a wall of names. This catalog links each skill to its deep docs and its source folder on GitHub. No sign-up, no telemetry, nothing to uninstall but a folder.</p>
 
-    <a id="hero-shiplog" data-status="prepared" href="#changelog" aria-label="Ship log. Prepared entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the changelog.">
+    <a id="hero-shiplog" data-status="released" href="#changelog" aria-label="Ship log. Released entry August 21, 2026: Graph search replaces the fixed shipping DAG. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
         <span style="height:8%"></span>
         <span style="height:0%"></span>
@@ -582,12 +582,12 @@
         <span style="height:42%"></span>
         <span style="height:50%"></span>
         <span style="height:56%"></span>
-        <span style="height:33%"></span>
+        <span style="height:45%"></span>
       </span>
       <span class="hero-shiplog-text">
-        <span class="hero-shiplog-top">Prepared Aug 21 <b>&middot; base 1280b11</b></span>
+        <span class="hero-shiplog-top">Released Aug 21 <b>&middot; d8a6ae8</b></span>
         <span class="hero-shiplog-title">Graph search replaces the fixed shipping DAG</span>
-        <span class="hero-shiplog-more">312 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+        <span class="hero-shiplog-more">320 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
       </span>
     </a>
 

--- a/tests/test_validator_runtime.mjs
+++ b/tests/test_validator_runtime.mjs
@@ -373,10 +373,13 @@ test("packaged validation rejects MCP QA and release metadata drift", (t) => {
 
   const citationPath = path.join(packagedRoot, "CITATION.cff");
   const citationOriginal = fs.readFileSync(citationPath, "utf8");
-  const citation = citationOriginal.replace(
-    /^(version:\s*[^\n]+)$/m,
-    "$1\ndate-released: 2099-01-01"
-  );
+  // Replace the date rather than only inserting one: a released checkout
+  // already carries date-released, and a second key would leave the fixture
+  // asserting against whichever copy the validator's regex happened to reach
+  // first.
+  const citation = /^date-released:/m.test(citationOriginal)
+    ? citationOriginal.replace(/^date-released:[^\n]*$/m, "date-released: 2099-01-01")
+    : citationOriginal.replace(/^(version:\s*[^\n]+)$/m, "$1\ndate-released: 2099-01-01");
   assert.notEqual(citation, citationOriginal, "test fixture must add a false prepared-release date");
   fs.writeFileSync(citationPath, citation);
 
@@ -385,10 +388,15 @@ test("packaged validation rejects MCP QA and release metadata drift", (t) => {
   const catalog = JSON.parse(
     fs.readFileSync(path.join(packagedRoot, "mcp", "catalog.json"), "utf8")
   );
-  const poisonedDocs = docs.replace(
-    `<p class="clog-detail">Version ${catalog.version}`,
-    `<p class="clog-detail">Release ${catalog.version}`
-  );
+  const poisonedDocs = docs
+    .replace(
+      `<p class="clog-detail">Version ${catalog.version}`,
+      `<p class="clog-detail">Release ${catalog.version}`
+    )
+    // The date-released assertion below is the prepared-state rule, and the
+    // version pill is where the validator reads that state from. Inheriting it
+    // from the repo meant this case only ran while a release was in flight.
+    .replace(/(<p class="clog-fresh[^"]*">Version \S+ )released/, "$1prepared");
   assert.notEqual(poisonedDocs, docs, "test fixture must remove the release-version marker");
   fs.writeFileSync(docsPath, poisonedDocs);
 
@@ -520,11 +528,7 @@ test(
   }
 );
 
-// The prepared base the site currently advertises. Tests poison THIS value
-// rather than whatever `merge-base HEAD origin/main` resolves to: the two are
-// no longer required to be equal, so deriving the search string from git would
-// make these fixtures silently match nothing the first time the site's stamp
-// and the merge base diverged.
+// The prepared base the pages advertise, read back as a post-condition.
 function preparedBaseIn(checkoutRoot) {
   const docs = fs.readFileSync(path.join(checkoutRoot, "docs", "index.html"), "utf8");
   const base = docs.match(/class="[^"]*\bclog-base\b[^"]*"[^>]*>base ([0-9a-f]{7,40})</)?.[1];
@@ -532,22 +536,92 @@ function preparedBaseIn(checkoutRoot) {
   return base;
 }
 
-// Idempotent on purpose: a fixture may ask for the base the pages already
-// advertise. The post-condition, not the presence of a diff, is what proves the
-// fixture landed.
-function restampPreparedBase(checkoutRoot, replacement) {
-  const current = preparedBaseIn(checkoutRoot);
+// Anchored on markup that must already exist. A rewrite that silently matches
+// nothing would leave the checkout in a state the test does not describe, and
+// then fail somewhere unrelated to the rule under test.
+function rewriteFixture(text, label, pattern, replacement) {
+  const next = text.replace(pattern, replacement);
+  assert.notEqual(next, text, `test fixture must rewrite ${label}`);
+  return next;
+}
+
+// Build the whole prepared state instead of flipping one attribute and
+// inheriting the rest from the repo. The validator cross-checks the newest
+// changelog entry, the version pill, the tiny ship-log box on all three pages,
+// and CITATION.cff against each other, so a fixture that sets data-status alone
+// leaves the page internally inconsistent and fails on that mismatch rather
+// than on the rule it means to exercise.
+//
+// These fixtures used to inherit the prepared state from whatever the repo
+// happened to be in. That only holds while a release is in flight: the suite
+// was green because nothing had shipped, and every prepared case would have
+// broken on the next release whatever else changed. Constructing the state here
+// is what makes them independent of the repo's own release cycle.
+function makePreparedChangelog(checkoutRoot, baseHash) {
+  const indexPath = path.join(checkoutRoot, "docs", "index.html");
+  let index = fs.readFileSync(indexPath, "utf8");
+
+  // Only the first .clog-item moves. A prepared entry below the newest one is a
+  // different fixture, and a rule of its own.
+  index = rewriteFixture(
+    index,
+    "the newest changelog entry's status",
+    /<li class="clog-item"([^>]*)>/,
+    (_match, attrs) => `<li class="clog-item"${attrs.replace(/\s*data-status="[^"]*"/, "")} data-status="prepared">`
+  );
+  // A prepared entry cites a merge base and must not claim a landing hash. The
+  // two classes together are what the validator reads as "base, not hash":
+  // `class="clog-hash"` stops matching once `clog-base` follows it.
+  index = rewriteFixture(
+    index,
+    "the newest entry's commit anchor",
+    /<a class="clog-hash(?: clog-base)?" href="([^"]*\/commit\/)[0-9a-f]{7,40}"([^>]*?)aria-label="View (?:base )?commit [0-9a-f]{7,40} on GitHub">(?:base )?[0-9a-f]{7,40}<\/a>/,
+    (_match, hrefLead, middle) =>
+      `<a class="clog-hash clog-base" href="${hrefLead}${baseHash}"${middle}aria-label="View base commit ${baseHash} on GitHub">base ${baseHash}</a>`
+  );
+  index = rewriteFixture(
+    index,
+    "the version pill",
+    /(<p class="clog-fresh[^"]*">Version \S+ )released/,
+    "$1prepared"
+  );
+  fs.writeFileSync(indexPath, index);
+
   for (const relative of ["docs/index.html", "docs/skills/index.html", "docs/guide.html"]) {
     const file = path.join(checkoutRoot, relative);
-    const original = fs.readFileSync(file, "utf8");
-    const restamped = current === replacement ? original : original.replaceAll(current, replacement);
-    if (current !== replacement) {
-      assert.notEqual(restamped, original, `test fixture must replace the prepared base in ${relative}`);
-    }
-    assert.ok(restamped.includes(replacement), `test fixture must stamp ${replacement} into ${relative}`);
-    fs.writeFileSync(file, restamped);
+    let text = fs.readFileSync(file, "utf8");
+    text = rewriteFixture(
+      text,
+      `the ${relative} card status`,
+      /(<a id="hero-shiplog"[^>]*\bdata-status=")[^"]*(")/,
+      "$1prepared$2"
+    );
+    text = rewriteFixture(
+      text,
+      `the ${relative} card aria-label`,
+      /(<a id="hero-shiplog"[^>]*\baria-label="Ship log\. )Released( entry )/,
+      "$1Prepared$2"
+    );
+    text = rewriteFixture(
+      text,
+      `the ${relative} card stamp`,
+      /(<span class="hero-shiplog-top">)(?:Released|Prepared) ([A-Z][a-z]{2} \d{1,2}) <b>&middot; (?:base )?[0-9a-f]{7,40}(<\/b>)/,
+      `$1Prepared $2 <b>&middot; base ${baseHash}$3`
+    );
+    fs.writeFileSync(file, text);
   }
-  assert.equal(preparedBaseIn(checkoutRoot), replacement, "test fixture must leave the pages advertising the new base");
+
+  // An unreleased version carries no release date, so CITATION.cff is part of
+  // the prepared state too.
+  const citationPath = path.join(checkoutRoot, "CITATION.cff");
+  const citation = fs.readFileSync(citationPath, "utf8");
+  fs.writeFileSync(citationPath, citation.replace(/^date-released:[^\n]*\n/m, ""));
+
+  assert.equal(
+    preparedBaseIn(checkoutRoot),
+    baseHash,
+    "test fixture must leave the pages advertising the prepared base"
+  );
 }
 
 // Points the fixture's origin/main at its own HEAD, which is the state these
@@ -631,7 +705,7 @@ test("validator accepts a prepared changelog anchored to the current merge base"
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-");
   // Exactly what `npm run build:shiplog` writes: the merge base, which in this
   // fixture is HEAD itself. Drift is zero, the strictest case the guard allows.
-  restampPreparedBase(checkoutRoot, shortRev(checkoutRoot, "HEAD"));
+  makePreparedChangelog(checkoutRoot, shortRev(checkoutRoot, "HEAD"));
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -651,7 +725,7 @@ test("validator accepts a prepared changelog base that origin/main has moved pas
     overtaken.distance >= 1 && overtaken.distance <= 40,
     `fixture must sit behind origin/main but inside the bound (${overtaken.distance})`
   );
-  restampPreparedBase(checkoutRoot, overtaken.rev);
+  makePreparedChangelog(checkoutRoot, overtaken.rev);
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -670,7 +744,7 @@ test("validator rejects a prepared changelog base that has fallen far behind ori
   assert.ok(available > 41, `history is too short to exercise the drift bound (${available} commits)`);
   const stale = baseBehindOriginMain(checkoutRoot, 41);
   assert.ok(stale.distance > 40, `fixture must sit past the limit (${stale.distance})`);
-  restampPreparedBase(checkoutRoot, stale.rev);
+  makePreparedChangelog(checkoutRoot, stale.rev);
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -704,7 +778,7 @@ test("validator rejects a prepared changelog base unreachable from origin/main",
     }
   );
   assert.equal(unreachable.status, 0, unreachable.stderr);
-  restampPreparedBase(checkoutRoot, unreachable.stdout.trim().slice(0, 7));
+  makePreparedChangelog(checkoutRoot, unreachable.stdout.trim().slice(0, 7));
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -714,7 +788,7 @@ test("validator rejects a prepared changelog base unreachable from origin/main",
 
 test("validator rejects an unresolvable prepared changelog base", completeSourceHistoryTest, (t) => {
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-validator-prepared-missing-");
-  restampPreparedBase(checkoutRoot, "0000001");
+  makePreparedChangelog(checkoutRoot, "0000001");
 
   const validation = runValidator(checkoutRoot);
   const diagnostics = `${validation.stdout}\n${validation.stderr}`;
@@ -729,6 +803,10 @@ test("validator rejects an unresolvable prepared changelog base", completeSource
 test("build-shiplog propagates one changelog edit to every ship-log card", completeSourceHistoryTest, (t) => {
   const checkoutRoot = checkoutWithOriginMainAtHead(t, "suede-build-shiplog-");
   const indexPath = path.join(checkoutRoot, "docs", "index.html");
+  // The prepared path is the one worth pinning here — it is the state where the
+  // generator, not the author, decides the stamp. Construct it rather than
+  // inheriting whatever the repo last shipped.
+  makePreparedChangelog(checkoutRoot, shortRev(checkoutRoot, "HEAD"));
 
   // A title carrying an internal period, because the card's aria-label reads as
   // a sentence and a naive anchor on the first ". " truncates it there.
@@ -1021,13 +1099,20 @@ test("validator rejects a prepared changelog item below the newest entry", compl
   const docsPath = path.join(checkoutRoot, "docs", "index.html");
   const docs = fs.readFileSync(docsPath, "utf8");
   let seen = 0;
-  const poisoned = docs.replace(/<li class="clog-item" data-type="new">/g, (match) => {
+  // Mark the second entry, never the first. The rule under test is that a
+  // prepared item may not sit below the newest one, so the fixture has to leave
+  // a released entry above it. Marking the first entry only exercised that rule
+  // while the repo's own newest entry was already prepared and this replace
+  // therefore skipped it; once one shipped, this marked the newest entry, which
+  // is legal, and the case stopped testing anything.
+  const poisoned = docs.replace(/<li class="clog-item"([^>]*)>/g, (match, attrs) => {
     seen += 1;
-    return seen === 1
-      ? '<li class="clog-item" data-type="new" data-status="prepared">'
+    return seen === 2 && !attrs.includes("data-status")
+      ? `<li class="clog-item"${attrs} data-status="prepared">`
       : match;
   });
-  assert.ok(seen >= 1, "test fixture must contain a released changelog item after the prepared entry");
+  assert.ok(seen >= 2, "test fixture must contain a changelog item below the newest entry");
+  assert.notEqual(poisoned, docs, "test fixture must mark a lower changelog item prepared");
   fs.writeFileSync(docsPath, poisoned);
 
   const validation = runValidator(checkoutRoot);


### PR DESCRIPTION
0.15.0's changelog entry has sat `prepared` on main since #105, long after the work it describes landed. Prepared means unreleased: the entry cites the merge base its branch was cut from and deliberately claims no landing commit, and the version pill, the three tiny ship-log boxes and `CITATION.cff` all read that state back off it. The documented next step, once the branch merges, is to flip the entry to released with the hash the merge produced.

This is that flip, citing `d8a6ae8` — the commit #105 landed as, and an ancestor of `origin/main`.

## What is hand-edited, and what is generated

Only the newest changelog entry and `CITATION.cff` are hand-edited. Since #119 the stamp is generated, so the version pill and the three `#hero-shiplog` cards are `npm run build:shiplog` propagating that one edit outward. The same run refreshed the commit-activity series it measures from `origin/main`, 312 commits to 320, across the cards, the `#changelog` chart, its spoken aria-label and both marquee copies of the `#proof-tape` claim.

## The fixtures

The flip broke eight tests, which is the more useful finding. They built a "prepared" state by restamping the base commit the pages already advertised, inheriting status, pill, cards and `CITATION.cff` from whatever state the repo happened to be in. That only holds while a release is in flight — the suite was green because nothing had shipped, and every prepared case would have failed on the next release whatever else changed.

They now construct the whole prepared state through one `makePreparedChangelog` helper, so they no longer depend on the repo's own release cycle.

The ordering test had the same flaw in reverse. It marked the first `.clog-item` carrying no `data-status`, which while the newest entry was prepared meant the *second* one — exercising "a prepared item must be the newest entry" by accident. Once the newest entry became released the same replace marked the newest entry, which is legal, and the case stopped testing its own rule. It now marks the second entry explicitly and asserts a released one remains above it.

## Verification

- `npm run validate` green.
- Confirmed the fixtures fail *without* this change: on a released tree the old prepared test fails with `docs/index.html must advertise a prepared .clog-base commit`, and the release-metadata test reports the date mismatch instead of the prepared-state rule it means to assert.
- All four changed cases pass with it: the prepared-base tests, `packaged validation rejects MCP QA and release metadata drift`, `build-shiplog propagates one changelog edit to every ship-log card`, and `validator rejects a prepared changelog item below the newest entry`.
- Full `npm test` running alongside CI.

## Note on scope

This supersedes an earlier local branch that also carried two skill edits. Both had already landed independently — the seo-audit Lane 4 chunking text via #108, and the `agentNamespace` prose via #118 (in `skills/suede-graph-flo-xr/`, after the rename in #112). Replaying them was what produced conflicts in the book corpus and its generated artifacts; dropped here, the book needs no regeneration and `build-book.mjs --check` confirms it is current.