### PR TITLE
Give the book count guard a writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,30 @@ The above is about not asking permission. It is not license to skip proof.
   merge rewrites the SHA, so "unmerged commits" does not mean unmerged work.
 - If something couldn't be verified, say so plainly rather than implying it was.
 
+## Adding or removing a skill: run `npm run fix:counts`
+
+The book quotes measurements of the pack in prose — how many `SKILL.md` files
+there are, what they total in bytes, how many descriptions close with a
+`NOT FOR:` clause. `scripts/validate-skill-pack.mjs` guards every one of them
+against a live measurement, so changing the skill set turns dozens of those
+checks red at once. Adding a single skill produced 45 failures.
+
+Do not hand-edit the figures. Run:
+
+```
+npm run fix:counts     # rewrites every stale count from the live measurement
+npm run build:book     # regenerates BOOK.md, the PDF and docs/book from those sources
+```
+
+`--fix` refuses to write a value its own check could no longer read — several
+patterns match only a hyphenated number word, so writing a round one
+("Seventy") would produce correct prose the guard can no longer see. When it
+refuses it names the sentence: reword the prose and update the regex together.
+
+**Counts inside dated posts under `docs/blog/` are deliberately frozen.** They
+are historical statements at stable URLs and they carry SEO weight in `<title>`,
+`meta description`, `og:` tags and JSON-LD. Do not "correct" them.
+
 ## Agent skills
 
 ### Issue tracker

--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "test:triggers": "node --test tests/test_trigger_routing.mjs",
     "test:ship-cost": "node --test tests/test_ship_workflow_cost.mjs tests/test_ship_copy_workflow_cost.mjs skills/suede-graph-flo-xr/workflows/tests/test_score_resilience.mjs skills/suede-graph-flo-xr/workflows/tests/test_plan_path_safety.mjs",
     "test:python": "python3 -m unittest discover -s tests -p 'test_*.py' -v",
-    "test": "npm run validate && npm run test:validator-runtime && npm run test:mcp && npm run test:triggers && npm run test:ship-cost && npm run test:contributions && npm run test:python",
+    "test": "npm run validate && npm run test:number-words && npm run test:validator-runtime && npm run test:mcp && npm run test:triggers && npm run test:ship-cost && npm run test:contributions && npm run test:python",
     "audit:dependencies": "npm audit --omit=dev --audit-level=high",
     "ci": "node --check mcp/suede-skills-mcp.mjs && node --check scripts/validate-skill-pack.mjs && npm run test",
-    "build:pdf": "node scripts/build-book-pdf.mjs"
+    "build:pdf": "node scripts/build-book-pdf.mjs",
+    "fix:counts": "node scripts/validate-skill-pack.mjs --fix",
+    "test:number-words": "node --test tests/test_number_words.mjs"
   },
   "dependencies": {
     "js-yaml": "5.2.2"

--- a/scripts/lib/number-words.mjs
+++ b/scripts/lib/number-words.mjs
@@ -1,0 +1,84 @@
+// The number<->word mapping the book's count guard reads and writes.
+//
+// Both directions live here on purpose. The guard in validate-skill-pack.mjs
+// reads a spelled-out number out of prose and compares it to a live
+// measurement; --fix writes the measurement back in the same spelling. If the
+// reader and the writer disagree about what "forty-five" means, --fix produces
+// prose the guard then rejects, so the two are defined together and tested
+// against each other in tests/test_number_words.mjs.
+//
+// Domain is 0-99. The pack size is two digits and so is every ratio the prose
+// spells out. Out-of-range returns null rather than inventing a word, and the
+// caller turns that null into a hard failure.
+
+const ONES = ["zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
+const TEENS = ["ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"];
+const TENS = ["", "", "twenty", "thirty", "forty", "fifty", "sixty", "seventy", "eighty", "ninety"];
+const ORDINAL_ONES = ["zeroth", "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth"];
+
+const ONES_TO_N = Object.fromEntries(ONES.map((w, i) => [w, i]));
+const TEENS_TO_N = Object.fromEntries(TEENS.map((w, i) => [w, i + 10]));
+const TENS_TO_N = Object.fromEntries(TENS.map((w, i) => [w, i * 10]).filter(([w]) => w));
+const ORDINAL_ONES_TO_N = Object.fromEntries(ORDINAL_ONES.map((w, i) => [w, i]));
+
+// "sixty-seven" -> 67, "sixty" -> 60, "three" -> 3, "twelve" -> 12.
+//
+// Teens are their own words, reachable through neither the ones map nor the
+// tens map. Before they were handled here a count drifting into 10-19 parsed as
+// null, and a null downgrades the guard from a failure to a warning — it went
+// quiet exactly when the number was wrong.
+export function wordNumber(word) {
+  const parts = String(word).toLowerCase().split("-");
+  if (parts.length === 1) {
+    if (ONES_TO_N[parts[0]] !== undefined) return ONES_TO_N[parts[0]];
+    if (TEENS_TO_N[parts[0]] !== undefined) return TEENS_TO_N[parts[0]];
+    return TENS_TO_N[parts[0]] ?? null;
+  }
+  const tens = TENS_TO_N[parts[0]];
+  if (tens === undefined) return null;
+  const ones = ONES_TO_N[parts[1]];
+  return ones === undefined ? null : tens + ones;
+}
+
+// "twenty-fourth" -> 24, "fortieth" -> 40, "twelfth" -> 12.
+export function wordOrdinal(word) {
+  const parts = String(word).toLowerCase().split("-");
+  const last = parts[parts.length - 1];
+  if (parts.length === 1) {
+    if (ORDINAL_ONES_TO_N[last] !== undefined) return ORDINAL_ONES_TO_N[last];
+    if (last === "twelfth") return 12;
+    const teen = TEENS_TO_N[last.replace(/th$/, "")];
+    if (teen !== undefined) return teen;
+    return TENS_TO_N[last.replace(/ieth$/, "y")] ?? null;
+  }
+  const tens = TENS_TO_N[parts[0]];
+  const ones = ORDINAL_ONES_TO_N[last];
+  return tens === undefined || ones === undefined ? null : tens + ones;
+}
+
+// Inverse of wordNumber().
+export function numberToWords(n) {
+  if (!Number.isInteger(n) || n < 0 || n > 99) return null;
+  if (n < 10) return ONES[n];
+  if (n < 20) return TEENS[n - 10];
+  const ones = n % 10;
+  const tens = TENS[Math.floor(n / 10)];
+  return ones === 0 ? tens : `${tens}-${ONES[ones]}`;
+}
+
+// Inverse of wordOrdinal().
+export function numberToOrdinalWords(n) {
+  if (!Number.isInteger(n) || n < 0 || n > 99) return null;
+  if (n < 10) return ORDINAL_ONES[n];
+  if (n < 20) return n === 12 ? "twelfth" : `${TEENS[n - 10]}th`;
+  const ones = n % 10;
+  if (ones === 0) return TENS[Math.floor(n / 10)].replace(/y$/, "ieth");
+  return `${TENS[Math.floor(n / 10)]}-${ORDINAL_ONES[ones]}`;
+}
+
+// Follow the sample's capitalization so "Forty-five of them add a `metadata`
+// block" does not come back lowercased at the head of its sentence.
+export function matchCase(sample, replacement) {
+  if (!replacement) return replacement;
+  return /^[A-Z]/.test(sample) ? replacement[0].toUpperCase() + replacement.slice(1) : replacement;
+}

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -7,6 +7,7 @@ import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
 import { measureBookFacts, measureSkillFile } from "./lib/book-facts.mjs";
 import { PDF_PROVENANCE_RELATIVE, bookPdfDigest, bookPdfInputDigest } from "./lib/book-pdf-provenance.mjs";
+import { wordNumber, wordOrdinal, numberToWords, numberToOrdinalWords, matchCase } from "./lib/number-words.mjs";
 const require = createRequire(import.meta.url);
 const { load: yamlLoad } = require("js-yaml");
 
@@ -1029,23 +1030,6 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-const numberWords = { one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7, eight: 8, nine: 9 };
-const tensWords = { twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60, seventy: 70, eighty: 80, ninety: 90 };
-
-// Accepts "sixty-seven" or a bare "sixty". Previously hard-coded to 20 + n,
-// which silently capped the pack at twenty-nine skills.
-function wordNumber(word) {
-  const parts = String(word).toLowerCase().split("-");
-  // Bare single digits ("three") for small counts such as the number of
-  // focused subset plugins. Tens callers are unaffected.
-  if (parts.length === 1 && numberWords[parts[0]] !== undefined) return numberWords[parts[0]];
-  const tens = tensWords[parts[0]];
-  if (tens === undefined) return null;
-  if (parts.length === 1) return tens;
-  const ones = numberWords[parts[1]];
-  return ones === undefined ? null : tens + ones;
-}
-
 const countChecks = [
   // The pack size used to be pinned in 102 places across 24 files — every
   // README line, every marketing sentence, every manifest description — so a
@@ -1145,16 +1129,6 @@ const deslop = measureSkillFile("suede-deslop");
 const commaNumber = (value) => parseInt(String(value).replace(/,/g, ""), 10);
 // "twenty-fourth" -> 24. The corpus-to-description ratio is written as an
 // ordinal, which wordNumber() cannot read.
-const ORDINAL_ONES = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5, sixth: 6, seventh: 7, eighth: 8, ninth: 9 };
-function wordOrdinal(word) {
-  const parts = String(word).toLowerCase().split("-");
-  const last = parts.pop();
-  const ones = ORDINAL_ONES[last];
-  const tens = tensWords[last.replace(/ieth$/, "y")];
-  const base = parts.length ? wordNumber(parts.join("-")) : 0;
-  if (ones !== undefined) return base === null ? null : base + ones;
-  return tens === undefined ? null : tens;
-}
 
 countChecks.push(
   { file: "book/01-the-competence-gap.md", label: "SKILL.md folder count", re: /SKILL\.md`, (\d+) of them, under documented open-source licenses/, expected: totalSkillCount },
@@ -1240,25 +1214,56 @@ for (const spec of specialtyIndex) {
   );
 }
 
+// --- Writer side of the count guard -----------------------------------------
+// Every check above pairs a regex whose first capture group is a printed number
+// with the live measurement that number must equal. That is enough to WRITE the
+// number as well as read it, and writing it is the point. Before this, adding a
+// single skill turned a dozen of these checks red at once and the only way to
+// clear them was to retype figures — including seven-digit byte totals — by hand
+// across eight prose files. The guard was real; the missing half was the writer.
+// `--fix` inverts each check's own parser and rewrites the capture group in place.
+const fixMode = process.argv.includes("--fix");
+const fixed = [];
+
+
+
+
+
+// Chosen by the same fields the reader dispatches on, so a check can never be
+// read one way and written another. An unrecognized parser yields null, which
+// the loop reports as a failure instead of writing a guess.
+function formatExpected(check, sample) {
+  if (check.parse === wordOrdinal) return matchCase(sample, numberToOrdinalWords(check.expected));
+  if (check.parse === commaNumber) return check.expected.toLocaleString("en-US");
+  if (check.parse) return null;
+  if (check.wordNumber) return matchCase(sample, numberToWords(check.expected));
+  return Number.isInteger(check.expected) ? String(check.expected) : null;
+}
+
 for (const check of countChecks) {
   const filePath = path.join(repoRoot, check.file);
   if (!fs.existsSync(filePath)) {
     warn.push(`Count check skipped — ${check.file} does not exist (${check.label})`);
     continue;
   }
-  const text = readText(filePath);
+  let text = readText(filePath);
   // Most checks guard a phrase that appears once. `every: true` guards a phrase
   // that repeats — every occurrence is validated, not just the first. Without
   // it, a repeated sentence drifts silently past the first hit: README said
   // "71" in three places and "all 70 skills" in five others, and a first-match
   // check on either phrasing would have reported the file clean.
+  // The `d` flag records each group's exact offsets, so --fix replaces the
+  // captured number where it actually sits instead of searching the match for
+  // a substring that may well appear twice in the same sentence.
+  const baseFlags = `${check.re.flags.replace(/g/g, "")}d`;
   const matches = check.every
-    ? [...text.matchAll(new RegExp(check.re.source, `${check.re.flags.replace(/g/g, "")}g`))]
-    : [text.match(check.re)].filter(Boolean);
+    ? [...text.matchAll(new RegExp(check.re.source, `${baseFlags}g`))]
+    : [text.match(new RegExp(check.re.source, baseFlags))].filter(Boolean);
   if (matches.length === 0) {
     warn.push(`Count check pattern not found in ${check.file} (${check.label}) — copy may have moved; update scripts/validate-skill-pack.mjs`);
     continue;
   }
+  const edits = [];
   matches.forEach((match, i) => {
     const where = check.every ? ` [occurrence ${i + 1} of ${matches.length}]` : "";
     const found = check.parse ? check.parse(match[1]) : check.wordNumber ? wordNumber(match[1]) : parseInt(match[1], 10);
@@ -1266,10 +1271,50 @@ for (const check of countChecks) {
       warn.push(`Count check could not parse a number in ${check.file} (${check.label})${where}: "${match[1]}"`);
       return;
     }
-    if (found !== check.expected) {
+    if (found === check.expected) return;
+    if (!fixMode) {
       fail.push(`Stale skill count in ${check.file} (${check.label})${where}: says ${found}, expected ${check.expected}`);
+      return;
     }
+    const replacement = formatExpected(check, match[1]);
+    if (replacement === null) {
+      fail.push(`Stale skill count in ${check.file} (${check.label})${where}: says ${found}, expected ${check.expected} — --fix has no writer for this check's parser`);
+      return;
+    }
+    const [start, end] = match.indices[1];
+    edits.push({ start, end, replacement });
+    fixed.push(`${check.file} (${check.label})${where}: ${match[1]} -> ${replacement}`);
   });
+  if (edits.length) {
+    // Apply right-to-left so an earlier edit never shifts a later offset.
+    edits.sort((a, b) => b.start - a.start);
+    let candidate = text;
+    for (const edit of edits) candidate = candidate.slice(0, edit.start) + edit.replacement + candidate.slice(edit.end);
+    // Several of these patterns constrain the SHAPE of the word, not just its
+    // value — `([A-Z][a-z]+-[a-z]+) of the \d+ descriptions` only matches a
+    // hyphenated number word. Writing a round one ("Seventy") into that slot
+    // produces correct prose that the guard can no longer see: the check
+    // degrades from a failure to a "pattern not found" warning and that
+    // sentence goes unguarded from then on. Caught in testing when the NOT FOR:
+    // count crossed 69 -> 70. So prove the rewrite is still readable before
+    // committing it to disk, and refuse the write rather than silently blind
+    // the guard.
+    const recheck = [...candidate.matchAll(new RegExp(check.re.source, `${baseFlags}g`))];
+    const readable = recheck.length >= matches.length
+      && recheck.slice(0, matches.length).every((m) => {
+        const value = check.parse ? check.parse(m[1]) : check.wordNumber ? wordNumber(m[1]) : parseInt(m[1], 10);
+        return value === check.expected;
+      });
+    if (!readable) {
+      fail.push(
+        `Cannot rewrite ${check.file} (${check.label}): the correct value ${check.expected} does not fit the pattern this check matches on, `
+        + `so writing it would silence the guard. Reword the sentence and update the regex in scripts/validate-skill-pack.mjs.`
+      );
+      for (let i = 0; i < edits.length; i += 1) fixed.pop();
+      continue;
+    }
+    fs.writeFileSync(filePath, candidate);
+  }
 }
 
 // Structural guard for the book's skill index. book/README.md calls the
@@ -2178,6 +2223,12 @@ if (sitemapCheck.error) {
   warn.push(`Sitemap freshness check skipped — could not run generate-sitemap.mjs (${sitemapCheck.error.code || sitemapCheck.error.message})`);
 } else if (sitemapCheck.status !== 0) {
   fail.push("docs/sitemap.xml is out of date — run `node scripts/generate-sitemap.mjs` and commit the result");
+}
+
+if (fixed.length) {
+  console.log(`Rewrote ${fixed.length} stale count${fixed.length === 1 ? "" : "s"}:`);
+  for (const item of fixed) console.log(`- ${item}`);
+  console.log("Run `npm run build:book` to regenerate BOOK.md, the PDF and docs/book from these sources.");
 }
 
 if (fail.length || warn.length) {

--- a/tests/test_number_words.mjs
+++ b/tests/test_number_words.mjs
@@ -1,0 +1,74 @@
+// The count guard reads a spelled-out number out of the book's prose and
+// writes the live measurement back in the same spelling. If the reader and the
+// writer disagree by even one word, `--fix` produces prose the guard then
+// rejects, and the pack is back to hand-editing figures across eight files.
+//
+// These tests pin the pair against each other across the whole domain rather
+// than spot-checking a few values, because the failures that actually happened
+// were at the boundaries: teens (unreachable from either the ones map or the
+// tens map) and round tens (whose ordinal is "fortieth", not "forty-th").
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  wordNumber,
+  wordOrdinal,
+  numberToWords,
+  numberToOrdinalWords,
+  matchCase,
+} from "../scripts/lib/number-words.mjs";
+
+test("cardinal words round-trip across the whole 0-99 domain", () => {
+  for (let n = 0; n <= 99; n += 1) {
+    const word = numberToWords(n);
+    assert.ok(word, `no cardinal word for ${n}`);
+    assert.equal(wordNumber(word), n, `"${word}" did not read back as ${n}`);
+  }
+});
+
+test("ordinal words round-trip across the whole 0-99 domain", () => {
+  for (let n = 0; n <= 99; n += 1) {
+    const word = numberToOrdinalWords(n);
+    assert.ok(word, `no ordinal word for ${n}`);
+    assert.equal(wordOrdinal(word), n, `"${word}" did not read back as ${n}`);
+  }
+});
+
+// The teens are the specific hole that made the guard go quiet instead of
+// failing: wordNumber() returned null for them, and the loop treats null as
+// "could not parse" — a warning, not a failure.
+test("teens parse rather than returning null", () => {
+  const teens = ["ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"];
+  teens.forEach((word, i) => assert.equal(wordNumber(word), i + 10, `"${word}" should read as ${i + 10}`));
+});
+
+test("known spellings are exact, not merely round-trippable", () => {
+  assert.equal(numberToWords(45), "forty-five");
+  assert.equal(numberToWords(70), "seventy");
+  assert.equal(numberToWords(12), "twelve");
+  assert.equal(numberToOrdinalWords(25), "twenty-fifth");
+  assert.equal(numberToOrdinalWords(40), "fortieth");
+  assert.equal(numberToOrdinalWords(12), "twelfth");
+  assert.equal(numberToOrdinalWords(3), "third");
+});
+
+test("out-of-domain values return null instead of inventing a word", () => {
+  for (const bad of [-1, 100, 1000, 1.5, NaN, "71"]) {
+    assert.equal(numberToWords(bad), null, `numberToWords(${bad}) should be null`);
+    assert.equal(numberToOrdinalWords(bad), null, `numberToOrdinalWords(${bad}) should be null`);
+  }
+});
+
+test("unparseable prose returns null rather than a wrong number", () => {
+  for (const bad of ["", "eleventy", "forty-twelve", "banana", "twenty-"]) {
+    assert.equal(wordNumber(bad), null, `wordNumber("${bad}") should be null`);
+  }
+});
+
+// "Forty-five of them add a `metadata` block" opens its sentence. Writing back
+// a lowercase word there would be a grammar regression introduced by the fixer.
+test("matchCase follows the sample it replaces", () => {
+  assert.equal(matchCase("Forty-five", "seventy"), "Seventy");
+  assert.equal(matchCase("forty-five", "seventy"), "seventy");
+  assert.equal(matchCase("Sixty-nine", "twenty-five"), "Twenty-five");
+});


### PR DESCRIPTION
## Why

The book quotes measurements of the pack in prose — how many `SKILL.md` files
there are, what they total in bytes, how many descriptions close with a
`NOT FOR:` clause — and `validate-skill-pack.mjs` guards every one against a
live measurement. The guard is right to exist. What it never had was a writer.

So changing the skill set turned dozens of checks red at once, and the only way
to clear them was to retype figures by hand across eight prose files, including
seven-digit byte totals. **Measured: adding one skill produced 45 failures.**

The book already names this as "the third rot… duplicated numbers," and
`chore/strip-count-treadmill` was an earlier swing at it. Skills get added and
dropped daily, so this fires constantly.

## What changed

- **`scripts/lib/number-words.mjs`** — the number↔word mapping, both directions
  in one module, so the reader and the writer cannot drift apart.
- **`validate-skill-pack.mjs --fix`** — inverts each check's own parser and
  rewrites the captured number in place, located by regex match indices rather
  than a substring search (the same sentence often contains the number twice).
- **`npm run fix:counts`** — plus `CLAUDE.md` documenting the two-command
  ritual: `npm run fix:counts && npm run build:book`.

No prose or content changes. The book is byte-identical to `main`.

## Two bugs found while testing this

**`wordNumber()` could not parse the teens.** A count drifting into 10–19
returned `null`, and the loop treats `null` as a warning rather than a failure —
the guard went quiet exactly when the number was wrong.

**`--fix` could blind the guard.** Several patterns match only a *hyphenated*
number word (`([A-Z][a-z]+-[a-z]+) of the \d+ descriptions`). When the `NOT FOR:`
count crossed 69 → 70, writing `"Seventy"` produced correct prose the check
could no longer see: it degraded to "pattern not found" and that sentence went
unguarded permanently. `--fix` now proves a rewrite is still readable before
writing, and refuses with the offending sentence named.

## SEO carve-out

Counts inside dated posts under `docs/blog/` are **deliberately frozen**. They
are historical statements at stable URLs and carry weight in `<title>`,
`meta description`, `og:`/`twitter:` tags and JSON-LD — e.g. the post titled
"71 skills installed. Your agent reads almost none of them." Rewriting those
would cost real SEO, so the fixer does not touch them and `CLAUDE.md` says so.

## Verification

Round-trip on the real scenario:

| Step | Result |
|---|---|
| Add one skill | 45 stale-count failures |
| `npm run fix:counts` | 0 failures |
| Remove the skill, re-run | prose byte-identical to `main` |

`tests/test_number_words.mjs` round-trips all of 0–99 in **both** directions
rather than spot-checking, because the failures that actually happened were at
the boundaries — teens, and round tens whose ordinal is "fortieth" not
"forty-th". Wired into `npm test`.

Full suite green on this branch: `npm test` exit 0, 0 failing subtests.
