### PR TITLE
schema: anchor every author Person node to the canonical entity

### DIFF
--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -28,7 +28,7 @@
         "url": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html",
         "datePublished": "2026-07-19",
         "dateModified": "2026-07-19",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Android app development", "next action recommendation", "agent workflow"],
         "mainEntityOfPage": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html"

--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -28,7 +28,7 @@
         "url": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html",
         "datePublished": "2026-07-19",
         "dateModified": "2026-07-19",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Android app development", "next action recommendation", "agent workflow"],
         "mainEntityOfPage": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html"

--- a/docs/blog/memory-belongs-in-skills.html
+++ b/docs/blog/memory-belongs-in-skills.html
@@ -30,8 +30,7 @@
   "dateModified": "2026-08-07",
   "author": {
     "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/blog/memory-belongs-in-skills.html
+++ b/docs/blog/memory-belongs-in-skills.html
@@ -29,7 +29,7 @@
   "datePublished": "2026-08-07",
   "dateModified": "2026-08-07",
   "author": {
-    "@type": "Person",
+    "@type": "Person", "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/blog/not-for-the-line-that-makes-a-pack-work.html
+++ b/docs/blog/not-for-the-line-that-makes-a-pack-work.html
@@ -30,8 +30,7 @@
   "dateModified": "2026-08-07",
   "author": {
     "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/blog/not-for-the-line-that-makes-a-pack-work.html
+++ b/docs/blog/not-for-the-line-that-makes-a-pack-work.html
@@ -29,7 +29,7 @@
   "datePublished": "2026-08-07",
   "dateModified": "2026-08-07",
   "author": {
-    "@type": "Person",
+    "@type": "Person", "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
+++ b/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
@@ -28,7 +28,7 @@
         "url": "https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html",
         "datePublished": "2026-08-07",
         "dateModified": "2026-08-21",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "progressive disclosure", "Agent Skills", "MCP server", "CI ship gate", "agent orchestration"],
         "mainEntityOfPage": "https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html"

--- a/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
+++ b/docs/blog/progressive-disclosure-ship-dag-and-mcp.html
@@ -28,7 +28,7 @@
         "url": "https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html",
         "datePublished": "2026-08-07",
         "dateModified": "2026-08-21",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "progressive disclosure", "Agent Skills", "MCP server", "CI ship gate", "agent orchestration"],
         "mainEntityOfPage": "https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html"

--- a/docs/blog/vetted-is-a-procedure-not-a-compliment.html
+++ b/docs/blog/vetted-is-a-procedure-not-a-compliment.html
@@ -29,7 +29,7 @@
   "datePublished": "2026-08-26",
   "dateModified": "2026-08-26",
   "author": {
-    "@type": "Person",
+    "@type": "Person", "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/blog/vetted-is-a-procedure-not-a-compliment.html
+++ b/docs/blog/vetted-is-a-procedure-not-a-compliment.html
@@ -30,8 +30,7 @@
   "dateModified": "2026-08-26",
   "author": {
     "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/blog/why-breadth-is-free.html
+++ b/docs/blog/why-breadth-is-free.html
@@ -30,8 +30,7 @@
   "dateModified": "2026-08-07",
   "author": {
     "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/blog/why-breadth-is-free.html
+++ b/docs/blog/why-breadth-is-free.html
@@ -29,7 +29,7 @@
   "datePublished": "2026-08-07",
   "dateModified": "2026-08-07",
   "author": {
-    "@type": "Person",
+    "@type": "Person", "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/anatomy-of-a-skill.html
+++ b/docs/book/anatomy-of-a-skill.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/anatomy-of-a-skill.html
+++ b/docs/book/anatomy-of-a-skill.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/design-and-copy-are-engineering.html
+++ b/docs/book/design-and-copy-are-engineering.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/design-and-copy-are-engineering.html
+++ b/docs/book/design-and-copy-are-engineering.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/evidence-or-it-did-not-ship.html
+++ b/docs/book/evidence-or-it-did-not-ship.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/evidence-or-it-did-not-ship.html
+++ b/docs/book/evidence-or-it-did-not-ship.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/front-matter.html
+++ b/docs/book/front-matter.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/front-matter.html
+++ b/docs/book/front-matter.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/full-send.html
+++ b/docs/book/full-send.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/full-send.html
+++ b/docs/book/full-send.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/getting-found.html
+++ b/docs/book/getting-found.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/getting-found.html
+++ b/docs/book/getting-found.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/grading-your-own-work.html
+++ b/docs/book/grading-your-own-work.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/grading-your-own-work.html
+++ b/docs/book/grading-your-own-work.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -38,6 +38,7 @@
   "datePublished": "2026-08-10",
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -39,8 +39,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/lanes-fleets-and-collisions.html
+++ b/docs/book/lanes-fleets-and-collisions.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/lanes-fleets-and-collisions.html
+++ b/docs/book/lanes-fleets-and-collisions.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/shipping-into-the-real-world.html
+++ b/docs/book/shipping-into-the-real-world.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/shipping-into-the-real-world.html
+++ b/docs/book/shipping-into-the-real-world.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/skill-index.html
+++ b/docs/book/skill-index.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/skill-index.html
+++ b/docs/book/skill-index.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/taste-judgment-and-stopping.html
+++ b/docs/book/taste-judgment-and-stopping.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/taste-judgment-and-stopping.html
+++ b/docs/book/taste-judgment-and-stopping.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/the-competence-gap.html
+++ b/docs/book/the-competence-gap.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/the-competence-gap.html
+++ b/docs/book/the-competence-gap.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/the-description-contract.html
+++ b/docs/book/the-description-contract.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/the-description-contract.html
+++ b/docs/book/the-description-contract.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/the-first-ninety-days.html
+++ b/docs/book/the-first-ninety-days.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/the-first-ninety-days.html
+++ b/docs/book/the-first-ninety-days.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/the-rules.html
+++ b/docs/book/the-rules.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/the-rules.html
+++ b/docs/book/the-rules.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/the-s-tier-ladder.html
+++ b/docs/book/the-s-tier-ladder.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/the-s-tier-ladder.html
+++ b/docs/book/the-s-tier-ladder.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/book/write-your-own.html
+++ b/docs/book/write-your-own.html
@@ -43,6 +43,7 @@
   },
   "author": {
     "@type": "Person",
+    "@id": "https://suedeai.ai/founder#person",
     "name": "Jason Colapietro",
     "url": "https://github.com/JasonColapietro"
   },

--- a/docs/book/write-your-own.html
+++ b/docs/book/write-your-own.html
@@ -44,8 +44,7 @@
   "author": {
     "@type": "Person",
     "@id": "https://suedeai.ai/founder#person",
-    "name": "Jason Colapietro",
-    "url": "https://github.com/JasonColapietro"
+    "name": "Jason Colapietro"
   },
   "publisher": {
     "@type": "Organization",

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -27,7 +27,7 @@
       "description": "Public copy bank for Suede Creator Skills: repo descriptions, page copy, docs copy, CTAs, anti-slop copy, visibility grading, A-F code grades, coordinated agent-team loops, SEO/AEO/AI EO metadata, and safety language.",
       "url": "https://skills.suedeai.ai/copy.html",
       "author": {
-        "@type": "Person",
+        "@type": "Person", "@id": "https://suedeai.ai/founder#person",
         "name": "Jason Colapietro",
         "url": "https://github.com/JasonColapietro"
       },

--- a/docs/copy.html
+++ b/docs/copy.html
@@ -28,8 +28,7 @@
       "url": "https://skills.suedeai.ai/copy.html",
       "author": {
         "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-        "name": "Jason Colapietro",
-        "url": "https://github.com/JasonColapietro"
+        "name": "Jason Colapietro"
       },
       "publisher": {
         "@type": "Organization",

--- a/docs/cracked.html
+++ b/docs/cracked.html
@@ -26,7 +26,7 @@
       "name": "The Agentic Adderall Stack",
       "description": "A stack of four Suede skills for the runs that have to finish: Suede Thought Graph shipping search, agent-team orchestration, an umbrella router, and a next-move loop.",
       "url": "https://skills.suedeai.ai/cracked.html",
-      "author": { "@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro" },
+      "author": { "@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro" },
       "publisher": { "@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai" },
       "mainEntity": {
         "@type": "ItemList",

--- a/docs/cracked.html
+++ b/docs/cracked.html
@@ -26,7 +26,7 @@
       "name": "The Agentic Adderall Stack",
       "description": "A stack of four Suede skills for the runs that have to finish: Suede Thought Graph shipping search, agent-team orchestration, an umbrella router, and a next-move loop.",
       "url": "https://skills.suedeai.ai/cracked.html",
-      "author": { "@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro" },
+      "author": { "@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro" },
       "publisher": { "@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai" },
       "mainEntity": {
         "@type": "ItemList",

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -27,7 +27,7 @@
       "description": "Install public Suede skills for Claude Code and Codex from GitHub and use the Suede Skills MCP for Suedify, design, anti-slop copywriting, visibility grading, code grading, Suede SEO/AEO/AI EO copy audits, and QA checklists.",
       "url": "https://skills.suedeai.ai/plugins.html",
       "author": {
-        "@type": "Person",
+        "@type": "Person", "@id": "https://suedeai.ai/founder#person",
         "name": "Jason Colapietro",
         "url": "https://github.com/JasonColapietro"
       },

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -28,8 +28,7 @@
       "url": "https://skills.suedeai.ai/plugins.html",
       "author": {
         "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-        "name": "Jason Colapietro",
-        "url": "https://github.com/JasonColapietro"
+        "name": "Jason Colapietro"
       },
       "publisher": {
         "@type": "Organization",

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -20,463 +20,463 @@
   </url>
   <url>
     <loc>https://skills.suedeai.ai/copy.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/plugins.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/cracked.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-workflow-skills.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/johnny-suede-write.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/johnny-suede-design.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-visibility-grader.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ai-eval.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-agent-teams.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-code-grader.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-rights-passport.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-release-linter.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-code.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-code-review.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ci-gate.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/amazon-returns-recovery.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/android-app-factory.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/site-to-ios-app.html</loc>
-    <lastmod>2026-08-18</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/subscription-recovery.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ab-testing.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ad-creative.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ads.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ai-seo.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-analytics.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-aso.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-attribution.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-churn-prevention.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-clip-to-guide.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-co-marketing.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-cold-email.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-community-marketing.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-competitor-profiling.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-competitors.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-content-strategy.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-copy.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-customer-research.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-design.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-deslop.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-directory-submissions.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-emails.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-free-tools.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-graph-flo-xr.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-image.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-instagram-growth.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-launch-packaging.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-lead-magnets.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-marketing-council.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-marketing-ideas.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-marketing-loops.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-marketing-plan.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-marketing-psychology.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-mcp-qa.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-newsroom.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-offers.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-onboarding.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ops-architecture.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ops-assessment.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-paywalls.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-pricing.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-product-marketing.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-programmatic-seo.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-prospecting.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-public-relations.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-recommend-next-action.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-referrals.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-revops.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-rights-audit.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-sales-enablement.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-seo-audit.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-ship-copy.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-signup.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-site-alchemy.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-sms.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-social.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-sync-packaging.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/skills/suede-video.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -488,145 +488,145 @@
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/memory-belongs-in-skills.html</loc>
-    <lastmod>2026-08-27</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/not-for-the-line-that-makes-a-pack-work.html</loc>
-    <lastmod>2026-08-27</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/progressive-disclosure-ship-dag-and-mcp.html</loc>
-    <lastmod>2026-08-24</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/vetted-is-a-procedure-not-a-compliment.html</loc>
-    <lastmod>2026-08-26</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/why-breadth-is-free.html</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/anatomy-of-a-skill.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/design-and-copy-are-engineering.html</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/evidence-or-it-did-not-ship.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/front-matter.html</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/full-send.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/getting-found.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/grading-your-own-work.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/lanes-fleets-and-collisions.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/shipping-into-the-real-world.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/skill-index.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/taste-judgment-and-stopping.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/the-competence-gap.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/the-description-contract.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/the-first-ninety-days.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/the-rules.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/the-s-tier-ladder.html</loc>
-    <lastmod>2026-08-29</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://skills.suedeai.ai/book/write-your-own.html</loc>
-    <lastmod>2026-09-01</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -26,7 +26,7 @@
         "headline": "Amazon Returns Recovery - Suede Creator Skills",
         "description": "$448.31 argued back so far, including a $372.69 refund Amazon had already denied once, granted after the return window closed. The skill reads your order history and your Amazon-billed subscriptions for restocking fees, short refunds, and charges you stopped noticing, builds the case, and drives the live chat. It touches nothing without your per-item say-so, and it never promises a recovery.",
         "url": "https://skills.suedeai.ai/skills/amazon-returns-recovery.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Amazon restocking fee", "Amazon refund dispute", "Amazon returns", "Amazon subscriptions", "Britbox", "Starz", "Audible", "browser automation", "Claude in Chrome", "consumer recovery"],
         "mainEntity": {

--- a/docs/skills/amazon-returns-recovery.html
+++ b/docs/skills/amazon-returns-recovery.html
@@ -26,7 +26,7 @@
         "headline": "Amazon Returns Recovery - Suede Creator Skills",
         "description": "$448.31 argued back so far, including a $372.69 refund Amazon had already denied once, granted after the return window closed. The skill reads your order history and your Amazon-billed subscriptions for restocking fees, short refunds, and charges you stopped noticing, builds the case, and drives the live chat. It touches nothing without your per-item say-so, and it never promises a recovery.",
         "url": "https://skills.suedeai.ai/skills/amazon-returns-recovery.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Amazon restocking fee", "Amazon refund dispute", "Amazon returns", "Amazon subscriptions", "Britbox", "Starz", "Audible", "browser automation", "Claude in Chrome", "consumer recovery"],
         "mainEntity": {

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -26,7 +26,7 @@
         "headline": "Android App Factory - Suede Creator Skills",
         "description": "Give it a product idea or a target keyword and it runs the native pipeline: Kotlin and Jetpack Compose scaffolding, a working core loop before any polish, Play Billing, the Data Safety disclosure, signing, and the Play Console release. Every rollout starts on a testing track, internal or closed, and stops for your confirmation. Nothing reaches production on its own.",
         "url": "https://skills.suedeai.ai/skills/android-app-factory.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Android app development", "Kotlin", "Jetpack Compose", "Play Billing", "Google Play Console", "ASO", "Play Store listing", "Data Safety form"],
         "mainEntity": {

--- a/docs/skills/android-app-factory.html
+++ b/docs/skills/android-app-factory.html
@@ -26,7 +26,7 @@
         "headline": "Android App Factory - Suede Creator Skills",
         "description": "Give it a product idea or a target keyword and it runs the native pipeline: Kotlin and Jetpack Compose scaffolding, a working core loop before any polish, Play Billing, the Data Safety disclosure, signing, and the Play Console release. Every rollout starts on a testing track, internal or closed, and stops for your confirmation. Nothing reaches production on its own.",
         "url": "https://skills.suedeai.ai/skills/android-app-factory.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Android app development", "Kotlin", "Jetpack Compose", "Play Billing", "Google Play Console", "ASO", "Play Store listing", "Data Safety form"],
         "mainEntity": {

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -26,7 +26,7 @@
         "headline": "Johnny Suede Design",
         "description": "Load it when a surface needs layout and words together: a landing page, a product UI, a launch page, or a restyle where the brief is make this site look like that one. It runs design, copy, and visual QA as a single pass and hands back evidence instead of a mockup. For one token, one component, or a dark-mode call, suede-design is the lighter tool.",
         "url": "https://skills.suedeai.ai/skills/johnny-suede-design.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "design systems", "Suedify", "website redesign", "product surfaces", "mobile design", "product screenshots", "copywriting", "Suede SEO", "SEO", "AI EO", "SKILL.md"],
         "mainEntity": {

--- a/docs/skills/johnny-suede-design.html
+++ b/docs/skills/johnny-suede-design.html
@@ -26,7 +26,7 @@
         "headline": "Johnny Suede Design",
         "description": "Load it when a surface needs layout and words together: a landing page, a product UI, a launch page, or a restyle where the brief is make this site look like that one. It runs design, copy, and visual QA as a single pass and hands back evidence instead of a mockup. For one token, one component, or a dark-mode call, suede-design is the lighter tool.",
         "url": "https://skills.suedeai.ai/skills/johnny-suede-design.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "design systems", "Suedify", "website redesign", "product surfaces", "mobile design", "product screenshots", "copywriting", "Suede SEO", "SEO", "AI EO", "SKILL.md"],
         "mainEntity": {

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -26,7 +26,7 @@
         "headline": "Johnny Suede Write",
         "description": "One skill for the whole writing stack: pages, docs, email, social, headlines, CTAs, product listings, and the documents an agent reads, like a SKILL.md or a CLAUDE.md. Every draft runs the persona and framework pick, the brand-voice pass, the SEO and AEO pass, and the shared Slop Stop pass, then leaves with a score and the list of claims that still need proof. One surface with no voice retune is a job for suede-copy.",
         "url": "https://skills.suedeai.ai/skills/johnny-suede-write.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "copywriting", "product pages", "mobile copy", "product listing", "Suede SEO", "SEO", "AEO", "AI EO", "CTAs", "founder voice", "SKILL.md"],
         "mainEntity": {

--- a/docs/skills/johnny-suede-write.html
+++ b/docs/skills/johnny-suede-write.html
@@ -26,7 +26,7 @@
         "headline": "Johnny Suede Write",
         "description": "One skill for the whole writing stack: pages, docs, email, social, headlines, CTAs, product listings, and the documents an agent reads, like a SKILL.md or a CLAUDE.md. Every draft runs the persona and framework pick, the brand-voice pass, the SEO and AEO pass, and the shared Slop Stop pass, then leaves with a score and the list of claims that still need proof. One surface with no voice retune is a job for suede-copy.",
         "url": "https://skills.suedeai.ai/skills/johnny-suede-write.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "copywriting", "product pages", "mobile copy", "product listing", "Suede SEO", "SEO", "AEO", "AI EO", "CTAs", "founder voice", "SKILL.md"],
         "mainEntity": {

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -26,7 +26,7 @@
         "headline": "Site to iOS App - Suede Creator Skills",
         "description": "Site to iOS App audits websites, chooses a Capacitor or native strategy, gates App Store 4.2 wrapper risk, plans native value, and blocks release until explicit submission delegation.",
         "url": "https://skills.suedeai.ai/skills/site-to-ios-app.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "site-to-iOS conversion", "App Store 4.2", "Capacitor", "SwiftUI", "WebView", "native value", "release gate"],
         "mainEntity": {

--- a/docs/skills/site-to-ios-app.html
+++ b/docs/skills/site-to-ios-app.html
@@ -26,7 +26,7 @@
         "headline": "Site to iOS App - Suede Creator Skills",
         "description": "Site to iOS App audits websites, chooses a Capacitor or native strategy, gates App Store 4.2 wrapper risk, plans native value, and blocks release until explicit submission delegation.",
         "url": "https://skills.suedeai.ai/skills/site-to-ios-app.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "site-to-iOS conversion", "App Store 4.2", "Capacitor", "SwiftUI", "WebView", "native value", "release gate"],
         "mainEntity": {

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -26,7 +26,7 @@
         "headline": "Subscription Recovery - Suede Creator Skills",
         "description": "The App Store, Google Play, and PayPal each keep one page listing every merchant with standing permission to bill you. The skill builds the inventory from those three pages, your bank and card statements, and one direct ask: what you pay, what you use, and what you forgot. You name each service before it cancels or disputes anything, and it never touches payment credentials.",
         "url": "https://skills.suedeai.ai/skills/subscription-recovery.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "subscription cancellation", "recurring charge audit", "Netflix", "Spotify", "App Store subscriptions", "Google Play subscriptions", "PayPal recurring payments", "browser automation", "Claude in Chrome", "consumer recovery"],
         "mainEntity": {

--- a/docs/skills/subscription-recovery.html
+++ b/docs/skills/subscription-recovery.html
@@ -26,7 +26,7 @@
         "headline": "Subscription Recovery - Suede Creator Skills",
         "description": "The App Store, Google Play, and PayPal each keep one page listing every merchant with standing permission to bill you. The skill builds the inventory from those three pages, your bank and card statements, and one direct ask: what you pay, what you use, and what you forgot. You name each service before it cancels or disputes anything, and it never touches payment credentials.",
         "url": "https://skills.suedeai.ai/skills/subscription-recovery.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "subscription cancellation", "recurring charge audit", "Netflix", "Spotify", "App Store subscriptions", "Google Play subscriptions", "PayPal recurring payments", "browser automation", "Claude in Chrome", "consumer recovery"],
         "mainEntity": {

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ab Testing - Suede Creator Skills",
         "description": "Sample size, duration, and the decision rule get written down before the test starts, so nobody calls a winner on day two. It frames the hypothesis, sizes the sample, sets the run length, and turns one-off guesses into an experiment backlog with a cadence. Instrumentation belongs to suede-analytics, and the variant copy to suede-copy.",
         "url": "https://skills.suedeai.ai/skills/suede-ab-testing.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ab-testing.html
+++ b/docs/skills/suede-ab-testing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ab Testing - Suede Creator Skills",
         "description": "Sample size, duration, and the decision rule get written down before the test starts, so nobody calls a winner on day two. It frames the hypothesis, sizes the sample, sets the run length, and turns one-off guesses into an experiment backlog with a cadence. Instrumentation belongs to suede-analytics, and the variant copy to suede-copy.",
         "url": "https://skills.suedeai.ai/skills/suede-ab-testing.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ad Creative - Suede Creator Skills",
         "description": "Hooks, headlines, and primary text written to each platform's character and asset limits, plus static and motion concepts, delivered as test-ready batches with a review page. A testing cadence decides which creative retires and when, so a loser stops spending on schedule rather than when someone notices. Budgets, bidding, and targeting live in suede-ads.",
         "url": "https://skills.suedeai.ai/skills/suede-ad-creative.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ad-creative.html
+++ b/docs/skills/suede-ad-creative.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ad Creative - Suede Creator Skills",
         "description": "Hooks, headlines, and primary text written to each platform's character and asset limits, plus static and motion concepts, delivered as test-ready batches with a review page. A testing cadence decides which creative retires and when, so a loser stops spending on schedule rather than when someone notices. Budgets, bidding, and targeting live in suede-ads.",
         "url": "https://skills.suedeai.ai/skills/suede-ad-creative.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ads - Suede Creator Skills",
         "description": "Every ad gets a kill-or-scale call against a break-even ceiling you compute before you pull any lever. The skill structures the campaign, sets the audiences and the bids, paces the budget, and keeps the negative keywords current, then uses that evidence to make the call. Creative variants come from suede-ad-creative, and the measurement from suede-analytics.",
         "url": "https://skills.suedeai.ai/skills/suede-ads.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ads.html
+++ b/docs/skills/suede-ads.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ads - Suede Creator Skills",
         "description": "Every ad gets a kill-or-scale call against a break-even ceiling you compute before you pull any lever. The skill structures the campaign, sets the audiences and the bids, paces the budget, and keeps the negative keywords current, then uses that evidence to make the call. Creative variants come from suede-ad-creative, and the measurement from suede-analytics.",
         "url": "https://skills.suedeai.ai/skills/suede-ads.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -27,7 +27,7 @@
         "description": "Public Codex skill for coordinating complex changes across agent lanes with quality gates, collision detection, rollback trees, and a signed evidence handoff.",
         "url": "https://skills.suedeai.ai/skills/suede-agent-teams.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-agent-teams.html
+++ b/docs/skills/suede-agent-teams.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-agent-teams.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-ai-eval.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-ai-eval.html
+++ b/docs/skills/suede-ai-eval.html
@@ -27,7 +27,7 @@
         "description": "It writes the one-paragraph AI-SPEC first, then maps every failure mode before a single test exists, and turns those into a severity-scored rubric, concrete pass and fail cases, and acceptance gates a release can fail on. A model grading its own output does not count as evidence here. Use it whenever a change ships LLM, RAG, agent, classifier, prompt, or generated-media behavior.",
         "url": "https://skills.suedeai.ai/skills/suede-ai-eval.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-ai-seo.html
+++ b/docs/skills/suede-ai-seo.html
@@ -26,7 +26,7 @@
         "headline": "Suede AI SEO - Suede Creator Skills",
         "description": "ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, and Copilot quote the pages they can parse and skip the ones they cannot. The skill restructures content into citable units, adds the machine-readable files the non-Google engines parse when they are there, llms.txt among them, and checks that the AI crawlers are allowed in at all; where Google does the citing, it optimizes for people and core Search. The verdict is advisory: it names what blocks a citation, and you decide what ships.",
         "url": "https://skills.suedeai.ai/skills/suede-ai-seo.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ai-seo.html
+++ b/docs/skills/suede-ai-seo.html
@@ -26,7 +26,7 @@
         "headline": "Suede AI SEO - Suede Creator Skills",
         "description": "ChatGPT, Perplexity, Google AI Overviews, Claude, Gemini, and Copilot quote the pages they can parse and skip the ones they cannot. The skill restructures content into citable units, adds the machine-readable files the non-Google engines parse when they are there, llms.txt among them, and checks that the AI crawlers are allowed in at all; where Google does the citing, it optimizes for people and core Search. The verdict is advisory: it names what blocks a citation, and you decide what ships.",
         "url": "https://skills.suedeai.ai/skills/suede-ai-seo.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -26,7 +26,7 @@
         "headline": "Suede Analytics - Suede Creator Skills",
         "description": "The plan says which events exist; the browser says which ones fire, how many times, and with what parameters. The skill writes the tracking plan, instruments events and conversions, enforces UTM discipline, then audits the live tags against the plan so the dashboard counts real behavior. Attribution models and experiment significance belong to suede-attribution and suede-ab-testing.",
         "url": "https://skills.suedeai.ai/skills/suede-analytics.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-analytics.html
+++ b/docs/skills/suede-analytics.html
@@ -26,7 +26,7 @@
         "headline": "Suede Analytics - Suede Creator Skills",
         "description": "The plan says which events exist; the browser says which ones fire, how many times, and with what parameters. The skill writes the tracking plan, instruments events and conversions, enforces UTM discipline, then audits the live tags against the plan so the dashboard counts real behavior. Attribution models and experiment significance belong to suede-attribution and suede-ab-testing.",
         "url": "https://skills.suedeai.ai/skills/suede-analytics.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -26,7 +26,7 @@
         "headline": "Suede Aso - Suede Creator Skills",
         "description": "Apple reads a keyword field; Google Play reads the title and the description. The skill scores your live listing dimension by dimension against the bundled Apple and Google Play specs, checks brand maturity before it scores, then rewrites the title, subtitle, keyword fields, and screenshot order for each store's rules, with a teardown of the competing listings. Building or releasing the app is another skill's job.",
         "url": "https://skills.suedeai.ai/skills/suede-aso.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-aso.html
+++ b/docs/skills/suede-aso.html
@@ -26,7 +26,7 @@
         "headline": "Suede Aso - Suede Creator Skills",
         "description": "Apple reads a keyword field; Google Play reads the title and the description. The skill scores your live listing dimension by dimension against the bundled Apple and Google Play specs, checks brand maturity before it scores, then rewrites the title, subtitle, keyword fields, and screenshot order for each store's rules, with a teardown of the competing listings. Building or releasing the app is another skill's job.",
         "url": "https://skills.suedeai.ai/skills/suede-aso.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-attribution.html
+++ b/docs/skills/suede-attribution.html
@@ -26,7 +26,7 @@
         "headline": "Suede Attribution - Suede Creator Skills",
         "description": "Three tools, one sale, three numbers. The skill reconciles them into one defensible read: which model fits your funnel, what self-reported attribution adds, and where the identity graph breaks. It also builds the instrumentation track, closing the identify() gap and stitching conversions that finish on a third-party checkout domain. The event plumbing itself belongs to suede-analytics.",
         "url": "https://skills.suedeai.ai/skills/suede-attribution.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-attribution.html
+++ b/docs/skills/suede-attribution.html
@@ -26,7 +26,7 @@
         "headline": "Suede Attribution - Suede Creator Skills",
         "description": "Three tools, one sale, three numbers. The skill reconciles them into one defensible read: which model fits your funnel, what self-reported attribution adds, and where the identity graph breaks. It also builds the instrumentation track, closing the identify() gap and stitching conversions that finish on a third-party checkout domain. The event plumbing itself belongs to suede-analytics.",
         "url": "https://skills.suedeai.ai/skills/suede-attribution.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -26,7 +26,7 @@
         "headline": "Suede Campaign in a Box - Suede Creator Skills",
         "description": "Hand it a song, a release, an era, a show, or a catalog moment and it returns the campaign: a rollout calendar down to release week, hooks and rituals, fan actions, site and email copy, press angles, and collaborator outreach. Where a rights or safety fact is missing it writes unknown instead of guessing. Sync packaging and single-surface copy route to their own skills.",
         "url": "https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills","Claude Code skills","Codex skills","artist campaigns","release rollouts","fan rituals","visualizer treatments","merch objects","campaign safety"],
         "mainEntity": {

--- a/docs/skills/suede-campaign-in-a-box.html
+++ b/docs/skills/suede-campaign-in-a-box.html
@@ -26,7 +26,7 @@
         "headline": "Suede Campaign in a Box - Suede Creator Skills",
         "description": "Hand it a song, a release, an era, a show, or a catalog moment and it returns the campaign: a rollout calendar down to release week, hooks and rituals, fan actions, site and email copy, press angles, and collaborator outreach. Where a rights or safety fact is missing it writes unknown instead of guessing. Sync packaging and single-surface copy route to their own skills.",
         "url": "https://skills.suedeai.ai/skills/suede-campaign-in-a-box.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills","Claude Code skills","Codex skills","artist campaigns","release rollouts","fan rituals","visualizer treatments","merch objects","campaign safety"],
         "mainEntity": {

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -26,7 +26,7 @@
         "headline": "Suede Churn Prevention - Suede Creator Skills",
         "description": "Involuntary churn first, because it is the checkable half: dunning for failed payments so a subscriber who never meant to leave gets a real chance to stay. Then the voluntary side: a cancel flow that offers a pause and an evidence-based save offer instead of a guilt trip, proactive signals before the cancel click, and a win-back sequence for the ones who left anyway. The emails themselves ship from suede-emails.",
         "url": "https://skills.suedeai.ai/skills/suede-churn-prevention.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-churn-prevention.html
+++ b/docs/skills/suede-churn-prevention.html
@@ -26,7 +26,7 @@
         "headline": "Suede Churn Prevention - Suede Creator Skills",
         "description": "Involuntary churn first, because it is the checkable half: dunning for failed payments so a subscriber who never meant to leave gets a real chance to stay. Then the voluntary side: a cancel flow that offers a pause and an evidence-based save offer instead of a guilt trip, proactive signals before the cancel click, and a win-back sequence for the ones who left anyway. The emails themselves ship from suede-emails.",
         "url": "https://skills.suedeai.ai/skills/suede-churn-prevention.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ci-gate.html
+++ b/docs/skills/suede-ci-gate.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ship Gate - Suede Creator Skills",
         "description": "Path-filtered jobs are where required checks deadlock; this one aggregates them so a bad merge is blocked and a good one never waits on a job that did not run. The skill detects the stack, writes the workflow files, pins the runtime from the repo, and hands you the exact branch-protection settings to apply. It does not touch your repository access.",
         "url": "https://skills.suedeai.ai/skills/suede-ci-gate.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "GitHub Actions", "branch protection", "path-aware CI", "ci-success aggregator", "lockfile hygiene", "runtime detection"],
         "mainEntity": {

--- a/docs/skills/suede-ci-gate.html
+++ b/docs/skills/suede-ci-gate.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ship Gate - Suede Creator Skills",
         "description": "Path-filtered jobs are where required checks deadlock; this one aggregates them so a bad merge is blocked and a good one never waits on a job that did not run. The skill detects the stack, writes the workflow files, pins the runtime from the repo, and hands you the exact branch-protection settings to apply. It does not touch your repository access.",
         "url": "https://skills.suedeai.ai/skills/suede-ci-gate.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "GitHub Actions", "branch protection", "path-aware CI", "ci-success aggregator", "lockfile hygiene", "runtime detection"],
         "mainEntity": {

--- a/docs/skills/suede-clip-to-guide.html
+++ b/docs/skills/suede-clip-to-guide.html
@@ -26,7 +26,7 @@
         "headline": "Suede Clip to Guide - Suede Creator Skills",
         "description": "A clip has to score 8 of 10 on the moment gate before it earns a guide. Third-party footage runs a rights route that can end in blocked, with the fair-use guidance cited and no clearance claimed. Then the exact bridge copy from the clip to the long-form piece and a verified publishing sequence. Video production itself is suede-video.",
         "url": "https://skills.suedeai.ai/skills/suede-clip-to-guide.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-clip-to-guide.html
+++ b/docs/skills/suede-clip-to-guide.html
@@ -26,7 +26,7 @@
         "headline": "Suede Clip to Guide - Suede Creator Skills",
         "description": "A clip has to score 8 of 10 on the moment gate before it earns a guide. Third-party footage runs a rights route that can end in blocked, with the fair-use guidance cited and no clearance claimed. Then the exact bridge copy from the clip to the long-form piece and a verified publishing sequence. Video production itself is suede-video.",
         "url": "https://skills.suedeai.ai/skills/suede-clip-to-guide.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Co Marketing - Suede Creator Skills",
         "description": "Before any outreach it sizes the audience overlap, so the partner list is the ones who already reach your buyer for a different problem. Then it designs the joint offer, the shared distribution, and the operating roles, and writes down who does the work and who gets the credit before the campaign runs. Affiliate and referral programs are suede-referrals.",
         "url": "https://skills.suedeai.ai/skills/suede-co-marketing.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-co-marketing.html
+++ b/docs/skills/suede-co-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Co Marketing - Suede Creator Skills",
         "description": "Before any outreach it sizes the audience overlap, so the partner list is the ones who already reach your buyer for a different problem. Then it designs the joint offer, the shared distribution, and the operating roles, and writes down who does the work and who gets the credit before the campaign runs. Affiliate and referral programs are suede-referrals.",
         "url": "https://skills.suedeai.ai/skills/suede-co-marketing.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -27,7 +27,7 @@
         "description": "A hardcoded secret, or an auth check bypassable through a request parameter, locks the grade at F with the exact file and line, and no other lane can lift it. Otherwise seven lanes get graded on evidence, from correctness and security through tests and deploy readiness, and the weakest lane sets the letter. Auth, payment, migration, and public-API surfaces carry grade caps of their own. You get the grade, the evidence, and the ranked upgrades that would move it; the findings list lives in suede-code-review.",
         "url": "https://skills.suedeai.ai/skills/suede-code-grader.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-code-grader.html
+++ b/docs/skills/suede-code-grader.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-code-grader.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -26,7 +26,7 @@
         "headline": "Suede Code Review - Suede Creator Skills",
         "description": "It runs the gates your repo already ships and refuses to invent new ones. It reads the changed files with their callers, contracts, and deploy surface, then ranks every finding P0 to P3. TypeScript, React, Next.js, Swift and iOS, database queries, OWASP, accessibility, SEO, and commit hygiene each get a lane. It ends at a ship gate, not a letter; the letter is suede-code-grader's job.",
         "url": "https://skills.suedeai.ai/skills/suede-code-review.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "findings-only review", "deploy safety", "Commit Dirt Score", "OWASP review", "accessibility review"],
         "mainEntity": {

--- a/docs/skills/suede-code-review.html
+++ b/docs/skills/suede-code-review.html
@@ -26,7 +26,7 @@
         "headline": "Suede Code Review - Suede Creator Skills",
         "description": "It runs the gates your repo already ships and refuses to invent new ones. It reads the changed files with their callers, contracts, and deploy surface, then ranks every finding P0 to P3. TypeScript, React, Next.js, Swift and iOS, database queries, OWASP, accessibility, SEO, and commit hygiene each get a lane. It ends at a ship gate, not a letter; the letter is suede-code-grader's job.",
         "url": "https://skills.suedeai.ai/skills/suede-code-review.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "findings-only review", "deploy safety", "Commit Dirt Score", "OWASP review", "accessibility review"],
         "mainEntity": {

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -26,7 +26,7 @@
         "headline": "Suede Code - Suede Creator Skills",
         "description": "One run returns both halves of a review: severity-ranked findings with file and line evidence, and the A to F ship grade where the weakest of seven lanes caps the letter. A hardcoded secret, or an auth check a request param can walk around, locks the grade at F and prints the file and the line. It runs only when you ask for a review, a grade, a security check, or a merge verdict.",
         "url": "https://skills.suedeai.ai/skills/suede-code.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "A-F ship grade", "OWASP review", "deploy safety gate", "Next.js review", "TypeScript review"],
         "mainEntity": {

--- a/docs/skills/suede-code.html
+++ b/docs/skills/suede-code.html
@@ -26,7 +26,7 @@
         "headline": "Suede Code - Suede Creator Skills",
         "description": "One run returns both halves of a review: severity-ranked findings with file and line evidence, and the A to F ship grade where the weakest of seven lanes caps the letter. A hardcoded secret, or an auth check a request param can walk around, locks the grade at F and prints the file and the line. It runs only when you ask for a review, a grade, a security check, or a merge verdict.",
         "url": "https://skills.suedeai.ai/skills/suede-code.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "code review", "A-F ship grade", "OWASP review", "deploy safety gate", "Next.js review", "TypeScript review"],
         "mainEntity": {

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -26,7 +26,7 @@
         "headline": "Suede Cold Email - Suede Creator Skills",
         "description": "It argues from the bundled reply-rate benchmarks instead of instinct, and treats personalization depth as a spend decision: how much research each prospect earns, given what the benchmarks say it returns. Subject line, opening line, a short body, one CTA, and a follow-up sequence with an end date. The list itself comes from suede-prospecting.",
         "url": "https://skills.suedeai.ai/skills/suede-cold-email.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-cold-email.html
+++ b/docs/skills/suede-cold-email.html
@@ -26,7 +26,7 @@
         "headline": "Suede Cold Email - Suede Creator Skills",
         "description": "It argues from the bundled reply-rate benchmarks instead of instinct, and treats personalization depth as a spend decision: how much research each prospect earns, given what the benchmarks say it returns. Subject line, opening line, a short body, one CTA, and a follow-up sequence with an end date. The list itself comes from suede-prospecting.",
         "url": "https://skills.suedeai.ai/skills/suede-cold-email.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Community Marketing - Suede Creator Skills",
         "description": "Platform choice comes first, and the strategy doc records the platform you rejected and the watch-out that killed it. Then it seeds the first members, sets the rituals and their cadence, writes the moderation rules, and names the health metrics that separate a living community from a graveyard with a logo. Public social channels are suede-social; referral mechanics are suede-referrals.",
         "url": "https://skills.suedeai.ai/skills/suede-community-marketing.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-community-marketing.html
+++ b/docs/skills/suede-community-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Community Marketing - Suede Creator Skills",
         "description": "Platform choice comes first, and the strategy doc records the platform you rejected and the watch-out that killed it. Then it seeds the first members, sets the rituals and their cadence, writes the moderation rules, and names the health metrics that separate a living community from a graveyard with a logo. Public social channels are suede-social; referral mechanics are suede-referrals.",
         "url": "https://skills.suedeai.ai/skills/suede-community-marketing.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -26,7 +26,7 @@
         "headline": "Suede Competitor Profiling - Suede Creator Skills",
         "description": "It reads what a competitor shows the public, current URLs only, and files every capture so any line in the profile can be re-checked or re-run months later. A quick scan covers the field; a deep profile spends the research budget on the one that matters: positioning, pricing, messaging, product, proof, and the market signals around them. Comparison pages and battle cards are downstream skills.",
         "url": "https://skills.suedeai.ai/skills/suede-competitor-profiling.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-competitor-profiling.html
+++ b/docs/skills/suede-competitor-profiling.html
@@ -26,7 +26,7 @@
         "headline": "Suede Competitor Profiling - Suede Creator Skills",
         "description": "It reads what a competitor shows the public, current URLs only, and files every capture so any line in the profile can be re-checked or re-run months later. A quick scan covers the field; a deep profile spends the research budget on the one that matters: positioning, pricing, messaging, product, proof, and the market signals around them. Comparison pages and battle cards are downstream skills.",
         "url": "https://skills.suedeai.ai/skills/suede-competitor-profiling.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -26,7 +26,7 @@
         "headline": "Suede Competitors - Suede Creator Skills",
         "description": "Every row on the comparison carries a source URL and the date it was checked, and anything without both is cut or marked unverified on the page. The skill picks the page format for the search intent, alternative, versus, or head-to-head, and writes the honest framing that still converts an evaluator. The underlying evidence comes from suede-competitor-profiling.",
         "url": "https://skills.suedeai.ai/skills/suede-competitors.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-competitors.html
+++ b/docs/skills/suede-competitors.html
@@ -26,7 +26,7 @@
         "headline": "Suede Competitors - Suede Creator Skills",
         "description": "Every row on the comparison carries a source URL and the date it was checked, and anything without both is cut or marked unverified on the page. The skill picks the page format for the search intent, alternative, versus, or head-to-head, and writes the honest framing that still converts an evaluator. The underlying evidence comes from suede-competitor-profiling.",
         "url": "https://skills.suedeai.ai/skills/suede-competitors.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Content Strategy - Suede Creator Skills",
         "description": "Pillars and priority topics come first, then the stop-doing table that marks every existing asset keep, refresh, consolidate, or kill against dated evidence. Searchable gets split from shareable so every piece is scored against the buyer stage it was written for instead of a vague traffic goal, and cadence, distribution, and refresh schedules follow. Writing the individual asset is suede-copy; the on-page audit is suede-seo-audit.",
         "url": "https://skills.suedeai.ai/skills/suede-content-strategy.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-content-strategy.html
+++ b/docs/skills/suede-content-strategy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Content Strategy - Suede Creator Skills",
         "description": "Pillars and priority topics come first, then the stop-doing table that marks every existing asset keep, refresh, consolidate, or kill against dated evidence. Searchable gets split from shareable so every piece is scored against the buyer stage it was written for instead of a vague traffic goal, and cadence, distribution, and refresh schedules follow. Writing the individual asset is suede-copy; the on-page audit is suede-seo-audit.",
         "url": "https://skills.suedeai.ai/skills/suede-content-strategy.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Copy - Suede Creator Skills",
         "description": "One surface, one pass, and the copy leaves with a score. Evidence review stays separate from Suede Slop Stop cleanup, which preserves factual wording, deliberate voice, and the supplied house style. Landing sections, email, microcopy, buttons, headlines, CTAs, and variants. The full stack with SEO and a voice retune is johnny-suede-write.",
         "url": "https://skills.suedeai.ai/skills/suede-copy.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion copy", "landing page copy", "email copy", "social posts", "CTA writing", "anti-slop review"],
         "mainEntity": {

--- a/docs/skills/suede-copy.html
+++ b/docs/skills/suede-copy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Copy - Suede Creator Skills",
         "description": "One surface, one pass, and the copy leaves with a score. Evidence review stays separate from Suede Slop Stop cleanup, which preserves factual wording, deliberate voice, and the supplied house style. Landing sections, email, microcopy, buttons, headlines, CTAs, and variants. The full stack with SEO and a voice retune is johnny-suede-write.",
         "url": "https://skills.suedeai.ai/skills/suede-copy.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion copy", "landing page copy", "email copy", "social posts", "CTA writing", "anti-slop review"],
         "mainEntity": {

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -26,7 +26,7 @@
         "headline": "Suede Customer Research - Suede Creator Skills",
         "description": "Themes get ranked by frequency times intensity, so the customer who shouted once does not outrank the twenty who mentioned the same thing quietly. Two modes: synthesize the interviews, transcripts, and tickets you already own, or go mine the reviews and forums where the segment talks when you are not in the room. Out come a quote bank, the jobs, and personas with evidence attached.",
         "url": "https://skills.suedeai.ai/skills/suede-customer-research.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-customer-research.html
+++ b/docs/skills/suede-customer-research.html
@@ -26,7 +26,7 @@
         "headline": "Suede Customer Research - Suede Creator Skills",
         "description": "Themes get ranked by frequency times intensity, so the customer who shouted once does not outrank the twenty who mentioned the same thing quietly. Two modes: synthesize the interviews, transcripts, and tickets you already own, or go mine the reviews and forums where the segment talks when you are not in the room. Out come a quote bank, the jobs, and personas with evidence attached.",
         "url": "https://skills.suedeai.ai/skills/suede-customer-research.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -26,7 +26,7 @@
         "headline": "Suede Design - Suede Creator Skills",
         "description": "Hand it a mock, a Figma frame, or a reference screenshot and the live route, and it returns the narrow patches that close the gap, with desktop and mobile renders as evidence. Underneath: design tokens, OKLCH color ramps, a fluid type scale, spacing and component laws, motion, and a dark mode built from tokens rather than inverted by hand. A whole surface that needs words as well as layout is johnny-suede-design.",
         "url": "https://skills.suedeai.ai/skills/suede-design.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "design system tokens", "component polish", "dark mode tokens", "fluid typography", "motion sequencing", "visual QA"],
         "mainEntity": {

--- a/docs/skills/suede-design.html
+++ b/docs/skills/suede-design.html
@@ -26,7 +26,7 @@
         "headline": "Suede Design - Suede Creator Skills",
         "description": "Hand it a mock, a Figma frame, or a reference screenshot and the live route, and it returns the narrow patches that close the gap, with desktop and mobile renders as evidence. Underneath: design tokens, OKLCH color ramps, a fluid type scale, spacing and component laws, motion, and a dark mode built from tokens rather than inverted by hand. A whole surface that needs words as well as layout is johnny-suede-design.",
         "url": "https://skills.suedeai.ai/skills/suede-design.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "design system tokens", "component polish", "dark mode tokens", "fluid typography", "motion sequencing", "visual QA"],
         "mainEntity": {

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -26,7 +26,7 @@
         "headline": "Suede Slop Stop - Suede Creator Skills",
         "description": "Five dimensions, fifty points, and anything under thirty-five goes back for another pass. It strips the patterns that read as generated, the throat-clearing, the false agency, the contrast that announces an insight instead of delivering it, without flattening the author's voice, and it never treats a pattern as proof of who wrote the text. Facts, quotes, code, and deliberate phrasing are protected. A findings-only audit is a mode.",
         "url": "https://skills.suedeai.ai/skills/suede-deslop.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "AI writing patterns", "copy editing", "anti-slop", "prose quality"],
         "mainEntity": {

--- a/docs/skills/suede-deslop.html
+++ b/docs/skills/suede-deslop.html
@@ -26,7 +26,7 @@
         "headline": "Suede Slop Stop - Suede Creator Skills",
         "description": "Five dimensions, fifty points, and anything under thirty-five goes back for another pass. It strips the patterns that read as generated, the throat-clearing, the false agency, the contrast that announces an insight instead of delivering it, without flattening the author's voice, and it never treats a pattern as proof of who wrote the text. Facts, quotes, code, and deliberate phrasing are protected. A findings-only audit is a mode.",
         "url": "https://skills.suedeai.ai/skills/suede-deslop.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "AI writing patterns", "copy editing", "anti-slop", "prose quality"],
         "mainEntity": {

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -26,7 +26,7 @@
         "headline": "Suede Directory Submissions - Suede Creator Skills",
         "description": "It picks the listings your product fits from the bundled directory list, sequences the submissions around launch day, tailors the positioning per directory, and then does the part everyone skips: reading the live listing's link attributes and logging them in a tracker. Three hard rules and a what-not-to-do section keep it from spraying. Launch orchestration is suede-launch-packaging.",
         "url": "https://skills.suedeai.ai/skills/suede-directory-submissions.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-directory-submissions.html
+++ b/docs/skills/suede-directory-submissions.html
@@ -26,7 +26,7 @@
         "headline": "Suede Directory Submissions - Suede Creator Skills",
         "description": "It picks the listings your product fits from the bundled directory list, sequences the submissions around launch day, tailors the positioning per directory, and then does the part everyone skips: reading the live listing's link attributes and logging them in a tracker. Three hard rules and a what-not-to-do section keep it from spraying. Launch orchestration is suede-launch-packaging.",
         "url": "https://skills.suedeai.ai/skills/suede-directory-submissions.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -26,7 +26,7 @@
         "headline": "Suede Emails - Suede Creator Skills",
         "description": "Welcome, onboarding, nurture, re-engagement, post-purchase, and win-back flows, each with entry criteria, a cadence, a role for every message, and a measurement plan. A sequence starts on what the user did, and the cadence inside it is designed around the list you want to keep. The sequence templates and email types load only when the flow needs them. Cold outreach is suede-cold-email.",
         "url": "https://skills.suedeai.ai/skills/suede-emails.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-emails.html
+++ b/docs/skills/suede-emails.html
@@ -26,7 +26,7 @@
         "headline": "Suede Emails - Suede Creator Skills",
         "description": "Welcome, onboarding, nurture, re-engagement, post-purchase, and win-back flows, each with entry criteria, a cadence, a role for every message, and a measurement plan. A sequence starts on what the user did, and the cadence inside it is designed around the list you want to keep. The sequence templates and email types load only when the flow needs them. Cold outreach is suede-cold-email.",
         "url": "https://skills.suedeai.ai/skills/suede-emails.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -26,7 +26,7 @@
         "headline": "Suede Free Tools - Suede Creator Skills",
         "description": "Build-versus-buy gets decided on the scorecard, and the honest verdict is sometimes do not build this. When the score clears, it scopes the smallest version worth shipping, a calculator, a grader, a generator, and designs the output so it pulls the user toward the paid product along a measurable path. Downloadable assets are suede-lead-magnets.",
         "url": "https://skills.suedeai.ai/skills/suede-free-tools.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-free-tools.html
+++ b/docs/skills/suede-free-tools.html
@@ -26,7 +26,7 @@
         "headline": "Suede Free Tools - Suede Creator Skills",
         "description": "Build-versus-buy gets decided on the scorecard, and the honest verdict is sometimes do not build this. When the score clears, it scopes the smallest version worth shipping, a calculator, a grader, a generator, and designs the output so it pulls the user toward the paid product along a measurable path. Downloadable assets are suede-lead-magnets.",
         "url": "https://skills.suedeai.ai/skills/suede-free-tools.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-graph-flo-xr.html
+++ b/docs/skills/suede-graph-flo-xr.html
@@ -26,7 +26,7 @@
         "headline": "Suede Graph Flo XR - Suede Creator Skills",
         "description": "Claude Code/macOS Suede Thought Graph repo search: compare competing plans, build only the selected plan, and hold behind clamped patch and Gate attestations. Light, standard, and deep runs are capped at 55, 110, and 200 calls. Production access is read-only; it never deploys.",
         "url": "https://skills.suedeai.ai/skills/suede-graph-flo-xr.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Suede Thought Graph", "plan search", "multi-agent orchestration", "adversarial verification", "git worktree isolation", "winner-only mutation"],
         "mainEntity": {

--- a/docs/skills/suede-graph-flo-xr.html
+++ b/docs/skills/suede-graph-flo-xr.html
@@ -26,7 +26,7 @@
         "headline": "Suede Graph Flo XR - Suede Creator Skills",
         "description": "Claude Code/macOS Suede Thought Graph repo search: compare competing plans, build only the selected plan, and hold behind clamped patch and Gate attestations. Light, standard, and deep runs are capped at 55, 110, and 200 calls. Production access is read-only; it never deploys.",
         "url": "https://skills.suedeai.ai/skills/suede-graph-flo-xr.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Suede Thought Graph", "plan search", "multi-agent orchestration", "adversarial verification", "git worktree isolation", "winner-only mutation"],
         "mainEntity": {

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -26,7 +26,7 @@
         "headline": "Suede Image - Suede Creator Skills",
         "description": "Prompt craft gets the picture; the skill keeps going through export sizing, compression, and the Open Graph and social preview images that decide whether your link looks like anything when someone pastes it. Hero graphics, social graphics, product mockups, and previews, each at the size the surface needs. Paid-ad creative systems are suede-ad-creative; video is suede-video.",
         "url": "https://skills.suedeai.ai/skills/suede-image.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-image.html
+++ b/docs/skills/suede-image.html
@@ -26,7 +26,7 @@
         "headline": "Suede Image - Suede Creator Skills",
         "description": "Prompt craft gets the picture; the skill keeps going through export sizing, compression, and the Open Graph and social preview images that decide whether your link looks like anything when someone pastes it. Hero graphics, social graphics, product mockups, and previews, each at the size the surface needs. Paid-ad creative systems are suede-ad-creative; video is suede-video.",
         "url": "https://skills.suedeai.ai/skills/suede-image.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-instagram-growth.html
+++ b/docs/skills/suede-instagram-growth.html
@@ -25,7 +25,7 @@
     "headline": "Suede Instagram Growth",
     "description": "Public metrics are not owned Insights, and the skill will not model growth on numbers it cannot see. It audits the recent post cohort, separates views from follows, leads, and sales, and maps attention to the action you want. Then the daily loop: Reels, carousels, Stories, and a calendar, delivered as an approval-ready package in the account's own voice. Multi-platform strategy is suede-social.",
     "url": "https://skills.suedeai.ai/skills/suede-instagram-growth.html",
-    "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://suedeai.ai/founder"},
+    "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://suedeai.ai/founder"},
     "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
     "license": "https://opensource.org/licenses/MIT",
     "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -26,7 +26,7 @@
         "headline": "Suede Launch Packaging - Suede Creator Skills",
         "description": "Nothing is called live until the exact install command runs from a clean temporary directory, never from inside the checkout that built it. Any @personal alias or local-only path is stripped before the copy goes public. README, docs page, release note, GitHub Pages update, MCP server, or skill-pack release: same gate, same handoff notes.",
         "url": "https://skills.suedeai.ai/skills/suede-launch-packaging.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "launch packaging", "install verification", "GitHub Pages updates", "README launches", "MCP setup", "public install support"],
         "mainEntity": {

--- a/docs/skills/suede-launch-packaging.html
+++ b/docs/skills/suede-launch-packaging.html
@@ -26,7 +26,7 @@
         "headline": "Suede Launch Packaging - Suede Creator Skills",
         "description": "Nothing is called live until the exact install command runs from a clean temporary directory, never from inside the checkout that built it. Any @personal alias or local-only path is stripped before the copy goes public. README, docs page, release note, GitHub Pages update, MCP server, or skill-pack release: same gate, same handoff notes.",
         "url": "https://skills.suedeai.ai/skills/suede-launch-packaging.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "launch packaging", "install verification", "GitHub Pages updates", "README launches", "MCP setup", "public install support"],
         "mainEntity": {

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -26,7 +26,7 @@
         "headline": "Suede Lead Magnets - Suede Creator Skills",
         "description": "Format and buyer stage first, then the decision most magnets get wrong: what to gate and what to leave open. An ebook, a checklist, a template, a content upgrade, the depth that makes it worth the address, the delivery, and the sequence that follows the download, checked against the bundled benchmarks. Interactive tools are suede-free-tools.",
         "url": "https://skills.suedeai.ai/skills/suede-lead-magnets.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-lead-magnets.html
+++ b/docs/skills/suede-lead-magnets.html
@@ -26,7 +26,7 @@
         "headline": "Suede Lead Magnets - Suede Creator Skills",
         "description": "Format and buyer stage first, then the decision most magnets get wrong: what to gate and what to leave open. An ebook, a checklist, a template, a content upgrade, the depth that makes it worth the address, the delivery, and the sequence that follows the download, checked against the bundled benchmarks. Interactive tools are suede-free-tools.",
         "url": "https://skills.suedeai.ai/skills/suede-lead-magnets.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Council - Suede Creator Skills",
         "description": "Clearly labeled simulated advisors apply documented public frameworks to one bounded question, and the written disagreement between them is the artifact, not the tidy synthesis at the end. You get where the lenses split, why, and the recommendation built from the arguments that survived. It never claims a living person's private views, and it does not run the tactic it picks.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-council.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-council.html
+++ b/docs/skills/suede-marketing-council.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Council - Suede Creator Skills",
         "description": "Clearly labeled simulated advisors apply documented public frameworks to one bounded question, and the written disagreement between them is the artifact, not the tidy synthesis at the end. You get where the lenses split, why, and the recommendation built from the arguments that survived. It never claims a living person's private views, and it does not run the tactic it picks.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-council.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Ideas - Suede Creator Skills",
         "description": "Every idea arrives scored on six dimensions, evidence and capacity among them, against your stage, budget, and timeline, so what comes back is a shortlist you can act on rather than a list you have to triage. The library is organized by stage, budget, and timeline, and it is for getting unstuck before a plan exists. The full roadmap is suede-marketing-plan; a loop that runs unattended is suede-marketing-loops.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-ideas.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-ideas.html
+++ b/docs/skills/suede-marketing-ideas.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Ideas - Suede Creator Skills",
         "description": "Every idea arrives scored on six dimensions, evidence and capacity among them, against your stage, budget, and timeline, so what comes back is a shortlist you can act on rather than a list you have to triage. The library is organized by stage, budget, and timeline, and it is for getting unstuck before a plan exists. The full roadmap is suede-marketing-plan; a loop that runs unattended is suede-marketing-loops.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-ideas.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Loops - Suede Creator Skills",
         "description": "The ad-fatigue check runs on its schedule instead of when someone notices the click-through rate sagging, and the ranking-drop alert has its threshold written down before the drop. Each loop gets a cadence, its inputs, decision rules, checkpoints, failure states, and a measurable output, so an agent can run it on schedule without inventing the rules mid-run. It designs the loop; it does not schedule a live automation without your say-so.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-loops.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-loops.html
+++ b/docs/skills/suede-marketing-loops.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Loops - Suede Creator Skills",
         "description": "The ad-fatigue check runs on its schedule instead of when someone notices the click-through rate sagging, and the ranking-drop alert has its threshold written down before the drop. Each loop gets a cadence, its inputs, decision rules, checkpoints, failure states, and a measurable output, so an agent can run it on schedule without inventing the rules mid-run. It designs the loop; it does not schedule a live automation without your say-so.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-loops.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Plan - Suede Creator Skills",
         "description": "Acquisition, activation, retention, referral, and revenue, planned against the budget, headcount, evidence, and stage you have right now, which means it refuses to recommend the channel you cannot staff. Ninety-day plan, twelve-month roadmap, or the go-to-market operating document. Single-channel execution routes to that channel's skill, and loose brainstorming to suede-marketing-ideas.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-plan.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-plan.html
+++ b/docs/skills/suede-marketing-plan.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Plan - Suede Creator Skills",
         "description": "Acquisition, activation, retention, referral, and revenue, planned against the budget, headcount, evidence, and stage you have right now, which means it refuses to recommend the channel you cannot staff. Ninety-day plan, twelve-month roadmap, or the go-to-market operating document. Single-channel execution routes to that channel's skill, and loose brainstorming to suede-marketing-ideas.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-plan.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Psychology - Suede Creator Skills",
         "description": "Anchoring, framing, social proof, loss aversion, choice architecture, and friction, each applied as a named model with the evidence behind it and a hypothesis you can test. Manufactured scarcity, fake countdowns, and invented social proof are refused outright rather than dressed up. Putting it on the page is suede-site-alchemy; pricing is suede-pricing.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-psychology.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-marketing-psychology.html
+++ b/docs/skills/suede-marketing-psychology.html
@@ -26,7 +26,7 @@
         "headline": "Suede Marketing Psychology - Suede Creator Skills",
         "description": "Anchoring, framing, social proof, loss aversion, choice architecture, and friction, each applied as a named model with the evidence behind it and a hypothesis you can test. Manufactured scarcity, fake countdowns, and invented social proof are refused outright rather than dressed up. Putting it on the page is suede-site-alchemy; pricing is suede-pricing.",
         "url": "https://skills.suedeai.ai/skills/suede-marketing-psychology.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -26,7 +26,7 @@
         "headline": "Suede MCP QA - Suede Creator Skills",
         "description": "Your agent runs the whole JSON-RPC lifecycle against the live Suede Skills MCP server, initialize through tools, resources, and prompts, and checks the answers against the source, the catalog, and the skill folders. Nine tools, seven resources, and five prompts each get exercised, with closed schemas and tool annotations verified. It is scoped to this pack's own server and its install and docs surface, and it runs when any of that changes.",
         "url": "https://skills.suedeai.ai/skills/suede-mcp-qa.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "MCP quality assurance", "Suede Skills MCP", "JSON-RPC testing", "Catalog alignment", "Install output checks", "Docs alignment"],
         "mainEntity": {

--- a/docs/skills/suede-mcp-qa.html
+++ b/docs/skills/suede-mcp-qa.html
@@ -26,7 +26,7 @@
         "headline": "Suede MCP QA - Suede Creator Skills",
         "description": "Your agent runs the whole JSON-RPC lifecycle against the live Suede Skills MCP server, initialize through tools, resources, and prompts, and checks the answers against the source, the catalog, and the skill folders. Nine tools, seven resources, and five prompts each get exercised, with closed schemas and tool annotations verified. It is scoped to this pack's own server and its install and docs surface, and it runs when any of that changes.",
         "url": "https://skills.suedeai.ai/skills/suede-mcp-qa.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "MCP quality assurance", "Suede Skills MCP", "JSON-RPC testing", "Catalog alignment", "Install output checks", "Docs alignment"],
         "mainEntity": {

--- a/docs/skills/suede-newsroom.html
+++ b/docs/skills/suede-newsroom.html
@@ -26,7 +26,7 @@
         "headline": "Suede Newsroom - Suede Creator Skills",
         "description": "The default failure of an AI content team is six posts repeating one sentence. This pipeline gives six roles written contracts, passes one inspectable campaign record between them, and ends at a distribution stage where each asset has to carry its own argument rather than a shorter draft of the flagship. Use it when content agents come back generic, duplicated, or unsourced, or when one piece has to carry a week.",
         "url": "https://skills.suedeai.ai/skills/suede-newsroom.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-newsroom.html
+++ b/docs/skills/suede-newsroom.html
@@ -26,7 +26,7 @@
         "headline": "Suede Newsroom - Suede Creator Skills",
         "description": "The default failure of an AI content team is six posts repeating one sentence. This pipeline gives six roles written contracts, passes one inspectable campaign record between them, and ends at a distribution stage where each asset has to carry its own argument rather than a shorter draft of the flagship. Use it when content agents come back generic, duplicated, or unsourced, or when one piece has to carry a week.",
         "url": "https://skills.suedeai.ai/skills/suede-newsroom.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -26,7 +26,7 @@
         "headline": "Suede Offers - Suede Creator Skills",
         "description": "Honest scarcity is the design constraint: the deadline exists, the guarantee is one you would pay out, and the offer survives a customer who checks. Around that it does the value framing, the bonus stack, the risk reversal, the name, and the payment structure for a service, a course, coaching, an agency, or a high-ticket B2B deal. SaaS tiers are suede-pricing; the sales page is suede-copy.",
         "url": "https://skills.suedeai.ai/skills/suede-offers.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-offers.html
+++ b/docs/skills/suede-offers.html
@@ -26,7 +26,7 @@
         "headline": "Suede Offers - Suede Creator Skills",
         "description": "Honest scarcity is the design constraint: the deadline exists, the guarantee is one you would pay out, and the offer survives a customer who checks. Around that it does the value framing, the bonus stack, the risk reversal, the name, and the payment structure for a service, a course, coaching, an agency, or a high-ticket B2B deal. SaaS tiers are suede-pricing; the sales page is suede-copy.",
         "url": "https://skills.suedeai.ai/skills/suede-offers.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -26,7 +26,7 @@
         "headline": "Suede Onboarding - Suede Creator Skills",
         "description": "It picks the single activation milestone that predicts retention and instruments it, then goes through the first run step by step and names the setup steps to delete, because most onboarding failures are steps nobody needed. Empty states, checklists, and first-session sequencing get rebuilt around that milestone. Registration itself is suede-signup; the emails are suede-emails.",
         "url": "https://skills.suedeai.ai/skills/suede-onboarding.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-onboarding.html
+++ b/docs/skills/suede-onboarding.html
@@ -26,7 +26,7 @@
         "headline": "Suede Onboarding - Suede Creator Skills",
         "description": "It picks the single activation milestone that predicts retention and instruments it, then goes through the first run step by step and names the setup steps to delete, because most onboarding failures are steps nobody needed. Empty states, checklists, and first-session sequencing get rebuilt around that milestone. Registration itself is suede-signup; the emails are suede-emails.",
         "url": "https://skills.suedeai.ai/skills/suede-onboarding.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ops-architecture.html
+++ b/docs/skills/suede-ops-architecture.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ops Architecture - Suede Creator Skills",
         "description": "Every existing tool gets marked absorb, keep, or kill, with a proof path for the verdict. Every entity gets exactly one write path, and every unit of work is routed to a deterministic automation, an AI agent, or a human decision, on paper, before anyone builds. The build is sequenced into phases, and a phase is done when a command proves it.",
         "url": "https://skills.suedeai.ai/skills/suede-ops-architecture.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ops-architecture.html
+++ b/docs/skills/suede-ops-architecture.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ops Architecture - Suede Creator Skills",
         "description": "Every existing tool gets marked absorb, keep, or kill, with a proof path for the verdict. Every entity gets exactly one write path, and every unit of work is routed to a deterministic automation, an AI agent, or a human decision, on paper, before anyone builds. The build is sequenced into phases, and a phase is done when a command proves it.",
         "url": "https://skills.suedeai.ai/skills/suede-ops-architecture.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ops-assessment.html
+++ b/docs/skills/suede-ops-assessment.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ops Assessment - Suede Creator Skills",
         "description": "It interviews the people who do the work, not the people who describe it. It inventories every silo, including the spreadsheets and inboxes nobody calls a database, and prices each bottleneck in the operation's own numbers. Opportunities come back ranked by annual value against build complexity, and adoption gets watched for thirty days after launch.",
         "url": "https://skills.suedeai.ai/skills/suede-ops-assessment.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-ops-assessment.html
+++ b/docs/skills/suede-ops-assessment.html
@@ -26,7 +26,7 @@
         "headline": "Suede Ops Assessment - Suede Creator Skills",
         "description": "It interviews the people who do the work, not the people who describe it. It inventories every silo, including the spreadsheets and inboxes nobody calls a database, and prices each bottleneck in the operation's own numbers. Opportunities come back ranked by annual value against build complexity, and adoption gets watched for thirty days after launch.",
         "url": "https://skills.suedeai.ai/skills/suede-ops-assessment.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -26,7 +26,7 @@
         "headline": "Suede Paywalls - Suede Creator Skills",
         "description": "The upgrade prompt fires after the user has felt the value, not before, and that timing is the whole design. Paywall screens, feature gates, trial-expiry states, and usage-limit prompts each get a trigger, a message structure, a plan presentation, and an experiment to prove the moment was right. Public pricing pages are suede-site-alchemy; tier architecture is suede-pricing; cancel and save flows are suede-churn-prevention.",
         "url": "https://skills.suedeai.ai/skills/suede-paywalls.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-paywalls.html
+++ b/docs/skills/suede-paywalls.html
@@ -26,7 +26,7 @@
         "headline": "Suede Paywalls - Suede Creator Skills",
         "description": "The upgrade prompt fires after the user has felt the value, not before, and that timing is the whole design. Paywall screens, feature gates, trial-expiry states, and usage-limit prompts each get a trigger, a message structure, a plan presentation, and an experiment to prove the moment was right. Public pricing pages are suede-site-alchemy; tier architecture is suede-pricing; cancel and save flows are suede-churn-prevention.",
         "url": "https://skills.suedeai.ai/skills/suede-paywalls.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Pricing - Suede Creator Skills",
         "description": "Packaging first, then the value metric, then the price point, because every tier boundary, trial rule, and price increase hangs off what you include and what you meter. Then the concrete calls: freemium or free trial, where the tiers break, what the willingness-to-pay research says, and how to raise prices without churning the base. It will also tear down a pricing page for clarity and for what an AI answer engine can read from it. In-product upgrade screens are suede-paywalls.",
         "url": "https://skills.suedeai.ai/skills/suede-pricing.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-pricing.html
+++ b/docs/skills/suede-pricing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Pricing - Suede Creator Skills",
         "description": "Packaging first, then the value metric, then the price point, because every tier boundary, trial rule, and price increase hangs off what you include and what you meter. Then the concrete calls: freemium or free trial, where the tiers break, what the willingness-to-pay research says, and how to raise prices without churning the base. It will also tear down a pricing page for clarity and for what an AI answer engine can read from it. In-product upgrade screens are suede-paywalls.",
         "url": "https://skills.suedeai.ai/skills/suede-pricing.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Product Marketing - Suede Creator Skills",
         "description": "This is the record the rest of the marketing lane reads from: what the product is, who it is for, the ICP, the positioning line, the objections, the customer's own language, the proof, and the goals. Fix it here once and the campaign, email, ads, and content skills consume it instead of inventing it per run. Writing the campaign is suede-campaign-in-a-box; new interviews are suede-customer-research.",
         "url": "https://skills.suedeai.ai/skills/suede-product-marketing.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-product-marketing.html
+++ b/docs/skills/suede-product-marketing.html
@@ -26,7 +26,7 @@
         "headline": "Suede Product Marketing - Suede Creator Skills",
         "description": "This is the record the rest of the marketing lane reads from: what the product is, who it is for, the ICP, the positioning line, the objections, the customer's own language, the proof, and the goals. Fix it here once and the campaign, email, ads, and content skills consume it instead of inventing it per run. Writing the campaign is suede-campaign-in-a-box; new interviews are suede-customer-research.",
         "url": "https://skills.suedeai.ai/skills/suede-product-marketing.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -26,7 +26,7 @@
         "headline": "Suede Programmatic Seo - Suede Creator Skills",
         "description": "Nothing beyond a bounded sample gets generated until that sample clears the index-worthiness bar, and thin variations ship noindexed rather than indexed. Around that gate: the template, the data source that fills it, the internal linking that holds up at scale, and the rollout checks before bulk publishing, which never happens without approval. Auditing an existing site is suede-seo-audit; editorial planning is suede-content-strategy.",
         "url": "https://skills.suedeai.ai/skills/suede-programmatic-seo.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-programmatic-seo.html
+++ b/docs/skills/suede-programmatic-seo.html
@@ -26,7 +26,7 @@
         "headline": "Suede Programmatic Seo - Suede Creator Skills",
         "description": "Nothing beyond a bounded sample gets generated until that sample clears the index-worthiness bar, and thin variations ship noindexed rather than indexed. Around that gate: the template, the data source that fills it, the internal linking that holds up at scale, and the rollout checks before bulk publishing, which never happens without approval. Auditing an existing site is suede-seo-audit; editorial planning is suede-content-strategy.",
         "url": "https://skills.suedeai.ai/skills/suede-programmatic-seo.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -26,7 +26,7 @@
         "headline": "Suede Prospecting - Suede Creator Skills",
         "description": "It names who is not a customer before it names who is, and writes the disqualification evidence down. Then ICP fit, sourcing, enrichment, and account scoring on a bounded list, including where the early adopters and design partners are. Sending the outreach is suede-cold-email; CRM routing is suede-revops.",
         "url": "https://skills.suedeai.ai/skills/suede-prospecting.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-prospecting.html
+++ b/docs/skills/suede-prospecting.html
@@ -26,7 +26,7 @@
         "headline": "Suede Prospecting - Suede Creator Skills",
         "description": "It names who is not a customer before it names who is, and writes the disqualification evidence down. Then ICP fit, sourcing, enrichment, and account scoring on a bounded list, including where the early adopters and design partners are. Sending the outreach is suede-cold-email; CRM routing is suede-revops.",
         "url": "https://skills.suedeai.ai/skills/suede-prospecting.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -26,7 +26,7 @@
         "headline": "Suede Public Relations - Suede Creator Skills",
         "description": "Coverage without a retainer is bought with timing: the angle gets validated and the pitch drafted while the story is still inside its coverage curve, and never at the cost of verification. Media lists, journalist pitches, newsjacking calls, press kits, and reporter requests are the standing work. It never contacts anyone without your approval. Directory listings and launch packaging have their own skills.",
         "url": "https://skills.suedeai.ai/skills/suede-public-relations.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-public-relations.html
+++ b/docs/skills/suede-public-relations.html
@@ -26,7 +26,7 @@
         "headline": "Suede Public Relations - Suede Creator Skills",
         "description": "Coverage without a retainer is bought with timing: the angle gets validated and the pitch drafted while the story is still inside its coverage curve, and never at the cost of verification. Media lists, journalist pitches, newsjacking calls, press kits, and reporter requests are the standing work. It never contacts anyone without your approval. Directory listings and launch packaging have their own skills.",
         "url": "https://skills.suedeai.ai/skills/suede-public-relations.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -26,7 +26,7 @@
         "headline": "Suede Recommend Next Action - Suede Creator Skills",
         "description": "It reads the repo, the terminal, the plan, or the handoff, read-only, and returns a single move with a short self-contained prompt. Behind that answer it scored two to four candidates on goal fit, unblocking, evidence, urgency, and leverage, so the recommendation can be argued with on the record. Ask for the prompt expanded or made granular and it does that too.",
         "url": "https://skills.suedeai.ai/skills/suede-recommend-next-action.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "next action recommendation", "prompt engineering", "agent orchestration", "decision scoring"],
         "mainEntity": {

--- a/docs/skills/suede-recommend-next-action.html
+++ b/docs/skills/suede-recommend-next-action.html
@@ -26,7 +26,7 @@
         "headline": "Suede Recommend Next Action - Suede Creator Skills",
         "description": "It reads the repo, the terminal, the plan, or the handoff, read-only, and returns a single move with a short self-contained prompt. Behind that answer it scored two to four candidates on goal fit, unblocking, evidence, urgency, and leverage, so the recommendation can be argued with on the record. Ask for the prompt expanded or made granular and it does that too.",
         "url": "https://skills.suedeai.ai/skills/suede-recommend-next-action.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "next action recommendation", "prompt engineering", "agent orchestration", "decision scoring"],
         "mainEntity": {

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -26,7 +26,7 @@
         "headline": "Suede Referrals - Suede Creator Skills",
         "description": "The incentive design decides who gets paid, so fraud controls and payout logic get built with the mechanics, not after the first abuse. Refer-a-friend loops, ambassador and partner incentives, affiliate structure, attribution, and the viral-loop math that says whether the channel compounds at all. It never executes a payout, never touches billing, and never reports a lift it cannot verify.",
         "url": "https://skills.suedeai.ai/skills/suede-referrals.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-referrals.html
+++ b/docs/skills/suede-referrals.html
@@ -26,7 +26,7 @@
         "headline": "Suede Referrals - Suede Creator Skills",
         "description": "The incentive design decides who gets paid, so fraud controls and payout logic get built with the mechanics, not after the first abuse. Refer-a-friend loops, ambassador and partner incentives, affiliate structure, attribution, and the viral-loop math that says whether the channel compounds at all. It never executes a payout, never touches billing, and never reports a lift it cannot verify.",
         "url": "https://skills.suedeai.ai/skills/suede-referrals.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -27,7 +27,7 @@
         "description": "It emits two reports, one a person reads and one a machine reads, and the public script runs offline, so the catalog never leaves the drive. Point it at a song, an album, a stem pack, an artwork or lyric folder, or a whole media project and it scores release readiness: missing files, malformed metadata, artwork and stem problems, split gaps, rights blockers, and platform-delivery issues. Findings only; it clears nothing.",
         "url": "https://skills.suedeai.ai/skills/suede-release-linter.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-release-linter.html
+++ b/docs/skills/suede-release-linter.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-release-linter.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -26,7 +26,7 @@
         "headline": "Suede Revops - Suede Creator Skills",
         "description": "Before a lead gets routed, marketing and sales write down what qualified means, and the scoring, the routing rules, and the pipeline stages follow from that definition instead of the reverse. CRM hygiene, automation, deal-desk rules, and the handoff get the same treatment: written, then wired. It never mutates a production CRM record without approval.",
         "url": "https://skills.suedeai.ai/skills/suede-revops.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-revops.html
+++ b/docs/skills/suede-revops.html
@@ -26,7 +26,7 @@
         "headline": "Suede Revops - Suede Creator Skills",
         "description": "Before a lead gets routed, marketing and sales write down what qualified means, and the scoring, the routing rules, and the pipeline stages follow from that definition instead of the reverse. CRM hygiene, automation, deal-desk rules, and the handoff get the same treatment: written, then wired. It never mutates a production CRM record without approval.",
         "url": "https://skills.suedeai.ai/skills/suede-revops.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -26,7 +26,7 @@
         "headline": "Suede Rights Audit - Suede Creator Skills",
         "description": "Every ownership, contributor, split, sample, license, provenance, and metadata fact comes back marked confirmed or unknown against an evidence trail, so nobody packages a release on an inference. Run it before a registry, licensing, sync, or payout conversation; the gaps it finds feed the rights passport and the licensing and royalty-routing prep. It reports; it does not clear rights or confirm ownership.",
         "url": "https://skills.suedeai.ai/skills/suede-rights-audit.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "rights gap audit", "provenance mapping", "licensing readiness", "royalty routing readiness", "creator intake", "evidence tables"],
         "mainEntity": {

--- a/docs/skills/suede-rights-audit.html
+++ b/docs/skills/suede-rights-audit.html
@@ -26,7 +26,7 @@
         "headline": "Suede Rights Audit - Suede Creator Skills",
         "description": "Every ownership, contributor, split, sample, license, provenance, and metadata fact comes back marked confirmed or unknown against an evidence trail, so nobody packages a release on an inference. Run it before a registry, licensing, sync, or payout conversation; the gaps it finds feed the rights passport and the licensing and royalty-routing prep. It reports; it does not clear rights or confirm ownership.",
         "url": "https://skills.suedeai.ai/skills/suede-rights-audit.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "rights gap audit", "provenance mapping", "licensing readiness", "royalty routing readiness", "creator intake", "evidence tables"],
         "mainEntity": {

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-rights-passport.html
+++ b/docs/skills/suede-rights-passport.html
@@ -27,7 +27,7 @@
         "description": "Turn a messy creator folder into a validated local rights and provenance package. The schema keeps a musical work and its recording as different objects, because a splits table that conflates them is exactly the gap a registry or a licensee will find first. Assets get inventoried and hashed, credits, splits, license notes, and provenance get normalized into one manifest, and a missing-information report names what is still unknown. It runs on your own machine, offline, and clears nothing.",
         "url": "https://skills.suedeai.ai/skills/suede-rights-passport.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sales Enablement - Suede Creator Skills",
         "description": "Three people wrote the deck, the demo script, and the objection guide in three different weeks. The skill builds them together, from the same positioning and proof, so they stop contradicting each other: pitch deck, one-pager, talk tracks, battle cards, proposal structure, buyer cards, and deal-level ROI framing. Price and terms are suede-pricing; the offer itself is suede-offers; it publishes no proof it cannot support.",
         "url": "https://skills.suedeai.ai/skills/suede-sales-enablement.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-sales-enablement.html
+++ b/docs/skills/suede-sales-enablement.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sales Enablement - Suede Creator Skills",
         "description": "Three people wrote the deck, the demo script, and the objection guide in three different weeks. The skill builds them together, from the same positioning and proof, so they stop contradicting each other: pitch deck, one-pager, talk tracks, battle cards, proposal structure, buyer cards, and deal-level ROI framing. Price and terms are suede-pricing; the offer itself is suede-offers; it publishes no proof it cannot support.",
         "url": "https://skills.suedeai.ai/skills/suede-sales-enablement.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -26,7 +26,7 @@
         "headline": "Suede SEO Audit - Suede Creator Skills",
         "description": "Every score comes from the page as served, and the CMS gets no vote. Access, intent, metadata, structure, supported schema, E-E-A-T, clusters, and the exact rewrite fixes, each lane graded, and a gate that says whether the page goes live rather than what could be nicer. The fast A to F launch grade is suede-visibility-grader; the conversion rework after the audit is suede-site-alchemy.",
         "url": "https://skills.suedeai.ai/skills/suede-seo-audit.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "SEO audit", "AEO audit", "AI EO audit", "schema validation", "metadata audit", "topic clusters"],
         "mainEntity": {

--- a/docs/skills/suede-seo-audit.html
+++ b/docs/skills/suede-seo-audit.html
@@ -26,7 +26,7 @@
         "headline": "Suede SEO Audit - Suede Creator Skills",
         "description": "Every score comes from the page as served, and the CMS gets no vote. Access, intent, metadata, structure, supported schema, E-E-A-T, clusters, and the exact rewrite fixes, each lane graded, and a gate that says whether the page goes live rather than what could be nicer. The fast A to F launch grade is suede-visibility-grader; the conversion rework after the audit is suede-site-alchemy.",
         "url": "https://skills.suedeai.ai/skills/suede-seo-audit.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "SEO audit", "AEO audit", "AI EO audit", "schema validation", "metadata audit", "topic clusters"],
         "mainEntity": {

--- a/docs/skills/suede-ship-copy.html
+++ b/docs/skills/suede-ship-copy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Graph Flo XR - Suede Creator Skills",
         "description": "A piece of writing runs as a graph instead of a chain: intake that captures what is already published, five blind research lenses, an audit that closes the set of facts the writers may assert, disjoint section writers, adversarial refutation, Suede Slop Stop cleanup, and a publish gate. A writer that cannot cite a fact leaves a labeled hole, [AUTHOR: supply X], instead of inventing one. The audit targets what the agents invent, never what you supplied.",
         "url": "https://skills.suedeai.ai/skills/suede-ship-copy.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "multi-agent orchestration", "directed acyclic graph", "agent fan-out", "adversarial verification", "git worktree isolation", "critical path"],
         "mainEntity": {

--- a/docs/skills/suede-ship-copy.html
+++ b/docs/skills/suede-ship-copy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Graph Flo XR - Suede Creator Skills",
         "description": "A piece of writing runs as a graph instead of a chain: intake that captures what is already published, five blind research lenses, an audit that closes the set of facts the writers may assert, disjoint section writers, adversarial refutation, Suede Slop Stop cleanup, and a publish gate. A writer that cannot cite a fact leaves a labeled hole, [AUTHOR: supply X], instead of inventing one. The audit targets what the agents invent, never what you supplied.",
         "url": "https://skills.suedeai.ai/skills/suede-ship-copy.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "multi-agent orchestration", "directed acyclic graph", "agent fan-out", "adversarial verification", "git worktree isolation", "critical path"],
         "mainEntity": {

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -26,7 +26,7 @@
         "headline": "Suede Signup - Suede Creator Skills",
         "description": "The audit goes field by field, and each one has to justify the signups that abandon at it. Then the calls: single-step or multi-step, social login or email, what progressive profiling can ask later instead of now, how the flow behaves on a phone, and how abandoned signups get recovered and measured. Activation after signup is suede-onboarding; it deploys no auth or compliance change without review.",
         "url": "https://skills.suedeai.ai/skills/suede-signup.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-signup.html
+++ b/docs/skills/suede-signup.html
@@ -26,7 +26,7 @@
         "headline": "Suede Signup - Suede Creator Skills",
         "description": "The audit goes field by field, and each one has to justify the signups that abandon at it. Then the calls: single-step or multi-step, social login or email, what progressive profiling can ask later instead of now, how the flow behaves on a phone, and how abandoned signups get recovered and measured. Activation after signup is suede-onboarding; it deploys no auth or compliance change without review.",
         "url": "https://skills.suedeai.ai/skills/suede-signup.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Site Alchemy - Suede Creator Skills",
         "description": "It ranks every fix by evidence strength, affected traffic, and effort, and where the impact is not known yet it names the measurement that will settle it instead of inventing a lift. Friction gets inventoried three ways, cognitive, physical, and trust, each item with its evidence, affected population, and severity, across the hero, the proof, the CTA, the pricing, and the mobile path. The copy itself is suede-copy; the SEO score is suede-seo-audit.",
         "url": "https://skills.suedeai.ai/skills/suede-site-alchemy.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion rate optimization", "funnel analysis", "friction audit", "conversion math", "mobile CRO", "landing page QA"],
         "mainEntity": {

--- a/docs/skills/suede-site-alchemy.html
+++ b/docs/skills/suede-site-alchemy.html
@@ -26,7 +26,7 @@
         "headline": "Suede Site Alchemy - Suede Creator Skills",
         "description": "It ranks every fix by evidence strength, affected traffic, and effort, and where the impact is not known yet it names the measurement that will settle it instead of inventing a lift. Friction gets inventoried three ways, cognitive, physical, and trust, each item with its evidence, affected population, and severity, across the hero, the proof, the CTA, the pricing, and the mobile path. The copy itself is suede-copy; the SEO score is suede-seo-audit.",
         "url": "https://skills.suedeai.ai/skills/suede-site-alchemy.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "conversion rate optimization", "funnel analysis", "friction audit", "conversion math", "mobile CRO", "landing page QA"],
         "mainEntity": {

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sms - Suede Creator Skills",
         "description": "TCPA consent, A2P 10DLC registration, and quiet hours get checked before a word of copy exists, because the block is the expensive part. Then the channel call, when SMS beats email, the number type, the cadence limits that keep the list, and the cart-recovery and win-back texts themselves. It certifies nothing legally; it keeps you from the obvious mistakes.",
         "url": "https://skills.suedeai.ai/skills/suede-sms.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-sms.html
+++ b/docs/skills/suede-sms.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sms - Suede Creator Skills",
         "description": "TCPA consent, A2P 10DLC registration, and quiet hours get checked before a word of copy exists, because the block is the expensive part. Then the channel call, when SMS beats email, the number type, the cadence limits that keep the list, and the cart-recovery and win-back texts themselves. It certifies nothing legally; it keeps you from the obvious mistakes.",
         "url": "https://skills.suedeai.ai/skills/suede-sms.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -26,7 +26,7 @@
         "headline": "Suede Social - Suede Creator Skills",
         "description": "Two mechanisms carry it: reverse-engineering the post that traveled, so the next one is built from why rather than from a guess, and a repurposing system that turns one argument into a week of assets across platforms. Platform mix, cadence, threads, calendars, listening, and engagement for a founder or a brand account. Instagram-specific audits and daily loops are suede-instagram-growth; paid creative is suede-ad-creative.",
         "url": "https://skills.suedeai.ai/skills/suede-social.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-social.html
+++ b/docs/skills/suede-social.html
@@ -26,7 +26,7 @@
         "headline": "Suede Social - Suede Creator Skills",
         "description": "Two mechanisms carry it: reverse-engineering the post that traveled, so the next one is built from why rather than from a guess, and a repurposing system that turns one argument into a week of assets across platforms. Platform mix, cadence, threads, calendars, listening, and engagement for a founder or a brand account. Instagram-specific audits and daily loops are suede-instagram-growth; paid creative is suede-ad-creative.",
         "url": "https://skills.suedeai.ai/skills/suede-social.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sync Packaging - Suede Creator Skills",
         "description": "No one-sheet leaves until the asset checklist is filled, and an unknown publishing assignment or sample status rides into it as a labeled clearance question, never a claim. Then the supervisor-facing package: scene and emotional angles, mood tags, screened lyric flags, and the exists, missing, unknown checklist for the master, the instrumental, the clean version, and the stems. Film, TV, ads, games, trailers, or creator campaigns.",
         "url": "https://skills.suedeai.ai/skills/suede-sync-packaging.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "sync pitching", "music supervisor requests", "sync one-sheets", "asset checklists", "lyric flags", "rights status"],
         "mainEntity": {

--- a/docs/skills/suede-sync-packaging.html
+++ b/docs/skills/suede-sync-packaging.html
@@ -26,7 +26,7 @@
         "headline": "Suede Sync Packaging - Suede Creator Skills",
         "description": "No one-sheet leaves until the asset checklist is filled, and an unknown publishing assignment or sample status rides into it as a labeled clearance question, never a claim. Then the supervisor-facing package: scene and emotional angles, mood tags, screened lyric flags, and the exists, missing, unknown checklist for the master, the instrumental, the clean version, and the stems. Film, TV, ads, games, trailers, or creator campaigns.",
         "url": "https://skills.suedeai.ai/skills/suede-sync-packaging.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "sync pitching", "music supervisor requests", "sync one-sheets", "asset checklists", "lyric flags", "rights status"],
         "mainEntity": {

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -26,7 +26,7 @@
         "headline": "Suede Video - Suede Creator Skills",
         "description": "Hook structure first, pacing second, the repurposing plan last, so one source becomes a run of cuts instead of one video and a regret. Format choice, scripting, storyboarding, generating or editing, and reverse-engineering the pacing of what already works, built into a pipeline you can run again. The calendar is suede-social; paid concepts are suede-ad-creative; it publishes nothing unapproved.",
         "url": "https://skills.suedeai.ai/skills/suede-video.html",
-        "author": {"@type": "Person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-video.html
+++ b/docs/skills/suede-video.html
@@ -26,7 +26,7 @@
         "headline": "Suede Video - Suede Creator Skills",
         "description": "Hook structure first, pacing second, the repurposing plan last, so one source becomes a run of cuts instead of one video and a regret. Format choice, scripting, storyboarding, generating or editing, and reverse-engineering the pacing of what already works, built into a pipeline you can run again. The calendar is suede-social; paid concepts are suede-ad-creative; it publishes nothing unapproved.",
         "url": "https://skills.suedeai.ai/skills/suede-video.html",
-        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro", "url": "https://github.com/JasonColapietro"},
+        "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "license": "https://opensource.org/licenses/MIT",
         "isPartOf": {"@type": "SoftwareSourceCode", "name": "Suede Creator Skills", "url": "https://skills.suedeai.ai/"}

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-visibility-grader.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/docs/skills/suede-visibility-grader.html
+++ b/docs/skills/suede-visibility-grader.html
@@ -27,7 +27,7 @@
         "description": "Each lane is graded A to F from inspection evidence, and a false published statement caps the page at D or drops it to F. Findability, first-screen clarity, CTA pull, proof and trust, AI readability, and design signal, with the evidence behind each letter and the fixes ranked. Run it before or after launch for a fast read; the deep nine-lane audit with rewrite fixes is suede-seo-audit.",
         "url": "https://skills.suedeai.ai/skills/suede-visibility-grader.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -27,7 +27,7 @@
         "description": "Describe the outcome and it picks the one specialist that fits, across copy, design, code review and grading, SEO and visibility, launch packaging, MCP QA, iOS and Android shipping, growth, and creator rights, then loads only that skill. An installed skill costs its name and its description; the body loads when a request matches, so carrying the whole pack costs a list of one-liners. Use it when a request crosses two lanes or you do not know which skill fits.",
         "url": "https://skills.suedeai.ai/skills/suede-workflow-skills.html",
         "author": {
-          "@type": "Person",
+          "@type": "Person", "@id": "https://suedeai.ai/founder#person",
           "name": "Jason Colapietro",
           "url": "https://github.com/JasonColapietro"
         },

--- a/docs/skills/suede-workflow-skills.html
+++ b/docs/skills/suede-workflow-skills.html
@@ -28,8 +28,7 @@
         "url": "https://skills.suedeai.ai/skills/suede-workflow-skills.html",
         "author": {
           "@type": "Person", "@id": "https://suedeai.ai/founder#person",
-          "name": "Jason Colapietro",
-          "url": "https://github.com/JasonColapietro"
+          "name": "Jason Colapietro"
         },
         "publisher": {
           "@type": "Organization",

--- a/scripts/build-book-site.mjs
+++ b/scripts/build-book-site.mjs
@@ -211,7 +211,7 @@ sources.forEach((page, index) => {
       dateModified: PUBLISHED,
       inLanguage: "en",
       isPartOf: { "@type": "Book", "@id": `${BASE}/book/#book`, name: "S-Tier: The Builder's Book Behind the Suede Skills" },
-      author: { "@type": "Person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
+      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
       publisher: { "@type": "Organization", name: "Suede Labs AI", url: "https://suedeai.ai" },
       mainEntityOfPage: canonical,
     },
@@ -326,7 +326,7 @@ written.set(
       license: "https://opensource.org/licenses/MIT",
       numberOfPages: sources.length,
       datePublished: PUBLISHED,
-      author: { "@type": "Person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
+      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
       publisher: { "@type": "Organization", name: "Suede Labs AI", url: "https://suedeai.ai" },
       hasPart: sources.map((p, i) => ({
         "@type": "Chapter",

--- a/scripts/build-book-site.mjs
+++ b/scripts/build-book-site.mjs
@@ -211,7 +211,7 @@ sources.forEach((page, index) => {
       dateModified: PUBLISHED,
       inLanguage: "en",
       isPartOf: { "@type": "Book", "@id": `${BASE}/book/#book`, name: "S-Tier: The Builder's Book Behind the Suede Skills" },
-      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
+      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro" },
       publisher: { "@type": "Organization", name: "Suede Labs AI", url: "https://suedeai.ai" },
       mainEntityOfPage: canonical,
     },
@@ -326,7 +326,7 @@ written.set(
       license: "https://opensource.org/licenses/MIT",
       numberOfPages: sources.length,
       datePublished: PUBLISHED,
-      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro", url: "https://github.com/JasonColapietro" },
+      author: { "@type": "Person", "@id": "https://suedeai.ai/founder#person", name: "Jason Colapietro" },
       publisher: { "@type": "Organization", name: "Suede Labs AI", url: "https://suedeai.ai" },
       hasPart: sources.map((p, i) => ({
         "@type": "Chapter",


### PR DESCRIPTION
101 pages across `docs/skills`, `docs/book`, `docs/blog` and the `docs` root credited Jason Colapietro in an author `Person` node with **no `@id`**. To a reconciler each of those is a separate, unknown person — so the highest-volume published writing in the estate was building authority for nobody.

Every author `Person` node now carries `"@id": "https://suedeai.ai/founder#person"`.

**The 18 pages under `docs/book` are generated.** The fix went into `scripts/build-book-site.mjs` (both emitters) and the site was regenerated — not hand-edited, so the next build keeps it.

### Verification
- **106 of 106** JSON-LD blocks still parse as valid JSON.
- `npm run validate` exits 0: 74 skills against 74 catalog entries, trigger routing (18 groups / 74 cases), `docs/book` current, `book/BOOK.md` current, skill cards current.
- Zero `Person` nodes remain unanchored in `docs/`.
- Every node touched names Jason Colapietro — checked before editing; there are no other people in these files.

Not touched: `skills/suede-seo-audit/references/schema-templates.md` shows a generic `[Author name]` template for auditing third-party sites, so a Suede-specific `@id` would be wrong there.
