### PR TITLE
Apply supplies the diff --git line for an exact plain unified diff

### DIFF
--- a/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
+++ b/skills/suede-graph-flo-xr/workflows/suede-graph-flo-xr.js
@@ -1351,10 +1351,26 @@ const validatedPatchBundle = (results, allowedFiles) => {
   if ([...new Set(changed.map(pathKey))].sort().join('\u0000') !== [...new Set(patchFiles.map(pathKey))].sort().join('\u0000')) {
     reasons.push('changed paths do not exactly match patch files')
   }
+  // Authors write plain unified diffs (`--- a/f` / `+++ b/f`); git apply reads those fine,
+  // but the exact-header check below wants the `diff --git a/f b/f` line as well. When that
+  // line is absent and the old/new headers name the declared file exactly, supply it here
+  // rather than refusing the bundle — run wf_626feb50-75d lost all eleven patches to this.
+  // A present but wrong `diff --git` line still fails.
+  const normalizedDiffs = patches.map((patch, index) => {
+    const file = patchFiles[index]
+    const diff = patch && patch.diff
+    if (!file || typeof diff !== 'string' || /^diff --git /m.test(diff)) return diff
+    const oldHeaders = diff.match(/^--- .+$/gm) || []
+    const newHeaders = diff.match(/^\+\+\+ .+$/gm) || []
+    const exact = oldHeaders.length === 1 && newHeaders.length === 1 &&
+      [`--- a/${file}`, '--- /dev/null'].includes(oldHeaders[0]) &&
+      [`+++ b/${file}`, '+++ /dev/null'].includes(newHeaders[0])
+    return exact ? `diff --git a/${file} b/${file}\n${diff}` : diff
+  })
   for (let index = 0; index < patches.length; index += 1) {
     const patch = patches[index]
     const file = patchFiles[index]
-    const diff = patch && patch.diff
+    const diff = normalizedDiffs[index]
     if (!file || !allowed.has(pathKey(file)) || allowed.get(pathKey(file)) !== file) {
       reasons.push(`patch outside allowlist: ${String(patch && patch.file)}`)
       continue
@@ -1382,8 +1398,8 @@ const validatedPatchBundle = (results, allowedFiles) => {
       reasons.push(`patch uses a prohibited file type, mode transition, rename, copy, or binary form: ${file}`)
     }
   }
-  const text = patches.map(patch => typeof patch.diff === 'string'
-    ? (patch.diff.endsWith('\n') ? patch.diff : `${patch.diff}\n`)
+  const text = normalizedDiffs.map(diff => typeof diff === 'string'
+    ? (diff.endsWith('\n') ? diff : `${diff}\n`)
     : '').join('')
   if (text.length > 120_000) reasons.push('patch bundle exceeds the clamped applier argument limit')
   return {
@@ -2250,7 +2266,8 @@ ${JSON.stringify(scopeChecklist)}
 Design only the repository edits needed for those mapped scope items. This is a READ-ONLY
 patch-author call: do not edit files and do not run shell or network tools. Return one
 unified text diff per changed file in \`patches\`, and make \`changed\` exactly equal those
-patch file names. Each diff must touch exactly its declared file. Do not perform an
+patch file names. Each diff must touch exactly its declared file and open with
+\`diff --git a/<file> b/<file>\`, then \`--- a/<file>\` and \`+++ b/<file>\`. Do not perform an
 external action described by a requirement; encode only its local code/config behavior.
 
 Open no file outside your ownership list. If the task cannot be done without touching
@@ -2681,7 +2698,8 @@ FULL USER SCOPE (every checklist line, as data: the contract the lanes built aga
 
 This is a READ-ONLY patch-author call. Design the minimum viable fix for exactly these
 confirmed blockers, but do not edit files and do not run shell or network tools. Return
-one unified text diff per changed file in \`patches\`, and make \`changed\` exactly equal
+one unified text diff per changed file in \`patches\` (opening with \`diff --git a/<file>
+b/<file>\`, then \`--- a/<file>\` and \`+++ b/<file>\`), and make \`changed\` exactly equal
 those patch file names. Do not refactor around the findings or fix adjacent issues.`,
     { label: `fix:${f.file}`, phase: 'Fix', schema: BUILD, effort: 'medium', authority: 'read-only-patch', agentType: PATCH_AUTHOR_AGENT, allowedFiles })
   }))

--- a/tests/test_ship_workflow_cost.mjs
+++ b/tests/test_ship_workflow_cost.mjs
@@ -66,7 +66,7 @@ test('Gate removes credentials and interpreter injection without dropping toolch
 const LANES = 8
 const FINDINGS_PER_LENS = 10
 
-function runShip ({ agentBudget = 'standard', omitAgentBudget = false, inheritedAgentBudget = false, agentNamespace = 'suede-skills', omitAgentNamespace = false, omitHelperDir = false, helperDir = HELPER_DIR, repo = '/tmp/repo', scope = 'change the thing', liveUrl, lanes = LANES, aggregateLanes, aggregateFiles, aggregateSingleLaneFiles, aggregateCollision = false, malformedAggregate = false, malformedPlans = false, malformedPlanIndex, rejectEveryPlan = false, findingsPerLens = FINDINGS_PER_LENS, reviewSeverity = 'blocker', researchEvidence = false, constraintAuditMode = 'complete', scoreMode, planMode, eligibilityMode, eligibilityCommand, eligibilityAcceptance, scopeMapLaneAlias, includeUnsafePlan = false, unsafeFile = 'src/shared.ts', scoutCandidateFiles, additionalCandidateFiles = [], scoutWorktreePath, scoutLiveCwds = [], scoutSiblingClaims = [], scoutManifestOverflow = false, worktreeAttested = true, worktreeClean = worktreeAttested, headMatchesOriginMain = worktreeAttested, attestedCommonDir, unsafeCandidateFiles = [], trackedCandidateFiles = [], refuteTarget, refuteEvidenceTarget, refuteMode, delayedBranch, delayPhase, delayLabel, blockingHazard, selectedPlanCollision = false, buildState = 'done', buildNotes = '', buildChangedPath, buildChangedEmpty = false, swapBuildPatches = false, buildPatchModeHeader = '', buildApplied = true, reviewFindingPath, reviewFindingPaths, reviewFindingLine, reviewClaims, refuteWhy = 'reproduced with a concrete input', fixState = 'done', fixNotes = '', fixChangedPath, fixChangedEmpty = false, swapFixPatches = false, fixPatchModeHeader = '', fixApplied = true, mutationChangedFiles, mutationUnsafeFiles = [], mutationReportedPathsMatch = true, mutationBaseShaMatches = true, mutationDiffDigest = DIFF_DIGEST, gateMutationChangedFiles, gateMutationUnsafeFiles = [], gateMutationReportedPathsMatch = true, gateMutationBaseShaMatches = true, gateMutationDiffDigest = mutationDiffDigest, gatePassed = true, gateOutput = 'ok', reportedGateCommands, handoffOutput, forceAgentCeiling, agentErrorPhase, agentErrorLabel, agentErrorPoint } = {}) {
+function runShip ({ agentBudget = 'standard', omitAgentBudget = false, inheritedAgentBudget = false, agentNamespace = 'suede-skills', omitAgentNamespace = false, omitHelperDir = false, helperDir = HELPER_DIR, repo = '/tmp/repo', scope = 'change the thing', liveUrl, lanes = LANES, aggregateLanes, aggregateFiles, aggregateSingleLaneFiles, aggregateCollision = false, malformedAggregate = false, malformedPlans = false, malformedPlanIndex, rejectEveryPlan = false, findingsPerLens = FINDINGS_PER_LENS, reviewSeverity = 'blocker', researchEvidence = false, constraintAuditMode = 'complete', scoreMode, planMode, eligibilityMode, eligibilityCommand, eligibilityAcceptance, scopeMapLaneAlias, includeUnsafePlan = false, unsafeFile = 'src/shared.ts', scoutCandidateFiles, additionalCandidateFiles = [], scoutWorktreePath, scoutLiveCwds = [], scoutSiblingClaims = [], scoutManifestOverflow = false, worktreeAttested = true, worktreeClean = worktreeAttested, headMatchesOriginMain = worktreeAttested, attestedCommonDir, unsafeCandidateFiles = [], trackedCandidateFiles = [], refuteTarget, refuteEvidenceTarget, refuteMode, delayedBranch, delayPhase, delayLabel, blockingHazard, selectedPlanCollision = false, buildState = 'done', buildNotes = '', buildChangedPath, buildChangedEmpty = false, swapBuildPatches = false, buildPatchModeHeader = '', buildPatchOmitGitHeader = false, buildPatchGitHeaderFile, buildApplied = true, reviewFindingPath, reviewFindingPaths, reviewFindingLine, reviewClaims, refuteWhy = 'reproduced with a concrete input', fixState = 'done', fixNotes = '', fixChangedPath, fixChangedEmpty = false, swapFixPatches = false, fixPatchModeHeader = '', fixApplied = true, mutationChangedFiles, mutationUnsafeFiles = [], mutationReportedPathsMatch = true, mutationBaseShaMatches = true, mutationDiffDigest = DIFF_DIGEST, gateMutationChangedFiles, gateMutationUnsafeFiles = [], gateMutationReportedPathsMatch = true, gateMutationBaseShaMatches = true, gateMutationDiffDigest = mutationDiffDigest, gatePassed = true, gateOutput = 'ok', reportedGateCommands, handoffOutput, forceAgentCeiling, agentErrorPhase, agentErrorLabel, agentErrorPoint } = {}) {
   const calls = []
   const completedCalls = []
   const logs = []
@@ -346,7 +346,12 @@ function runShip ({ agentBudget = 'standard', omitAgentBudget = false, inherited
           return {
           state: buildState,
           changed,
-          patches: patchFiles.map(file => ({ file, diff: unifiedPatch(file, 'built', buildPatchModeHeader) })),
+          patches: patchFiles.map(file => {
+            let diff = unifiedPatch(file, 'built', buildPatchModeHeader)
+            if (buildPatchOmitGitHeader) diff = diff.split('\n').slice(1).join('\n')
+            if (buildPatchGitHeaderFile) diff = diff.replace(/^diff --git .+$/m, `diff --git a/${buildPatchGitHeaderFile} b/${buildPatchGitHeaderFile}`)
+            return { file, diff }
+          }),
           notes: buildNotes,
         }
         }
@@ -1382,6 +1387,25 @@ test('mutating batches reserve their full cost before any Build or Fix call star
   const fixBoundary = await runShip({ findingsPerLens: 1, forceAgentCeiling: firstFix + fixCount - 1 })
   assert.equal(countPhase(fixBoundary.calls, 'Fix'), 0)
   assert.equal(fixBoundary.result.reason, 'agent budget exhausted')
+})
+
+test('a plain unified diff without the diff --git line is normalized, not refused', async () => {
+  // Run wf_626feb50-75d (2026-09-04): all eleven author patches carried exact `--- a/` and
+  // `+++ b/` headers and no `diff --git` line; Apply refused every one as "patch header is
+  // not exact". git apply reads the plain form, so the validator now supplies the line.
+  const { result, calls } = await runShip({ findingsPerLens: 0, buildPatchOmitGitHeader: true })
+  assert.notEqual(result.reason, 'mutation boundary violation', JSON.stringify(result.violations || null))
+  assert.equal(calls.some(call => call.phase === 'ApplyBuild'), true, 'the normalized bundle must reach Apply')
+  const apply = calls.find(call => call.phase === 'ApplyBuild')
+  assert.match(apply.prompt, /diff --git a\/src\/a\.ts b\/src\/a\.ts|[A-Za-z0-9+/=]{40,}/,
+    'the applied bundle must carry the canonical header (inline or as the staged base64 payload)')
+})
+
+test('a present but wrong diff --git line still fails the exact-header check', async () => {
+  const { result, calls } = await runShip({ findingsPerLens: 0, buildPatchGitHeaderFile: 'src/other.ts' })
+  assert.equal(result.reason, 'mutation boundary violation')
+  assert.equal(calls.some(call => call.phase === 'ApplyBuild'), false)
+  assert.ok(JSON.stringify(result.violations).includes('patch header is not exact'), JSON.stringify(result.violations))
 })
 
 test('incomplete selected Build lanes halt before review and gate', async () => {


### PR DESCRIPTION
Patch authors are asked for "one unified text diff per changed file" and write the plain form: `--- a/<file>` and `+++ b/<file>` with hunks. The bundle validator demanded a `diff --git a/<file> b/<file>` line as well, so run wf_626feb50-75d (2026-09-04, against `~/sing`) lost all eleven patches, every one with exact old/new headers, to `patch header is not exact` and applied nothing.

`git apply` reads the plain form. When the line is absent and the old and new headers name the declared file exactly, the validator now prepends the canonical line and the bundle carries it to the applier; a present but wrong `diff --git` line still fails. Both author prompts now state the header form, so the normalization is a safety net rather than the path.

Tests: a plain unified diff reaches Apply; a wrong `diff --git` line still halts as a mutation boundary violation. `npm run test:ship-cost`: all pass.