### PR TITLE
Add HOL plugin scanner workflow

### DIFF
--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -1,0 +1,33 @@
+name: HOL Plugin Scanner
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: HOL Plugin Scanner
+        uses: hashgraph-online/ai-plugin-scanner-action@dbc0fe534ab46276bf8f9edacd51ebd8e23378fe # v1.2.561
+        with:
+          plugin_dir: "."
+          mode: scan
+          min_score: 80
+          fail_on_severity: high
+          format: sarif
+          upload_sarif: true


### PR DESCRIPTION
## Summary

- add Hashgraph Online's official plugin scanner as a separate GitHub Actions workflow
- run the standard 80-point / high-severity SARIF gate on pushes and pull requests targeting `main`
- pin the scanner to immutable release commit `dbc0fe534ab46276bf8f9edacd51ebd8e23378fe` (`v1.2.561`)
- keep the existing Skill pack CI workflow unchanged

## Verification

- `npm run validate`
- `npm run audit:dependencies` — 0 vulnerabilities
- `npm test` — strict validation, validator-runtime 32/32, MCP 16/16, routing 78/78, and workflow-cost 119/119 passed; the sandbox denied `ps` for contribution lock recovery
- `npm run test:contributions` with normal process visibility — 28/28 passed
- `npm run test:python` — 48/48 passed
- workflow YAML parse and `git diff --check`

## Scope

This adds scanner CI only. It does not enable submission, claim an HOL listing, or authorize OAuth access.
