### PR TITLE
Add vendorable copies of two skills for single-skill directories

### DIFF
--- a/vendorable/README.md
+++ b/vendorable/README.md
@@ -1,0 +1,26 @@
+# vendorable
+
+Neutral, standalone copies of pack skills, prepared for third-party skill
+directories that vendor a single skill folder into their own repository rather
+than linking out to a collection.
+
+These are not installed by the plugin and are not part of the catalog. They
+exist so a submission can be made without asking a curator to accept branding
+or references to sibling skills they do not have.
+
+| Folder | Derived from | Notes |
+| --- | --- | --- |
+| `site-to-ios-app` | `skills/site-to-ios-app` | `CARD.md` omitted (release metadata, repo-relative links) |
+| `voice-preserving-line-edit` | `skills/suede-deslop` | Renamed. Leads on the voice-preserving and audit-mode differentiators |
+
+What was changed in each: the frontmatter description no longer opens with a
+brand name, routing to sibling skills is removed, and the sections some
+directories require (When to Use, What This Skill Does, How to Use, Example,
+Tips, Common Use Cases) are present. Thresholds, checklists, rules, and worked
+examples are unchanged from the source.
+
+`voice-preserving-line-edit/LICENSE` keeps the original copyright line. That is
+attribution, not branding.
+
+These do not update automatically. If the source skill changes, update the copy
+here before submitting it anywhere.

--- a/vendorable/site-to-ios-app/SKILL.md
+++ b/vendorable/site-to-ios-app/SKILL.md
@@ -1,0 +1,338 @@
+---
+name: site-to-ios-app
+description: "Turns a website, PWA, dashboard, or marketplace into an iOS app. Use when the user has a live site or web app and asks to put it on the App Store, wrap it in an app, ship an iOS version, or convert a PWA to native. Covers URL audit, shell-vs-native strategy, App Store Guideline 4.2 wrapper-rejection risk, native value requirements, screenshots, metadata, privacy answers, and the release gate. Not for: building a native iOS app when no website exists; repairing or releasing an existing Capacitor shell; Android conversions; or keyword and listing audits on an app that already shipped."
+---
+
+# Site to iOS App
+
+## When to Use This Skill
+
+Use it when a live web surface already exists and the user wants it on iPhone:
+
+- "Put my site on the App Store."
+- "Wrap this dashboard in an iOS app."
+- "Ship an iOS version of our web app."
+- "Convert our PWA to native."
+- "Can we get this marketplace into the App Store?"
+- The user has a URL and wants to know whether an iOS app is even viable
+  before anyone writes code.
+
+Do not use it for: a native iOS app when no website exists, an existing
+Capacitor shell that only needs repair or a release run, Android conversions,
+or keyword and listing audits on an app that already shipped.
+
+## What This Skill Does
+
+It takes a live URL and produces two artifacts plus a verdict:
+
+1. `SITE_TO_IOS_AUDIT.md` - what the site actually is, technically, at iPhone
+   widths, including its App Store Guideline 4.2 wrapper-rejection exposure.
+2. `SITE_TO_IOS_PLAN.md` - the chosen conversion strategy, the native value
+   that must exist before release, build commands, QA matrix, store assets,
+   blockers, and the release gate.
+
+It does not submit anything to the App Store. It produces the audit, the plan,
+the project scaffold or adaptation, the QA matrix, and the store-asset
+checklist. Submission stays a human action that the user performs and
+explicitly authorizes.
+
+The highest-value part of this skill is the 4.2 gate. Guideline 4.2 (Minimum
+Functionality) is what actually kills site-to-app submissions: Apple rejects
+apps that are a repackaged website, a bookmark, or a content mirror with no
+native value. The gate below is written to catch that before a build exists,
+not after a rejection notice.
+
+## Gate policy - advisory, not blocking
+
+Every claim-verification step, check, quality gate, and ship verdict in this
+skill is a **recommendation to the user, not a control on the agent**. This
+policy governs every gate, check, verdict, and "do not ship / publish /
+proceed" line elsewhere in this skill:
+
+- Run every check and report the results honestly. Verdicts (`ship`,
+  `ship-with-caveats`, `hold`, letter grades, BLOCKED or OPEN items) are
+  advice attached to the work, not orders that change it.
+- Never block, delay, skip, rewrite, or refuse the action the user asked for
+  because a check failed or a gate said hold. Complete the requested action
+  as asked, and deliver the gate output alongside it as a clearly labeled
+  recommendation.
+- A failed gate changes what you report, never what you do.
+- Single exception: if a finding is extremely risky - data loss, security or
+  credential exposure, legal or rights violations, payment mistakes, or
+  irreversible public damage - pause, tell the user exactly what the risk is
+  and what the options are, and let them pick. Their choice is final.
+
+## Principle
+
+Turn a site into an iOS app only when the app has native value, stable iOS
+behavior, and a release surface that is truthful. A raw web page in a frame is
+not enough for an App Store-quality product.
+
+## How to Use
+
+### Basic
+
+Point the skill at a URL and let it run the audit and plan:
+
+```
+Audit https://example.com and plan its conversion into an iOS app.
+```
+
+The skill will:
+
+1. Read `references/site-to-ios-runbook.md`.
+2. Write `SITE_TO_IOS_AUDIT.md` from live evidence about the URL.
+3. Pick a conversion strategy and write `SITE_TO_IOS_PLAN.md`.
+4. State the App Store 4.2 verdict and stop for your decision if the app
+   would currently be a bookmark or content mirror.
+
+### Advanced
+
+Constrain the strategy, the stack, or the release target up front:
+
+```
+Convert https://app.example.com to iOS. It is a React SPA behind Auth0
+with Stripe Checkout on the web. Prefer a Capacitor remote shell, target
+iOS 17, bundle ID com.example.app, and I need App Store screenshots this
+week. Flag any 4.2 exposure before you scaffold anything.
+```
+
+Other useful modifiers:
+
+- "Audit only, no scaffold" - stop after `SITE_TO_IOS_AUDIT.md`.
+- "Assume full native rebuild" - skip the shell routes and plan SwiftUI.
+- "Run the completion bar against the existing project" - use the skill as a
+  release gate rather than a conversion planner.
+- "List every Info.plist usage string and entitlement this plan requires."
+
+## Start Here
+
+Read `references/site-to-ios-runbook.md` before scaffolding or changing an
+iOS wrapper.
+
+If a URL is available, create `SITE_TO_IOS_AUDIT.md` directly. Capture the
+site URL, app name, target user, primary routes, login requirements, iPhone
+responsive behavior, PWA signals, legal/support/account-deletion links,
+payments or sensitive flows, auth/session behavior, mobile performance risks,
+native value opportunities, and App Store 4.2 wrapper risk.
+
+Then create `SITE_TO_IOS_PLAN.md` directly. Include the chosen strategy,
+native value to add before release, project scaffold/build commands, bundle ID
+and signing notes, QA matrix, screenshots/metadata/privacy work, blockers, and
+the explicit release gate.
+
+## Strategy Decision
+
+Choose one route and write down why:
+
+- Capacitor remote shell: live site remains the product surface and web deploys
+  should update most content and behavior.
+- Capacitor bundled shell: static/SPA assets are packaged into the binary and
+  updates require App Store release unless paired with live APIs.
+- Native SwiftUI shell with WebView: native navigation, settings, auth, push,
+  share, error, and account surfaces wrap a site view.
+- Full native rebuild: use when the site is mostly content, has weak mobile UX,
+  or carries high wrapper rejection risk.
+
+Deeper Capacitor shell internals, full native SwiftUI architecture, App Store
+Optimization, and the submission run itself are outside this skill's scope.
+None of them are required to complete the audit, the plan, or the build.
+
+## App Store 4.2 Gate
+
+Halt when the app is only a bookmark, content mirror, or unmodified website:
+name the exact 4.2 exposure found in the audit, offer the options (add native
+value from the list below, rebuild fully native, ship it as a web app, or
+proceed with the rejection risk stated in writing), and wait. Native value:
+
+- iOS-native onboarding, empty states, errors, offline, and retry.
+- Native settings with support, privacy, terms, account deletion, restore, and
+  notification controls where applicable.
+- Universal links or deep links.
+- Share sheet, widgets, push notifications, camera/media/file pickers, Apple
+  Wallet, StoreKit, or other native capabilities only when they serve the app.
+- Safe-area, keyboard, navigation, dark/light mode, and dynamic type handling.
+
+## Conversion Flow
+
+1. Audit the URL, responsive behavior, PWA assets, auth, payments, privacy,
+   support, route depth, and mobile performance.
+2. Pick the conversion strategy and write a `SITE_TO_IOS_PLAN.md`.
+3. Scaffold or adapt the project using the repo's package manager and iOS
+   project conventions.
+4. Configure bundle ID, display name, app icon, launch screen, associated
+   domains, Info.plist usage strings, and entitlements.
+5. Implement native value and failure states before visual polish.
+6. Run web build and `cap sync ios` for Capacitor shells.
+7. Test on simulator or device across first launch, auth, deep links, tabs,
+   keyboard, payments, offline, backgrounding, and account flows.
+8. Produce App Store screenshots, metadata, privacy answers, and review notes.
+9. Run the ship gate. Do not submit unless the user explicitly delegates public
+   release and confirms the exact app, bundle ID, version, build, and account.
+
+## Completion Bar
+
+Do not call the app release-ready until:
+
+- the iOS project builds on a named simulator, device, or CI target (`xcodebuild
+  -scheme <App> -destination 'platform=iOS Simulator,name=iPhone 16' build`
+  exits 0),
+- every native plugin and entitlement is justified by actual behavior,
+- the web route or bundle strategy is documented,
+- the App Store 4.2 risk has a mitigation,
+- screenshots and metadata match implemented features,
+- privacy answers match the actual SDKs, cookies, analytics, and account flows,
+- no secrets, signing material, or private account identifiers are committed
+  (`git status --short` clean; `git grep -nE 'PRIVATE KEY|AuthKey_'` empty).
+
+## Example
+
+**Prompt**
+
+```
+Audit https://app.shiftly.example and plan its conversion into an iOS app.
+It is a shift-scheduling SaaS for restaurant managers.
+```
+
+**Excerpt from the generated `SITE_TO_IOS_AUDIT.md`**
+
+```markdown
+# Site to iOS Audit - Shiftly
+
+URL checked: https://app.shiftly.example (2026-09-02)
+App name: Shiftly
+Target user: restaurant shift managers and hourly staff
+Core job: publish a weekly schedule, claim and swap shifts
+
+## Route map
+| Route | Auth | Notes |
+| --- | --- | --- |
+| /login | public | email + OAuth (Google) |
+| /schedule | required | primary surface, drag-and-drop grid |
+| /shifts/:id | required | deep-link target, currently no canonical URL |
+| /billing | required | Stripe Checkout redirect, web only |
+| /help | public | support articles |
+| /legal/privacy, /legal/terms | public | present |
+| account deletion | MISSING | no self-serve delete path found |
+
+## Responsive behavior at iPhone widths
+- 390pt: schedule grid overflows horizontally, no touch scroll momentum.
+- Bottom action bar sits under the home indicator (no safe-area padding).
+- Tap targets on shift chips measure ~28pt, below the 44pt guidance.
+
+## PWA signals
+- manifest.webmanifest present, name/short_name set, 192 and 512 icons.
+- apple-touch-icon present. theme-color set. Service worker registered,
+  cache-first for assets only, no offline route.
+
+## Auth and session
+- Google OAuth redirects to accounts.google.com and back to /schedule.
+- Session cookie is SameSite=Lax, 30-day persistence, survives web reload.
+- No Sign in with Apple. Required if third-party social login ships.
+
+## Sensitive flows
+- Payments: Stripe Checkout, web redirect, subscription for managers.
+- Personal data: names, phone numbers, shift availability. No health data.
+
+## App Store 4.2 wrapper risk: HIGH
+A shell over /schedule with no native surfaces is a repackaged website.
+Concrete exposure: no native settings, no offline or retry state, no push,
+no deep-link handling, and no account deletion path, which also implicates
+the account-deletion requirement for apps that create accounts.
+```
+
+**Excerpt from the generated `SITE_TO_IOS_PLAN.md`**
+
+```markdown
+## Strategy: Capacitor remote shell
+Chosen because /schedule is the product and it ships web changes weekly.
+Rejected full native rebuild: the drag-and-drop grid is the whole product
+and rebuilding it natively is a quarter of work, not a conversion.
+
+## Native value required before release (4.2 mitigation)
+1. Native onboarding: 3 screens, no web content.
+2. Native settings screen: support, privacy, terms, notification toggles,
+   restore, and a self-serve account deletion flow.
+3. Push notifications for shift published, shift swap requested, shift
+   claimed. This is the strongest 4.2 argument the app has.
+4. Universal links for /shifts/:id, cold and warm start.
+5. Native offline state and retry for schedule fetch failures.
+6. Safe-area, keyboard, and dynamic type handling in the shell chrome.
+
+## Blockers
+- BLOCKED: account deletion does not exist on the web product either.
+  Must ship server-side before submission.
+- OPEN: Sign in with Apple required alongside Google OAuth.
+- OPEN: Stripe Checkout must stay outside the app or move to StoreKit.
+  Confirm which flow the app exposes before writing review notes.
+
+## Build
+xcodebuild -scheme Shiftly \
+  -destination 'platform=iOS Simulator,name=iPhone 16' build
+
+## Release gate
+HOLD. 4.2 mitigation items 1-5 incomplete, account deletion missing,
+Sign in with Apple missing. Not release-ready.
+```
+
+**Verdict returned to the user**
+
+```
+App Store 4.2 verdict: HIGH risk, gate held.
+As specified, this is a bookmark to /schedule. Your options:
+  1. Add the native value in the plan (push + settings + deep links is
+     the minimum I would submit behind).
+  2. Rebuild the schedule grid natively in SwiftUI.
+  3. Ship it as a PWA and skip the App Store.
+  4. Submit as-is with the rejection risk on the record.
+Two items block submission regardless of route: account deletion and
+Sign in with Apple. Tell me which option and I will write the build.
+```
+
+## Tips
+
+- Run the audit before anyone writes code. The 4.2 verdict changes the
+  budget, and finding it after a rejection costs a review cycle per attempt.
+- Push notifications plus a native settings screen plus working universal
+  links is the smallest bundle of native value that reliably reads as an app
+  rather than a bookmark. Add more when the product justifies it.
+- If the site creates user accounts, find the account deletion path during
+  the audit. It is a common submission blocker and it usually needs
+  server-side work, not app work.
+- Only request an entitlement or a native plugin the app actually uses. An
+  unjustified permission string is both a review risk and a privacy-answer
+  mismatch.
+- Decide the update route explicitly. A remote shell means web deploys change
+  shipped app behavior; a bundled shell means every change is a new binary.
+  Write the choice into the plan so nobody assumes the other one.
+- Make privacy answers match the real SDKs, cookies, and analytics on the web
+  surface, not the ones you intended to keep.
+- Check payment flows against current App Store policy before writing review
+  notes. Web checkout, StoreKit, and reader-app rules land differently.
+- Test deep links from a cold start, not just a warm one. Warm-start handling
+  passes far more often than cold-start handling.
+
+## Common Use Cases
+
+- **SaaS dashboard to iOS app.** Capacitor remote shell plus native settings,
+  push, and deep links. The most frequent case and the one 4.2 catches most.
+- **PWA to App Store.** The manifest and service worker already exist; the
+  work is native value, offline behavior, and store assets.
+- **Marketplace or commerce site to iOS.** Remote shell plus native account,
+  support, and deletion surfaces, with a payments-policy review first.
+- **Content or marketing site to iOS.** Usually a full native rebuild or a
+  native content app. A thin wrapper here is the highest 4.2 risk there is.
+- **Media or creator web app to iOS.** Native shell or SwiftUI rebuild with
+  media pickers, share sheet, library, and notifications.
+- **Feasibility check before committing budget.** Run the audit alone to get
+  a 4.2 verdict, a strategy recommendation, and a blocker list.
+- **Release gate on an existing conversion.** Run the Completion Bar against
+  a project someone else built to find missing mitigations before submission.
+
+## Credit
+
+This skill is vendored from the Suede Creator Skills collection:
+<https://github.com/JasonColapietro/suede-creator-skills>
+
+It comes out of production use rather than theory: the same terminal that runs
+this skill has archived and uploaded 8 iOS apps.

--- a/vendorable/site-to-ios-app/agents/openai.yaml
+++ b/vendorable/site-to-ios-app/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Site to iOS App"
+  short_description: "Turn websites into App Store-ready iOS app plans and shells"
+  default_prompt: "$site-to-ios-app Audit this site and plan its conversion into an iOS app: "

--- a/vendorable/site-to-ios-app/references/site-to-ios-runbook.md
+++ b/vendorable/site-to-ios-app/references/site-to-ios-runbook.md
@@ -1,0 +1,102 @@
+# Site-to-iOS Runbook
+
+## 1. URL Audit
+
+Start with facts about the site:
+
+- URL, app name, target user, and core job.
+- Primary routes and whether they require login.
+- Responsive behavior on iPhone widths.
+- PWA signals: manifest, theme color, apple touch icon, service worker.
+- Legal links: privacy, terms, support, contact, account deletion if accounts
+  exist.
+- Sensitive flows: payments, subscriptions, user-generated content, messaging,
+  uploads, camera, microphone, location, health, finance, or minors.
+- Auth behavior: OAuth redirects, Sign in with Apple need, cookies, session
+  persistence, same-site restrictions, universal links.
+
+When a URL is reachable, write `SITE_TO_IOS_AUDIT.md` directly from current
+evidence. Include the URL checked, route map, auth and payment behavior, PWA
+signals, legal/support/account-deletion links, responsive findings at iPhone
+widths, performance risks, sensitive permissions, native value opportunities,
+and App Store 4.2 wrapper-risk notes.
+
+## 2. Strategy Matrix
+
+| Site Type | Default Strategy | Notes |
+| --- | --- | --- |
+| Existing SaaS or dashboard | Capacitor remote shell | Add native settings, deep links, offline/error states, and auth stability. |
+| Static marketing or content site | Full native rebuild or native content app | A thin wrapper is high risk under App Store 4.2. |
+| PWA with strong mobile UX | Capacitor bundled or remote shell | Keep update route explicit and preserve PWA assets. |
+| Marketplace or commerce site | Capacitor remote plus native account/support | Verify payments policy, Stripe web checkout, account deletion, and support. |
+| Media or creator app | Native shell or SwiftUI rebuild | Add media pickers, share, library, notifications, or offline where useful. |
+
+## 3. Native Value Requirements
+
+The required native value is the blocking gate and lives in one place: see
+"App Store 4.2 Gate" in `SKILL.md`. Build against that list, not a copy.
+
+## 4. Capacitor Scaffold
+
+Use the repo's locked package manager. For a new shell, the common shape is:
+
+```bash
+pnpm create vite site-ios --template react-ts
+cd site-ios
+pnpm add @capacitor/core @capacitor/ios
+pnpm exec cap init
+pnpm build
+pnpm exec cap add ios
+pnpm exec cap sync ios
+```
+
+For a remote web app, configure the server URL only when the release policy
+accepts remote-delivered behavior. For a bundled app, build local assets and
+ship updates through binary releases unless using a governed live-update
+system.
+
+## 5. Native Configuration
+
+Check these before release:
+
+- `capacitor.config.*` app ID, display name, webDir, and server routing.
+- Xcode bundle identifier, version, build number, signing team, and deployment
+  target.
+- App icon, launch screen, status bar, orientation, and safe areas.
+- Associated domains and universal links.
+- Info.plist usage descriptions for every native permission.
+- Entitlements for Sign in with Apple, push, associated domains, iCloud, or
+  Apple Pay only when implemented.
+
+## 6. QA Matrix
+
+Run on a named simulator or device:
+
+- first launch and return launch,
+- login, logout, expired session, OAuth redirect,
+- primary route navigation,
+- keyboard forms and scroll-to-focused-field behavior,
+- network offline, slow network, API failure, retry,
+- file/media permission denial and later approval,
+- deep link from cold and warm start,
+- dark/light mode,
+- background/foreground,
+- payment or subscription flow if present,
+- account deletion/support/privacy/terms links.
+
+## 7. Release Gate
+
+Produce:
+
+- `SITE_TO_IOS_AUDIT.md`
+- `SITE_TO_IOS_PLAN.md` with strategy, native value, build/run commands, QA
+  matrix, screenshots/metadata/privacy work, blockers, and release gate
+- build command output or CI link
+- simulator/device QA notes
+- screenshots and metadata
+- privacy questionnaire inputs
+- reviewer notes
+
+Block release if the site cannot pass the wrapper-risk gate, if privacy/legal
+links are missing, if payments violate policy, if the app does not build, or if
+the user has not explicitly delegated public submission.

--- a/vendorable/voice-preserving-line-edit/LICENSE
+++ b/vendorable/voice-preserving-line-edit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Suede Labs AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendorable/voice-preserving-line-edit/README.md
+++ b/vendorable/voice-preserving-line-edit/README.md
@@ -1,0 +1,126 @@
+# Voice-Preserving Line Edit
+
+A finishing pass that removes generic AI writing patterns from prose you have
+already written, without erasing the author underneath.
+
+## The problem with most anti-slop rules
+
+Most cleanup rule sheets are absolute. Kill every adverb. Never use passive
+voice. Remove every em dash. Applied literally, they turn three different
+writers into the same writer, break technical prose that needs a conventional
+passive, and fight a house style that already made the punctuation call.
+
+This skill applies the same pattern knowledge contextually:
+
+- **Adverbs** are cut when they merely intensify, soften, or announce
+  importance, and kept when they carry factual, technical, legal, quoted, or
+  voice-specific meaning.
+- **Passive voice** is converted when the actor matters and kept when the actor
+  is unknown, immaterial, deliberately withheld, or conventional for the genre.
+- **Register** is preserved. Third-person, academic, legal, and documentary
+  writing is not forced into second-person marketing voice.
+- **Punctuation** follows the house style you supply, and punctuation is never
+  treated as evidence that a model wrote something.
+
+## Two modes
+
+**Findings-only audit.** Say "audit", "flag", "review", "diagnose", or "do not
+rewrite" and your text comes back unchanged, alongside quoted issues split into
+two tiers:
+
+- **Clear issues** with the exact quote, why it weakens this piece, and the
+  minimum correction.
+- **Judgment calls** with the trade-off named, so you decide whether the trait
+  is voice or slop.
+
+Useful when the draft is a client's, a colleague's, or a named author's and you
+do not have the standing to just rewrite it.
+
+**Cleaning pass.** The default. Cleaned prose first, then a change report with
+counts per category and a 50-point score.
+
+## What it never does
+
+- Change a fact, number, date, name, price, claim, qualifier, quotation, code,
+  command, link, citation, or path.
+- Invent a metric, actor, anecdote, customer, quote, or first-person
+  experience. If a rewrite needs a specific the source did not supply, the gap
+  is marked rather than filled.
+- Say whether a human or a model wrote the text. Findings describe the prose
+  and its effect only.
+- Publish, post, send, commit, or overwrite anything. Cleaned prose comes back
+  in the response and you decide where it lands.
+
+## What it catches
+
+Throat-clearing openers, emphasis crutches, business jargon, low-information
+adverbs, meta-commentary, performative sincerity, vague declaratives, binary
+contrasts in all eleven spellings, negative listing, dramatic fragmentation,
+rhetorical setups, formulaic templates, false agency, narrator-from-a-distance
+voice, responsibility-hiding passives, Wh- sentence starters, metronomic
+rhythm, and lazy extremes.
+
+`SKILL.md` carries the 25 highest-frequency offenders inline. The full sweep,
+with forty-plus more entries, is in `references/kill-list.md`, meant for text
+going to press, to investors, or to customers.
+
+## Scoring
+
+Rate 1-10 on each dimension after the pass:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements, not announcements? |
+| Rhythm | Varied, not metronomic? |
+| Trust | Respects the reader? |
+| Authenticity | Sounds human? |
+| Density | Anything still cuttable? |
+
+Below 35 out of 50: revise. The verdict is advice about the prose, not a gate
+on your decision to publish.
+
+## Structure
+
+```
+voice-preserving-line-edit/
+  SKILL.md                  Core instructions, rules, checklist, output contract
+  references/
+    kill-list.md            The full sweep, deferred until needed
+  agents/
+    openai.yaml             Agent interface metadata
+  README.md
+  LICENSE
+```
+
+## Install
+
+**Claude Code.** Copy this folder into `.claude/skills/` in your project, or
+into the user-level skills directory.
+
+**Claude Projects.** Upload `SKILL.md` and `references/kill-list.md` to project
+knowledge.
+
+**System prompt or custom instructions.** Paste `SKILL.md`. Load
+`references/kill-list.md` on demand.
+
+## Usage
+
+    Run a voice-preserving line edit on this README intro.
+    <paste text>
+
+    Audit this launch email for slop. Findings only, do not rewrite it.
+
+    Line-edit this page. House style: em dashes are fine, we write in third
+    person, and "platform" is our term, never "ecosystem".
+
+Paste real numbers and names alongside the draft. Vague prose usually hides
+missing facts, and a line edit cannot conjure them.
+
+## Credit
+
+Adapted from the suede-creator-skills collection:
+<https://github.com/JasonColapietro/suede-creator-skills>
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/vendorable/voice-preserving-line-edit/SKILL.md
+++ b/vendorable/voice-preserving-line-edit/SKILL.md
@@ -1,0 +1,614 @@
+---
+name: voice-preserving-line-edit
+description: "Context-aware line edit that strips generic AI writing patterns without flattening the author's voice, plus a findings-only audit mode that names issues instead of rewriting. Applies contextual rules rather than blanket bans on adverbs, passive voice, and punctuation, and locks facts, numbers, quotes, code, links, and the supplied house style before it touches a sentence. Use before copy, a README, an email, a social post, or a doc ships; after a long assisted-writing session; when the text sounds fine but feels generated; or when the user asks for a findings-only slop audit. NOT FOR: writing new copy from scratch; deciding whether a person or a model wrote text; changing or certifying facts, which must be checked against primary evidence before publication."
+---
+
+# Voice-Preserving Line Edit
+
+A finishing pass for prose that is already written. It hunts throat-clearing
+before the point, inanimate things doing human work, binary contrasts that
+announce an insight instead of delivering it, and rhythm that never varies.
+
+Two things separate this from a generic anti-slop rule sheet:
+
+1. **Every rule is contextual.** Adverbs, passive voice, third-person register,
+   and em dashes are not banned outright. Each is cut only when it weakens
+   this piece, in this genre, under this house style. A technical adverb, a
+   conventional passive, an academic register, and a house-approved em dash all
+   survive the pass.
+2. **There is an audit mode.** Ask for findings and you get quoted issues,
+   reasons, and minimum corrections, with your text returned unchanged. The
+   rewrite mode is opt-in, not the only setting.
+
+These are writing-quality signals. They are not evidence of who or what wrote
+the text, and this skill never claims otherwise.
+
+---
+
+## What This Skill Does
+
+- Finds and, on request, removes filler phrases, business jargon, empty
+  intensifiers, formulaic structures, false agency, vague declaratives, and
+  metronomic rhythm in finished prose.
+- Preserves the author's voice: deliberate fragments, dry humor, technical
+  vocabulary, chosen formality, and useful rough edges.
+- Preserves the record: facts, numbers, dates, names, prices, claims,
+  qualifiers, quotations, code, commands, links, citations, and paths pass
+  through untouched.
+- Runs in either of two modes, findings-only audit or cleaning pass, each with
+  its own fixed output contract.
+- Scores the result on five dimensions out of 50 and returns a CLEAN or REVISE
+  verdict about the prose quality.
+
+What it does not do: write new copy, restructure an argument, fact-check,
+guess at authorship, or publish anything. See Boundaries.
+
+---
+
+## When to Use This Skill
+
+- Before copy, a README, an email, a social post, or a doc ships
+- After a long AI-assisted writing session
+- When the text sounds fine but feels generated
+- Before anything goes to press, to investors, or to customers
+- When someone wants the issues identified without a rewrite
+- When a draft has to keep a specific author's voice and a generic cleanup
+  would erase it
+
+Do not run it on fiction, conversational replies, or internal notes where a
+loose voice is intentional. When the request is findings only, report the
+issues and leave the supplied text unchanged.
+
+---
+
+## How to Use
+
+### Basic
+
+Hand the skill a block of prose and ask for a cleanup:
+
+    Run a voice-preserving line edit on this README intro.
+    <paste text>
+
+You get the cleaned prose first, then a change report and a 50-point score.
+
+### Advanced
+
+**Findings-only audit.** Use the words detect, flag, review, diagnose, audit,
+or do not rewrite:
+
+    Audit this launch email for slop. Findings only, do not rewrite it.
+
+You get quoted issues split into Clear issues and Judgment calls, with a
+minimum correction for each. Your text comes back unchanged.
+
+**Supply a house style.** A company or author style brief overrides the
+defaults in this skill, including punctuation and register:
+
+    Line-edit this page. House style: em dashes are fine, we write in
+    third person, and "platform" is our term, never "ecosystem".
+
+**Supply author context.** The example rewrites below only get specific because
+the source supplied the specifics. If real numbers, names, or before/after
+figures exist, paste them alongside the draft. Without them the skill marks the
+gap rather than inventing a filler.
+
+**Run the deep sweep.** The 25-row table below is the high-frequency cut. For
+press, investor, or customer-facing text, or when the table comes back clean and
+the prose still reads generated, run the full list in
+[references/kill-list.md](references/kill-list.md).
+
+**Scope the pass.** Ask for a subset when only part of the problem matters, for
+example "structural patterns only, leave word choice alone."
+
+---
+
+## Advisory, not blocking
+
+Every check, gate, score, and verdict in this skill is a recommendation to the
+user, not a control on the agent.
+
+- Run every check and report the results honestly. Verdicts (CLEAN, REVISE,
+  a score below threshold) are advice attached to the work, not orders that
+  change it.
+- Never block, delay, skip, or refuse the action the user asked for because a
+  check failed. Complete the request as asked and deliver the check output
+  alongside it, clearly labeled as a recommendation.
+- A failed check changes what you report, never what you do.
+- Single exception: if a finding is extremely risky, such as legal or rights
+  exposure, a claim that could mislead a customer or investor, or irreversible
+  public damage, pause, state the risk and the options, and let the user pick.
+  Their choice is final.
+
+---
+
+## Before the pass
+
+1. **Choose the deliverable.** Default to cleaned prose. Use a findings-only
+   audit when the user says detect, flag, review, diagnose, audit, or do not
+   rewrite.
+2. **Lock the source.** Preserve facts, numbers, dates, names, prices, claims,
+   quotations, qualifiers, code, commands, links, citations, and paths.
+3. **Lock the voice.** Preserve deliberate fragments, dry humor, technical
+   vocabulary, formality, and useful rough edges. Remove a pattern only when it
+   weakens this piece in this context.
+4. **Read the house style.** A supplied company or author brief overrides the
+   punctuation and register defaults in this skill.
+
+Make the minimum effective edit. Never add anecdotes, customers, metrics,
+quotes, first-person experience, or specificity that the source did not supply.
+
+---
+
+## The eight rules
+
+### 1. Cut filler phrases
+
+No throat-clearing before the point. No emphasis crutches that add weight
+without meaning. No adverbs doing work a specific fact should do.
+
+The kill list, 25 highest-frequency offenders:
+
+| Category | Kill | Fix |
+|----------|------|-----|
+| Opener | Here's the thing: | Start with the point |
+| Opener | Let's be honest / Let's face it | Cut; say the honest thing |
+| Opener | The truth is / The reality is | Cut; state it |
+| Opener | It's worth noting that | Cut; note it |
+| Opener | In today's fast-paced world | Cut the sentence |
+| Opener | Picture this: / Imagine this: | Describe the scene directly |
+| Opener | At its core / At the end of the day | Cut; make the core claim |
+| Crutch | Let that sink in / Read that again | Cut; the sentence carries or it does not |
+| Crutch | genuinely / truly / literally | Cut |
+| Crutch | actually / really / very | Cut |
+| Crutch | full stop / period (as emphasis) | Cut |
+| Crutch | make no mistake | Cut |
+| Jargon | leverage (as a verb) | use |
+| Jargon | utilize | use |
+| Jargon | delve into | cover, get into |
+| Jargon | navigate (a challenge) | handle, work through |
+| Jargon | landscape / ecosystem (abstract) | market, field, or the named thing |
+| Jargon | journey (not travel) | process, or name the steps |
+| Jargon | unlock / unleash | say what was blocked |
+| Jargon | robust / seamless / powerful | name the capability or prove it |
+| Jargon | elevate / empower / transform | say what changes, before and after |
+| Adverb | incredibly / remarkably / surprisingly | cut, or give the number that surprises |
+| Adverb | seamlessly / effortlessly | cut; show the step count |
+| Adverb | fundamentally / essentially / ultimately | cut; the claim stands or it does not |
+| Adverb | importantly / notably | cut; if it matters, the content shows it |
+
+The table is the high-frequency cut. The full sweep, with forty-plus more
+phrases across every category, lives in
+[references/kill-list.md](references/kill-list.md); run it when the text goes
+to press, to investors, or to customers. Three categories the table compresses:
+
+- **Adverbs, contextual rule.** Cut adverbs that merely intensify, soften, or
+  announce importance. Keep an adverb when it carries factual, technical,
+  legal, quoted, or voice-specific meaning.
+- **Meta-commentary.** The piece moves; it never announces its own structure.
+  Cut "Let me walk you through", "In this section, we'll", "As we'll see",
+  "Plot twist:", "Hint:", "But that's another post", "X is a feature, not a
+  bug".
+- **Performative sincerity.** False intimacy and announced significance. Cut
+  "I promise", "creeps in", "This is genuinely hard", "This is what X actually
+  looks like", "actually matters". Show the difficulty; never claim it.
+
+Bad: "Here's the thing: this is genuinely hard. Let that sink in."
+Good: "This is hard."
+
+---
+
+### 2. Break formulaic structures
+
+The patterns a model reaches for when it has nothing original to say. Each with
+its fix:
+
+- **Binary contrast** ("It's not about speed. It's about precision.") | Fix:
+  state the real claim directly. "Precision matters more than speed here."
+- **"Isn't just" construction** ("This isn't just a tool, it's a platform.") |
+  Fix: cut the setup; say what it is with one proof.
+- **Negative listing** ("No setup. No config. No hassle.") | Fix: one positive
+  sentence naming what the user does.
+- **Dramatic fragment** ("One problem." / "And it worked.") | Fix: attach the
+  fragment to the sentence it modifies.
+- **Rhetorical setup** ("So what does this mean for you?" / "What if I told
+  you...?" / "Think about it:") | Fix: delete the question; give the answer.
+- **False agency** ("The data tells us" / "the decision emerges" / "the culture
+  shifts" / "the market rewards") | Fix: name the person. "We measured." "I
+  argue." If no one fits, use "you".
+- **Triad rhythm** ("Faster. Cleaner. Better.") | Fix: two items, or a full
+  sentence. Three-beat lists only when the count is really three.
+- **Reveal fragment** ("[Noun]. That's it. That's the [thing].") | Fix: one
+  complete sentence, no staged reveal.
+- **Formulaic template** ("By the time X, I was Y." / "X that isn't Y") | Fix:
+  drop the template; state the fact. "X is broken."
+- **Permission grant** ("And that's okay.") | Fix: cut it; the reader did not
+  ask.
+
+Binary contrast alone has eleven spellings ("The answer isn't X. It's Y." /
+"It feels like X. It's actually Y." / "stops being X and starts being Y" and
+more); the full variant table is in
+[references/kill-list.md](references/kill-list.md).
+
+Bad: "It's not about speed. It's about precision."
+Good: "Precision matters more than speed here."
+
+---
+
+### 3. Prefer active voice when the actor matters
+
+Name the actor when responsibility or causality matters. Keep passive voice
+when the actor is unknown, immaterial, deliberately withheld, or conventional
+in the technical context. Do not force a human subject into a sentence that
+does not need one.
+
+Bad: "The decision was reached after careful consideration."
+Good: "The team decided after reviewing three options."
+
+Bad: "Mistakes were made."
+Good: Name who made them.
+
+---
+
+### 4. Be specific
+
+No vague declaratives. No lazy extremes. Name the specific thing.
+
+Lazy extremes are every, always, never, everyone, everybody, nobody: false
+authority doing vague work. Vague declaratives announce weight without naming
+it: "The reasons are structural", "The stakes are high", "This is the deepest
+problem", "The consequences are real".
+
+Bad: "The implications are significant."
+Good: Name the implication.
+
+Bad: "Everyone knows this."
+Good: Name who knows it and what they know.
+
+---
+
+### 5. Put the reader in the room when the genre supports it
+
+Specifics beat abstractions. In direct guidance, "you" often beats a vague
+"people." Preserve third-person, academic, legal, or documentary register when
+the source calls for it.
+
+Bad: "Nobody designed this. It just happened."
+Good: "You didn't sit down and decide to build this. It accumulated."
+
+---
+
+### 6. Vary rhythm
+
+Mix sentence lengths. Two items often beat three. End paragraphs differently.
+Follow the supplied house style for em dashes; with no house style given,
+replace them with commas, parentheses, colons, or periods. Never treat
+punctuation as evidence of authorship.
+
+Three consecutive sentences at the same length: break one. Every paragraph
+ending with a punchy one-liner: vary it. Staccato fragments stacked for effect:
+merge them. A question answered in the same breath: let it breathe or cut it.
+Hedging dressed as reassurance ("Not always. Not perfectly."): cut it.
+
+Sentence starters count as rhythm. Wh- openers ("What makes this hard is...")
+read as a crutch: lead with the subject ("The constraint is..."). Paragraphs
+opening with "So": start with content. Sentences opening with "Look,": remove.
+
+---
+
+### 7. Trust the reader
+
+State facts directly. Skip softening, justification, hand-holding. The reader
+is an adult.
+
+Cut: "I want to be clear that..." / "It's important to note that..." / "As you
+might expect..." Start with the content.
+
+---
+
+### 8. Cut quotables
+
+If a sentence sounds like it was written to be screenshotted, rewrite it.
+Pull-quote prose is manufactured. Cut the performance.
+
+---
+
+## Pre-ship checklist
+
+Run every item before delivering prose:
+
+- Empty intensifiers or hedges? Cut them; preserve meaning-bearing adverbs.
+- Passive voice hiding responsibility? Name the actor; preserve useful
+  technical passive voice.
+- Inanimate thing doing a human verb ("the decision emerges")? Name the person.
+- Sentence starts with What/When/Where/Which/Who/Why/How? Restructure it.
+- "Here's what/this/that" opener? Cut to the point.
+- "Not X, it's Y" contrast? State Y directly.
+- Three consecutive sentences at the same length? Break one.
+- Paragraph ends punchily? Vary it.
+- Em dash conflicts with the active house style? Replace it; otherwise preserve
+  the author's punctuation.
+- Vague declarative ("The implications are significant")? Name the specific
+  implication.
+- Narrator above the scene ("Nobody designed this")? Put the reader in it.
+- Meta-joiner ("The rest of this piece...")? Delete. Let it move.
+- Paragraph starts with "So", or a sentence starts with "Look,"? Start with the
+  content.
+- Question answered in the same breath? Let it breathe or cut it.
+- Announced significance ("This is genuinely hard" / "actually matters")? Show
+  it or cut it.
+- Lazy extreme (every, always, never, everyone, nobody) making a vague claim?
+  Name the specific.
+
+---
+
+## Scoring
+
+Rate 1-10 on each dimension after the pass:
+
+| Dimension | Question |
+|-----------|----------|
+| Directness | Statements, not announcements? |
+| Rhythm | Varied, not metronomic? |
+| Trust | Respects the reader? |
+| Authenticity | Sounds human? |
+| Density | Anything still cuttable? |
+
+**Below 35/50: revise.** Do not ship it.
+
+---
+
+## Example
+
+A README intro, run through both modes. The source paragraph carries real
+facts, so the rewrite has something to surface. Nothing below is invented.
+
+### Source
+
+> Here's the thing: developer onboarding isn't just a process problem. It's a
+> cultural one. In today's fast-paced landscape, teams need to leverage robust
+> tooling to seamlessly navigate the challenges of scale. The implications are
+> significant. Our new CLI fundamentally transforms setup. No manual config. No
+> YAML wrangling. No waiting on ops. It turns out that the setup that used to be
+> handled by a dedicated engineer over two days now takes one command. Let that
+> sink in.
+
+### Mode 1: findings-only audit
+
+```text
+Clear issues
+- "Here's the thing:" - throat-clearing before the point - delete; open on the CLI claim.
+- "isn't just a process problem. It's a cultural one." - binary contrast announces an
+  insight the paragraph never delivers; nothing that follows supports "cultural" - state
+  the actual claim or cut the sentence.
+- "In today's fast-paced landscape" - dated filler, and "landscape" names nothing - cut.
+- "leverage robust tooling to seamlessly navigate the challenges of scale" - jargon stack
+  (leverage, robust, seamlessly, navigate) with no capability named - replace with the
+  capability the paragraph already has: one command.
+- "The implications are significant." - vague declarative; the implication appears two
+  sentences later - cut.
+- "fundamentally transforms" - announced significance instead of the before and after,
+  which the source supplies - use the two-days-to-one-command figures.
+- "No manual config. No YAML wrangling. No waiting on ops." - negative listing; runway
+  before the point - one positive sentence naming what the user does.
+- "the setup that used to be handled by a dedicated engineer" - passive hides an actor
+  who matters to the claim - name the engineer's role as the subject.
+- "It turns out that" - throat-clearing - cut.
+- "Let that sink in." - emphasis crutch - cut; the numbers carry it.
+
+Judgment calls
+- "Our new CLI" - "new" expires within a release cycle - drop "new" unless this README is
+  a launch announcement.
+- "developer onboarding" - reads as house vocabulary; if the rest of the docs say
+  "onboarding" alone, match that. Left as supplied.
+
+Boundary: writing-quality signals do not establish authorship.
+```
+
+The source text is returned unchanged in this mode.
+
+### Mode 2: cleaning pass
+
+> A dedicated engineer used to spend two days setting up each new developer.
+> Our CLI does it in one command.
+
+```
+Line edit pass
+------------------------------
+Filler phrases removed:      9
+Structural patterns fixed:   2
+Passive voice to active:     1
+Vague declaratives cut:      1
+Rhythm breaks added:         1
+Em dashes removed:           0
+
+Score
+------------------------------
+Directness:   9
+Rhythm:       8
+Trust:        9
+Authenticity: 8
+Density:      9
+Total:        43/50
+
+Verdict: CLEAN
+```
+
+Note what did not happen. No metric was invented, no customer was named, and
+the "cultural" claim was cut rather than expanded, because the source offered
+no support for it. The two days and the one command were already there.
+
+### More before and after pairs
+
+Before: "Here's the thing - the migration wasn't just a technical challenge. It
+was a fundamental shift in how the team operates. No more silos. No more
+handoffs. No more waiting."
+After: "The migration changed how the team operates: engineers now deploy their
+own services instead of filing tickets and waiting two days."
+
+Before: "The implications are truly significant. This decision was reached
+after careful consideration, and it will ultimately transform the developer
+experience."
+After: "The platform team chose Vite over Webpack. Local builds dropped from 90
+seconds to 4."
+
+Before: "So what does this mean for creators? It means empowerment. It means
+ownership. It means the landscape has fundamentally shifted."
+After: "Creators now hold the registry keys. When a track sells, the split
+executes without a label in the loop."
+
+The specifics in these After lines came from author context. Never invent
+specifics. Ask for missing material when interaction is possible; otherwise
+mark the unresolved gap without manufacturing an answer.
+
+---
+
+## Tips
+
+- **Audit first on anything you did not write.** Findings mode shows you the
+  cost of each edit before a single word moves, which matters when the author
+  is a client, a colleague, or your own past self.
+- **Give it the numbers.** The largest quality jump comes from pasting the real
+  figures next to the draft. Vague prose usually hides missing facts, and a
+  line edit cannot conjure them.
+- **State your house style up front.** One sentence ("we use em dashes, we
+  write in third person") prevents the most common bad edit, which is a
+  correctly applied rule that is wrong for your publication.
+- **Read the Judgment calls section, not just Clear issues.** The judgment calls
+  are where the author's voice actually lives.
+- **A score of 34 means revise.** The threshold is not a suggestion, and
+  rounding up to "close enough" is how slop ships.
+- **Run the pass on your own edit.** The second pass usually finds two or three
+  filler phrases the first one introduced.
+- **Do not run it on a rough draft.** This is a finishing pass. Cleaning prose
+  you are about to restructure wastes the work.
+- **Keep the source.** The skill returns cleaned prose in the response and
+  never overwrites a file, so keep the original until you have compared them.
+
+---
+
+## Common Use Cases
+
+- **README and docs polish** before a repository goes public.
+- **Landing page and product copy** review before launch.
+- **Investor updates, board memos, and press releases**, where the deep sweep
+  in the reference file is worth running.
+- **Newsletters, blog posts, and essays** after an assisted drafting session.
+- **Social posts and launch threads**, where quotable-sounding lines multiply.
+- **Editing someone else's draft** without imposing your voice on it: audit
+  mode gives them findings they can accept or reject one at a time.
+- **Ghostwriting and client work**, where the deliverable has to sound like the
+  named author rather than like a style guide.
+- **Grant applications, proposals, and academic abstracts**, where the
+  third-person register must survive the cleanup.
+- **Style QA on a team**, using the 50-point score as a shared, repeatable
+  quality bar.
+
+---
+
+## Red Flags: Stop
+
+If you catch yourself thinking any of these, stop and correct:
+
+- "It's just an internal note." Internal notes get pasted into public docs. Run
+  the pass.
+- "An em dash proves this was generated." Punctuation cannot establish
+  authorship. Follow the active house style.
+- "That line earned its quotability." If it sounds written to be screenshotted,
+  it was. Rewrite it.
+- "The triad has rhythm." Rhythm the reader has seen a thousand times is a
+  tell, not a style.
+- "The score is 34, close enough." Below 35 means revise. Revise.
+- "This adverb is technically an adverb." Check whether it carries factual,
+  technical, legal, or quoted meaning before cutting it.
+
+---
+
+## Boundaries
+
+This skill edits style only. It must NOT:
+
+- Change any fact, number, date, name, price, claim, qualifier, quotation,
+  code, command, link, citation, or path.
+- Infer or report whether a human or a model wrote the text. Findings describe
+  the prose and its effect only.
+- Flatten deliberate voice traits merely because they resemble a common
+  pattern.
+- Invent a metric, actor, anecdote, customer, quote, or first-person
+  experience.
+- Verify or vouch for the truth of any claim. Flag missing support separately;
+  never qualify, remove, or otherwise alter supplied factual wording during
+  this style pass.
+- Publish, post, send, commit, or overwrite the original file or message.
+  Return cleaned prose in the response; the author decides where it lands.
+- Decide whether the piece should ship at all: the CLEAN or REVISE verdict is
+  about slop, not content approval.
+
+---
+
+## Output format
+
+For a findings-only audit, return:
+
+```text
+Clear issues
+- [exact quote] - [why it weakens this piece] - [minimum correction]
+
+Judgment calls
+- [exact quote] - [context or voice trade-off] - [optional correction]
+
+Boundary: writing-quality signals do not establish authorship.
+```
+
+Do not include cleaned prose in a findings-only audit.
+
+For a cleaning pass, return the cleaned prose first. Then append:
+
+```
+Line edit pass
+------------------------------
+Filler phrases removed:      [count]
+Structural patterns fixed:   [count]
+Passive voice to active:     [count]
+Vague declaratives cut:      [count]
+Rhythm breaks added:         [count]
+Em dashes removed:           [count]
+
+Score
+------------------------------
+Directness:   [1-10]
+Rhythm:       [1-10]
+Trust:        [1-10]
+Authenticity: [1-10]
+Density:      [1-10]
+Total:        [X/50]
+
+Verdict: [CLEAN / REVISE]
+```
+
+If the total is below 35, name what is still generating the score and why it
+could not be resolved without more author context.
+
+---
+
+## Handoffs
+
+- The text needs writing, not cleaning. Use a copywriting or drafting skill;
+  this one only edits prose that already exists.
+- The cleaned text makes claims a public audience will read. Route factual
+  verification to primary evidence such as the current product, a live URL, a
+  recorded metric, or a named source. Report unsupported claims separately
+  without changing their wording.
+- The text needs its argument restructured. That is a developmental edit, not a
+  line edit. Do that first, then run this pass.
+
+---
+
+## Credit
+
+Adapted from the suede-creator-skills collection:
+<https://github.com/JasonColapietro/suede-creator-skills>
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/vendorable/voice-preserving-line-edit/agents/openai.yaml
+++ b/vendorable/voice-preserving-line-edit/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Voice-Preserving Line Edit"
+  short_description: "Remove AI writing patterns without flattening the author's voice, with a findings-only audit mode"
+  default_prompt: "Use $voice-preserving-line-edit on [text]. If I ask for findings only, quote and explain the issues without rewriting. Otherwise make the minimum effective style edits, preserve facts, numbers, quotes, code, links, house style, and deliberate voice, invent nothing, then return the cleaned prose with the change report and 50-point score. Never infer authorship from writing patterns."
+policy:
+  allow_implicit_invocation: true

--- a/vendorable/voice-preserving-line-edit/references/kill-list.md
+++ b/vendorable/voice-preserving-line-edit/references/kill-list.md
@@ -1,0 +1,231 @@
+# Full Kill List
+
+SKILL.md carries the 25 highest-frequency offenders. This file is the complete
+sweep. Run it when the text goes to press, to investors, or to customers, or
+when the SKILL.md table comes back clean and the text still reads generated.
+
+Treat every entry as a contextual signal, not a token ban. Preserve wording
+that carries technical meaning, quotation fidelity, deliberate voice, genre,
+or the supplied house style. Apply the minimum edit that fixes the actual
+problem in the supplied piece.
+
+## Throat-clearing openers
+
+Cut the opener; state the point. Any "here's what/this/that/why" construction
+counts.
+
+- "Here's the thing:"
+- "Here's what [X]" / "Here's this [X]" / "Here's that [X]" / "Here's why [X]"
+- "Here's what I find interesting"
+- "Here's the problem though"
+- "Let's be honest" / "Let's face it"
+- "The truth is" / "The reality is"
+- "The uncomfortable truth is"
+- "It turns out"
+- "The real [X] is"
+- "Let me be clear" / "I want to be clear"
+- "I'll say it again:"
+- "I'm going to be honest"
+- "Can we talk about"
+- "It's worth noting that"
+- "In today's fast-paced world" / "In today's [X]"
+- "Picture this:" / "Imagine this:"
+- "At its core" / "At the end of the day"
+- "When it comes to"
+- "In a world where"
+
+## Emphasis crutches
+
+Delete; they add no meaning.
+
+- "Let that sink in" / "Read that again"
+- "Full stop." / "Period." (as emphasis)
+- "Make no mistake"
+- "This matters because"
+- "Here's why that matters"
+
+## Business jargon
+
+| Kill | Fix |
+|------|-----|
+| leverage (as a verb) | use |
+| utilize | use |
+| delve into | cover, get into |
+| unpack | explain, examine |
+| navigate (a challenge) | handle, work through |
+| lean into | accept, embrace |
+| landscape / ecosystem (abstract) | market, field, or the named thing |
+| journey (not travel) | process, or name the steps |
+| game-changer | name the change |
+| double down | commit, increase |
+| deep dive | analysis, examination |
+| take a step back | reconsider |
+| moving forward | next, from now |
+| circle back | return to, revisit |
+| on the same page | aligned, agreed |
+| unlock / unleash | say what was blocked |
+| robust / seamless / powerful | name the capability or prove it |
+| elevate / empower / transform | say what changes, before and after |
+
+## Adverbs that add no information
+
+Cut an adverb when it merely intensifies, softens, or announces importance.
+Keep it when it carries factual, technical, legal, quoted, or voice-specific
+meaning. Common low-information candidates:
+
+really, just, very, literally, genuinely, honestly, simply, actually, deeply,
+truly, fundamentally, essentially, ultimately, inherently, inevitably,
+interestingly, importantly, notably, crucially, incredibly, remarkably,
+surprisingly, seamlessly, effortlessly.
+
+## Meta-commentary
+
+The piece moves; it never announces its own structure.
+
+- "Hint:"
+- "Plot twist:" / "Spoiler:"
+- "You already know this, but"
+- "But that's another post"
+- "X is a feature, not a bug"
+- "Dressed up as"
+- "The rest of this essay/piece explains..."
+- "Let me walk you through..."
+- "In this section, we'll..."
+- "As we'll see..."
+- "I want to explore..."
+
+## Performative emphasis
+
+False intimacy and manufactured sincerity.
+
+- "creeps in"
+- "I promise"
+- "They exist, I promise"
+
+## Telling instead of showing
+
+Announcing difficulty or significance instead of demonstrating it.
+
+- "This is genuinely hard"
+- "This is what leadership actually looks like"
+- "This is what X actually looks like"
+- "actually matters"
+
+## Vague declaratives
+
+The sentence announces weight without naming the thing. Cut it or replace it
+with the specific thing.
+
+- "The reasons are structural"
+- "The implications are significant"
+- "This is the deepest problem"
+- "The stakes are high"
+- "The consequences are real"
+
+## Binary contrasts, all variants
+
+Telegraphed reversals. Fix: state Y directly and drop the negation.
+
+- "Not because X. Because Y." / "Not because X, but because Y."
+- "[X] isn't the problem. [Y] is."
+- "The answer isn't X. It's Y."
+- "It feels like X. It's actually Y."
+- "The question isn't X. It's Y."
+- "Not X. But Y." / "not X, it's Y" / "isn't X, it's Y"
+- "It's not this. It's that." / "It's not about X. It's about Y."
+- "This isn't just X, it's Y" / "not just X but also Y"
+- "stops being X and starts being Y"
+- "doesn't mean X, but actually Y"
+- "is about X but not Y"
+
+## Negative listing
+
+A rhetorical striptease. Fix: state Z; the reader does not need the runway.
+
+- "No setup. No config. No hassle." (marketing stack)
+- "Not a X... Not a Y... A Z." (buildup through negation)
+- "It wasn't X. It wasn't Y. It was Z." (same, past tense)
+
+## Dramatic fragmentation
+
+Manufactured profundity. Fix: complete sentences; attach fragments to the
+sentence they modify.
+
+- "One problem." / "And it worked."
+- "[Noun]. That's it. That's the [thing]."
+- "X. And Y. And Z."
+- "This unlocks something. [Word]."
+
+## Rhetorical setups
+
+Announce insight instead of delivering it. Fix: delete the question or
+preview; give the answer.
+
+- "So what does this mean for you?"
+- "What if [reframe]?" / "What if I told you...?"
+- "Here's what I mean:"
+- "Think about it:"
+- "And that's okay." (unnecessary permission)
+
+## Formulaic constructions
+
+- "By the time X, I was Y." (narrative template; state the fact)
+- "X that isn't Y" (indirect; say "X is broken")
+
+## False agency
+
+Inanimate things doing human verbs. Fix: name the human. If no specific person
+fits, use "you" to put the reader in the seat.
+
+- "the data tells us" (someone read it and concluded)
+- "the essay argues" (the author argues)
+- "a complaint becomes a fix" (someone fixed it)
+- "a bet lives or dies in days" (someone ships it or kills it)
+- "the decision emerges" (someone decides)
+- "the culture shifts" (people change behavior)
+- "the conversation moves toward" (someone steers)
+- "the market rewards" (buyers pay for things)
+
+## Narrator-from-a-distance
+
+Floating above the scene. Fix: put the reader in the room.
+
+- "Nobody designed this."
+- "This happens because..."
+- "This is why..."
+- "People tend to..."
+
+## Passive voice
+
+Fix: find the actor, put them at the front of the sentence. Keep the passive
+when the actor is unknown, immaterial, deliberately withheld, or conventional
+for the genre.
+
+- "X was created" (name who created it)
+- "It is believed that" (name who believes it)
+- "Mistakes were made" (name who made them)
+- "The decision was reached" (name who decided)
+
+## Sentence starters
+
+- Sentences opening with What / When / Where / Which / Who / Why / How:
+  restructure. "What makes this hard is..." becomes "The constraint is...", or
+  name the specific constraint.
+- Paragraphs opening with "So": start with content.
+- Sentences opening with "Look,": remove.
+
+## Rhythm patterns
+
+- Three-item lists: use two items or one, unless the count is really three.
+- Questions answered in the same breath: let the question breathe or cut it.
+- Every paragraph ending punchy: vary endings.
+- Em dashes: follow the supplied house style. With no house style given,
+  replace them with commas, parentheses, colons, or periods. Punctuation is
+  never evidence of authorship.
+- Staccato fragments stacked for effect: merge them.
+- "Not always. Not perfectly.": hedging dressed as reassurance. Cut it.
+
+## Lazy extremes
+
+every, always, never, everyone, everybody, nobody. False authority doing vague
+work. Replace the sweeping claim with the specific.


### PR DESCRIPTION
Some skill directories vendor a folder into their own repository instead of linking out to a collection. ComposioHQ/awesome-claude-skills works that way, and PR #1803 there is a neutralized copy of `suede-design` submitted as `frontend-design-review`.

That route cannot carry a brand-prefixed frontmatter description or routing to sibling skills a curator does not have, so each submission needs a prepared copy. `vendorable/` is where those live.

## What is here

| Folder | Source | Change |
| --- | --- | --- |
| `site-to-ios-app` | `skills/site-to-ios-app` | Description debranded, sibling routing removed, `CARD.md` omitted |
| `voice-preserving-line-edit` | `skills/suede-deslop` | Renamed, and the description now leads on the differentiators |

## What was preserved

`site-to-ios-app` keeps the App Store Guideline 4.2 wrapper-rejection gate and its halt condition, the four strategy routes, the nine-step flow, and the literal `xcodebuild` and secret-scan commands from the Completion Bar.

`voice-preserving-line-edit` keeps all 26 kill-table rows, the 16-item pre-ship checklist, the 35/50 threshold, and both output contracts. Its `references/kill-list.md` differs from the source in four hunks, all deliberate.

## Notes

- `voice-preserving-line-edit/LICENSE` keeps the original copyright line. That is attribution, not branding, and removing it would be wrong.
- Plain ASCII throughout, verified. That mattered for the line-edit skill in particular, since it instructs readers to remove em dashes.
- These are not installed by the plugin and are not in the catalog, so skill counts are unaffected.
- They do not track their sources automatically. `vendorable/README.md` says so.