### PR TITLE
Select folds a repeated item-lane mapping instead of rejecting the plan

### DIFF
--- a/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+++ b/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
@@ -1574,9 +1574,13 @@ const planEligibility = (plan, score) => {
     if (!lane || mapping.lane !== lane.name) reasons.push('scope mapping lane is not canonical')
     else {
       mappedLanes.add(lane.name)
-      const pair = `${mapping.item}\u0000${lane.name}`
-      if (mappingPairs.has(pair)) reasons.push('scope mapping contains a duplicate item-lane pair')
-      mappingPairs.add(pair)
+      // A repeated (item, lane) pair is one mapping cited from several sources, not
+      // two mappings: the planner prompts ask for "a source" per entry, so every
+      // finalist of run wf_13062fd6-bf3 split one line's mapping into one entry per
+      // cited source (27-32 entries over 7 items) and Select rejected all three for
+      // it. Each entry still has to name the lane's acceptance and a known source
+      // below; the repetition itself is folded, never a defect.
+      mappingPairs.add(`${mapping.item}\u0000${lane.name}`)
       if (normalizeText(mapping.acceptance) !== normalizeText(lane.acceptance)) reasons.push(`scope mapping for ${mapping.item} does not name an existing lane acceptance command`)
     }
     if (!knownPlanSources.has(normalizeSourceKey(mapping.source))) reasons.push('scope mapping cites an unknown source')

--- a/skills/suede-graph-flo-xr/workflows/tests/test_plan_path_safety.mjs
+++ b/skills/suede-graph-flo-xr/workflows/tests/test_plan_path_safety.mjs
@@ -329,3 +329,41 @@ test('diff-digest.cjs rejects a file reached through a symlinked worktree ancest
     },
   )
 })
+
+// Run wf_13062fd6-bf3 (2026-09-04, seven-line scope, three finalists): every finalist
+// mapped each checklist line to its owning lane two or three times — one scopeMap
+// entry per cited source — and Select rejected all of them for "a duplicate item-lane
+// pair", ending the run with zero mutations. A repeated pair is one mapping with more
+// sources, not a defect; every entry still has to name the lane's acceptance and a
+// known source.
+const planWithRepeatedPair = (target, extra) => {
+  const plan = planFor(target)
+  plan.scopeMap.push({ item: 'Reconcile the docs', lane: 'target-lane', acceptance: 'npm test', source: 'user scope', ...extra })
+  return plan
+}
+
+test('a scopeMap that repeats an item-lane pair with a second source is still selectable', async () => {
+  const route = 'src/a.ts'
+  const { result } = await runShip({
+    source: CURRENT,
+    candidateFiles: [route, 'README.md'],
+    trackedCandidateFiles: [route, 'README.md'],
+    planScript: () => planWithRepeatedPair(route),
+  })
+  assert.ok(result.selectedPlan,
+    `a repeated (item, lane) mapping is one mapping cited twice and must reach Select; run ended with ${JSON.stringify(result.reason)} ${JSON.stringify(result.haltDetail && result.haltDetail.eligibilityRejections)}`)
+})
+
+test('folding repeated pairs does not skip the per-entry acceptance check', async () => {
+  const route = 'src/a.ts'
+  const { result } = await runShip({
+    source: CURRENT,
+    candidateFiles: [route, 'README.md'],
+    trackedCandidateFiles: [route, 'README.md'],
+    planScript: () => planWithRepeatedPair(route, { acceptance: 'npm run build' }),
+  })
+  assert.equal(result.selectedPlan, null,
+    'a repeated entry naming an acceptance the lane does not run must still reject the plan')
+  assert.ok((result.haltDetail.eligibilityRejections || []).some(r => /does not name an existing lane acceptance/.test(r)),
+    `the rejection must be the acceptance mismatch; got ${JSON.stringify(result.haltDetail.eligibilityRejections)}`)
+})


### PR DESCRIPTION
Run wf_13062fd6-bf3 (2026-09-04, a seven-line scope against `~/sing`) reached Select with three finalists and rejected every one for `scope mapping contains a duplicate item-lane pair`. Each finalist had mapped every checklist line to its owning lane two or three times, one scopeMap entry per cited source (27–32 entries over 7 items): the planner prompts ask for "a source" per entry, so planners split one mapping into several. The repetition is harmless; each entry still has to name the lane's acceptance and a known source. Only the pair-uniqueness rejection goes.

Tests: `test_plan_path_safety.mjs` gains two cases — a repeated pair with a second known source reaches Select; a repeated entry naming an acceptance the lane does not run is still rejected for that reason. `npm run test:ship-cost` passes.