### PR TITLE
ci: give validate a budget the suite actually fits in

### DIFF
--- a/.github/workflows/skill-pack-ci.yml
+++ b/.github/workflows/skill-pack-ci.yml
@@ -16,7 +16,21 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 25, not 10. `npm run ci` is ~6 minutes of wall clock on an M-series Mac and
+    # roughly twice that on a hosted runner, so the old budget killed the job
+    # mid-run at ~10m and reported it as a failure. Measured 2026-09-03:
+    #
+    #   npm run ci                     355 s total, exit 0
+    #   of which test:validator-runtime 261 s  (32 tests, all passing)
+    #
+    # The cost is inherent, not a leak: each of those 32 tests spawns
+    # validate-skill-pack.mjs against a packaged copy of the repo, and one
+    # validator run alone is ~4.9 s. Building the fixture is only ~0.4 s, so
+    # there is nothing to win by caching it.
+    #
+    # If this starts timing out again, the fix is concurrency - the tests are
+    # independent, each in its own temp dir - not another bump.
+    timeout-minutes: 25
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The `validate` job has been failing on every PR in this repo. **It is not hanging and nothing is broken** — it was being killed at its 10-minute limit.

The log looked like a hang because the kill left `npm run test:validator-runtime` in the orphaned-process list. It was simply still working.

## Measured, 2026-09-03

On an M-series Mac:

| | |
|---|--:|
| `npm run ci` | **355 s**, exit 0 |
| of which `test:validator-runtime` | **261 s** — 32 tests, **all 32 passing** |

A hosted runner is roughly twice as slow. That is why the job died at 10m16s.

## The cost is inherent, not a leak

Each of those 32 tests spawns `validate-skill-pack.mjs --strict` against a packaged copy of the repo. Timed separately:

| | |
|---|--:|
| fixture copy (`fs.cpSync` of the repo) | 420 ms |
| one validator run | **4880 ms** |

So caching or sharing fixtures would save almost nothing — the validator itself is the whole bill, 32 times over.

## The change

`timeout-minutes: 10` → `25` on `validate` only. The `build` job keeps its 10; it finishes in about 9 seconds.

The measurements and the real next lever are in a comment above the setting, so nobody has to re-derive this:

> If this starts timing out again, the fix is concurrency — the tests are independent, each in its own temp dir — not another bump.

That is a genuine option worth taking later: the tests are I/O-bound on subprocess spawns and share no state, so running them concurrently should cut wall clock several-fold. It is a real refactor of a 1182-line file though, and not something to fold into a timeout fix.

## Why this matters beyond one PR

This was blocking **every** pull request in the repo, not just mine — including #154, which is otherwise ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)