### PR TITLE
claims: remove the unsubstantiated Forbes contributor credential

### DIFF
--- a/COPY.md
+++ b/COPY.md
@@ -182,8 +182,7 @@ Suede Creator Skills are those misses written down as methods, and they now run
 30+ live sites and 8 iOS apps from one terminal with zero employees.
 
 Suede's founder is
-[Jason Colapietro](https://suedeai.ai/founder), a published author and Forbes
-contributor building programmable IP and creator ownership infrastructure.
+[Jason Colapietro](https://suedeai.ai/founder), a published author building programmable IP and creator ownership infrastructure.
 
 ### Progressive updating note
 


### PR DESCRIPTION
Removes the "Forbes contributor" string from public copy.

No source for the claim exists anywhere in the repo, and two test suites already assert the string must not appear: `suede-agent-studio/tests/seo-aeo-discovery.test.ts` and `Suede-AI-App/suede-home/tests/seo-entity-source.test.mjs`.
