### PR TITLE
Pin cisco-ai-skill-scanner to 2.0.13 in the HOL scanner workflow

### DIFF
--- a/.github/hol-scanner-constraints.txt
+++ b/.github/hol-scanner-constraints.txt
@@ -1,0 +1,15 @@
+# pip constraints for the HOL Plugin Scanner workflow (.github/workflows/hol-plugin-scanner.yml).
+# The workflow exports PIP_CONSTRAINT pointing here, so pip applies these pins inside the
+# action's own "Install scanner" step.
+#
+# Why: the action bundle installs plugin-scanner by exact version and SHA256, but that wheel
+# declares its Cisco dependency as the open range `cisco-ai-skill-scanner~=2.0.12`, so every
+# run resolved whatever 2.0.x release PyPI served that day. Cisco 2.0.14 (published
+# 2026-09-01) added the UNICODE_OBFUSCATED_INSTRUCTION rule, which treats three or more
+# non-ASCII characters in a Markdown file as obfuscation and reported HIGH findings on em
+# dashes, arrows and multiplication signs in four prose files. Pull requests went red with
+# no content change. 2.0.13 is the release this tree was last reviewed against.
+#
+# Moving this pin is a deliberate change: re-run the scan locally against the new release
+# and review each new finding before editing the version below. See SECURITY.md.
+cisco-ai-skill-scanner==2.0.13

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -24,6 +24,16 @@ jobs:
 
       - name: HOL Plugin Scanner
         uses: hashgraph-online/ai-plugin-scanner-action@dbc0fe534ab46276bf8f9edacd51ebd8e23378fe # v1.2.561
+        # This bundle pins plugin-scanner 3.0.30 by version and SHA256, but the
+        # wheel leaves cisco-ai-skill-scanner as an open ~=2.0.12 range, so the
+        # deep skill scan silently tracked PyPI. PIP_CONSTRAINT pins it to the
+        # release this tree was reviewed against; see the constraints file and
+        # SECURITY.md. When bumping the action, re-run the scan locally first:
+        # newer bundles install the Cisco scanner only with install_cisco: true,
+        # carry their own hash lock, and ignore the repository's
+        # .plugin-scanner.toml exceptions unless trust_repository_policy: true.
+        env:
+          PIP_CONSTRAINT: ${{ github.workspace }}/.github/hol-scanner-constraints.txt
         with:
           plugin_dir: "."
           mode: scan

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,7 @@ Security reports may cover plugin manifests and installation paths, bundled exec
 - The four listed WAV files under `skills/suede-release-linter/scripts/fixtures/sample-clean-project/` are identical 16,044-byte PCM test fixtures (SHA-256 `56d4af65701c26df20bd4021eda95b6e830348ce3a746086079fe89285548dc9`). The exact skill-directory exception accounts only for the scanner's aggregate analyzability finding; each binary path is also listed explicitly.
 
 These exceptions are not a security certification. Changes to an excepted path require renewed review, and reports about those paths remain in scope.
+
+## Scanner version pin
+
+The HOL Plugin Scanner workflow installs `plugin-scanner` by exact version and SHA256, but that wheel leaves its `cisco-ai-skill-scanner` dependency as an open `~=2.0.12` range. `.github/hol-scanner-constraints.txt` pins that dependency to `2.0.13`, the release the current tree was reviewed against, so a new scanner release cannot change the verdict on an unchanged tree. Cisco `2.0.14` (2026-09-01) added a `UNICODE_OBFUSCATED_INSTRUCTION` rule that treats three or more non-ASCII characters in a Markdown file as obfuscation; it reported HIGH findings on em dashes, arrows and multiplication signs in four prose files that contain no homoglyphs. Moving the pin forward is a deliberate change: re-run the scan against the new release, then review each new finding on its own terms before editing the constraint.


### PR DESCRIPTION
## Why

The HOL Plugin Scanner workflow went red on every pull request and on `main` starting 2026-09-02 with `Findings met or exceeded the "high" severity threshold.` The runs on 2026-09-01 passed, the failing PRs were prose-only, and the SARIF upload was skipped, so nothing showed what was flagged.

## Root cause: scanner drift, not repo content

The action bundle pinned at `dbc0fe5` (v1.2.561) installs `plugin-scanner==3.0.30` by exact version, SHA256 and PyPI provenance, but that wheel's metadata requires `cisco-ai-skill-scanner~=2.0.12` unconditionally. `install_cisco` is irrelevant on this bundle: pip pulls the Cisco scanner as a dependency of the wheel and resolves whatever 2.0.x PyPI serves that day.

| Run | Cisco scanner installed | Result |
|---|---|---|
| 33492396861, push `main` fbed87d, 2026-09-01 09:28Z | 2.0.13 | pass |
| 33585206108, PR fix/readme-license-accuracy, 2026-09-02 02:58Z | 2.0.14 | fail |
| 33590040394, PR #147, 2026-09-02 04:14Z | 2.0.14 | fail |
| 33590411393, push `main` 4d2c9b9, 2026-09-02 04:20Z | 2.0.14 | fail |

`cisco-ai-skill-scanner` 2.0.14 was published 2026-09-01 23:17Z, between the last green run and the first red one. The `plugin-scanner` wheel hash is identical in all four runs.

Local reproduction in a `python:3.12` linux/amd64 container, replaying the action's own install commands and its `action_runner` env (scan, default profile, min score 80, fail on high, Cisco auto/balanced):

| Run | Wheel | Cisco | Tree | Exit | Findings |
|---|---|---|---|---|---|
| A | 3.0.30 | 2.0.14 (floating) | 4d2c9b9, main after #147 | 1 | 4 HIGH |
| B | 3.0.30 | 2.0.13 | 4d2c9b9 | 0 | 0 |
| C | 3.0.30 | 2.0.14 | fbed87d, main before #147 | 1 | same 4 HIGH |
| E | 3.0.43 + upstream hash lock | 2.0.12 | 4d2c9b9 | 1 | 16 (11 HIGH) |
| F | 3.0.30 with this PR's `PIP_CONSTRAINT` | 2.0.13 | this branch | 0 | 0 |

A and B differ only in the Cisco version. C shows PR #147's content was never the trigger.

## What 2.0.14 flags

All four findings are `UNICODE_OBFUSCATED_INSTRUCTION` (HIGH, `cisco-skill-scanner`), a rule new in 2.0.14:

- `skills/johnny-suede-design/SKILL.md:6`
- `skills/suede-ad-creative/references/generative-tools.md:96`
- `skills/suede-design/SKILL.md:21`
- `skills/suede-social/references/listening.md:38`

The rule fires when a Markdown file contains three or more non-ASCII characters (every non-ASCII character counts as "unicode-confusable") and the NFKC-normalized text matches an instruction regex such as `(read|collect|capture|harvest|exfiltrate).{0,160}(credentials?|tokens?|api keys?|...)` or `(post|send|transmit|exfiltrate).{0,160}https?://`. The four files' non-ASCII content is em and en dashes, rightwards arrows, box-drawing lines, multiplication signs, a `≤`, an ellipsis and one emoji; there are no homoglyphs. The regex matches are "read the surface context: ... color tokens" (design tokens) and `POST https://` / `curl ... https://` in API examples. These are false positives on ordinary typography.

## What changed

- `.github/hol-scanner-constraints.txt`: `cisco-ai-skill-scanner==2.0.13`, the release the current tree was reviewed against, with the justification in comments.
- `.github/workflows/hol-plugin-scanner.yml`: `PIP_CONSTRAINT` set on the action step. pip honors the variable inside the composite action's install step, so the pin travels with the workflow and no fork of the action is needed.
- `SECURITY.md`: a "Scanner version pin" section documenting the pin and the accepted 2.0.14 false positives.

Threshold, profile and the exact-path exception list are unchanged. No rule-global suppression was added.

## Alternatives considered

- Raising `fail_on_severity` to `critical` weakens the gate for real HIGH findings.
- Disabling `UNICODE_OBFUSCATED_INSTRUCTION` in `.plugin-scanner.toml` leaves the dependency floating, so the next Cisco release can break PRs again, and it would be the repo's first rule-global exception.
- Bumping the action to the current bundle (v1.2.572, plugin-scanner 3.0.43, Cisco 2.0.12 hash-locked) is not a drop-in: run E produced 16 findings, all on paths already listed in `.plugin-scanner.toml`, because 3.0.43's action runner ignores repository-owned config unless the new `trust_repository_policy: true` input is set. That bump deserves its own review.

## Verification

- Run F above: the action's exact install commands with the constraint resolve `plugin-scanner 3.0.30` and `cisco-ai-skill-scanner 2.0.13`, `pip check` clean, SARIF-mode scan exits 0 with score 100 and zero findings.
- `npm test` on this branch: exit 0; every node:test suite reports `fail 0`; Python suite 48/48; validate reports the book, site and cards current.
- The scan is not a required check (`validate`, `build`), so this PR does not block on it, but its own HOL Plugin Scanner run is the live proof that the pin takes effect on the runner.
