### PR TITLE
Add a distribution ledger and guard the proof-tape skill count

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,0 +1,72 @@
+# Distribution ledger
+
+Where the Suede skill pack is listed, where it is not, what is stale, and what it takes to close each gap. Keep this file current when a listing changes. Numbers below are as of the last audit date and are not maintained by the validator.
+
+Last audit: 2026-09-05. Read-only research by four web-reader agents plus local checks. Nothing was submitted, claimed, or posted during the audit.
+
+Ground truth on the audit date: 74 skills, repository `JasonColapietro/suede-creator-skills`, homepage `https://skills.suedeai.ai`, GitHub description already states 74, 20 GitHub topics set (including `claude-code-plugin`, `claude-skills`, `agent-skills`, `codex`, `mcp-server`).
+
+## Listed
+
+| Directory | Status | Evidence | Staleness | Fix |
+| --- | --- | --- | --- | --- |
+| skills.sh (Vercel `npx skills`) | Listed, automatic | https://www.skills.sh/jasoncolapietro/suede-creator-skills shows 992 installs; top installs are suede-agent-teams, suede-ai-eval, suede-code, suede-code-grader, suede-code-review | Shows "79 skills" against 74 | No claim mechanism exists. The count refreshes on re-crawl or install traffic. Nothing to file. |
+| GetBindu/awesome-claude-code-and-skills | Listed under "Comprehensive Skill Collections" | README entry reads "67 MIT-licensed skills for Claude Code and Codex" | 67 vs 74 | PR to that repo updating the line |
+| awesomeclaude.ai/awesome-claude-skills (backed by webfuse-com/awesome-claude) | Listed under "Development & Code Tools" | Entry reads "23-skill pack for agent orchestration with WIP collision detection and rollback trees" | Description is from the first release and describes one skill, not the pack | PR to webfuse-com/awesome-claude replacing the description |
+| BehiSecc/awesome-claude-skills | Listed | Same "23-skill pack" line as above | Same | PR to that repo, same replacement |
+| ComposioHQ/awesome-claude-skills | Pending | PR #1803 (`frontend-design-review`, a neutralized copy of suede-design) is open with no review as of the audit date | The pack itself is not listed there | Nudge or wait; a pack entry is a separate submission |
+| SaaSHub | Listed, wrong product | https://www.saashub.com/suede is the paid Suede creator-rights product, not this pack | Not a pack listing | Nothing to do here |
+
+## Not listed
+
+Reach is inferred from stars or self-reported traffic. "Owner action" means an account, form, or login only the owner can operate.
+
+| Directory | Reach | How to get listed | Owner action |
+| --- | --- | --- | --- |
+| Anthropic official marketplace (`anthropics/claude-plugins-official`) | Every Claude Code install | Submission form linked from https://code.claude.com/docs/en/plugins (the `clau.de/plugin-directory-submission` redirect) | Form |
+| hesreallyhim/awesome-claude-code | 74.5k stars | PR per CONTRIBUTING.md | PR to a third-party repo |
+| ComposioHQ/awesome-claude-skills (pack entry) | 53.6k stars | PR with their template | PR to a third-party repo |
+| punkpeye/awesome-mcp-servers | 94.3k stars | PR against README | PR to a third-party repo; needs a runnable install line |
+| SkillsMP (skillsmp.com) | Tens of thousands of skills indexed | Automatic GitHub crawl; no form found | None known; wait for crawl |
+| claudemarketplaces.com | Claims 380k monthly visitors | Crawl-based; no form found | Unknown |
+| claudemarketplace.net | Claims 150k monthly visitors | Not stated | Unknown |
+| aitmpl.com (davila7/claude-code-templates) | Popular catalog | PR to the repo, or the "Promote your component" Google Form | Form or PR |
+| claudepluginhub.com, claudedirectory.org (tmcpa/claudedirectory), claudeskills.info, skillhub.club, agenticskills.io | Smaller | skillhub.club and claudeskills.info crawl GitHub; agenticskills.io has a "Submit a Skill" form; claudedirectory has a contributing guide | Form for agenticskills.io; otherwise wait |
+| ClawHub (clawhub.ai) | OpenClaw users | `clawhub skill publish <path>` from the CLI; GitHub account must be at least one week old | CLI login |
+| Official Codex plugin directory | Codex users | Not open for public submission yet per developers.openai.com/codex/plugins | Not possible yet |
+| codex-marketplace.com | Third-party Codex list | `/submit` | Form |
+| hashgraph-online/awesome-codex-plugins | Backs hol.org/plugins | Fork, run the HOL plugin scanner, add one README line, PR with the score. This repo already runs the HOL scanner in CI. | PR to a third-party repo |
+| Official MCP Registry (registry.modelcontextprotocol.io) | Feeds PulseMCP and others automatically | `mcp-publisher` CLI, a `server.json`, and a namespace verified by GitHub OAuth (`io.github.jasoncolapietro/*`) or by DNS/HTTP for `skills.suedeai.ai`. The registry expects an installable package; the MCP is clone-and-run only today. | Publish an npm package first, then GitHub OAuth login |
+| Glama (glama.ai/mcp/servers) | 82k servers indexed | Auto-crawl plus owner claim; "Add Server" button | Claim after crawl |
+| Smithery (smithery.ai) | One-click installs in several clients | https://smithery.ai/servers/new behind GitHub login, or `smithery mcp publish` | GitHub login |
+| PulseMCP | Large index | Submissions paused; it ingests the official MCP Registry automatically | None; publish to the registry |
+| mcpservers.org, Cline MCP marketplace (cline/mcp-marketplace), Cursor Directory plugins | Medium | PR (Cline), `cursor.directory/plugins/new` | PR or form |
+| Hacker News | Largest developer audience | Show HN at https://news.ycombinator.com/submit | Account |
+| Product Hunt | Large launch audience | https://www.producthunt.com/posts/new | Account |
+| Reddit r/ClaudeAI, r/ClaudeCode | Highest intent | Post | Account |
+| dev.to, Hashnode, Medium | Writeup readership | Post | Account |
+| There's An AI For That, Futurepedia, Toolify | Broad, low fit | Submission forms; two sites blocked automated checks, so listing status is unconfirmed | Form |
+
+Not verified either way because the site blocked automated reads: mcp.so, LobeHub (market.lobehub.com), mcp-get.com, There's An AI For That, Toolify, cursor.directory (rate limited).
+
+## npm
+
+No package exists for the skills MCP. These names returned 404 from the npm registry API on the audit date: `suede-skills-mcp`, `suede-creator-skills`, `suede-mcp`, `@suede/skills-mcp`. The `@suedeai` scope is in use by the sibling media product (`@suedeai/mcp-server`, `@suedeai/plugin-suede`), which is a different codebase; do not conflate the two in any listing.
+
+The MCP Registry, Glama, and Smithery index GitHub repositories directly, so npm is not a prerequisite for them. The official MCP Registry is the one place where a packaged distribution matters, and PulseMCP now ingests only from that registry.
+
+## Own surfaces
+
+All six checked URLs were reachable on the audit date: `/`, `/llms.txt`, `/sitemap.xml`, `/robots.txt`, `/plugins.html`, `/skills/suede-graph-flo-xr.html`. No "suede-ship" or "Suede Ship Gate" naming remains. `robots.txt` and `sitemap.xml` agree. The homepage proof tape said "71 skills, open source" against 74; that line is fixed in the same change that added this file, and the validator now guards it. Dated changelog and blog copy that says 71 or 73 is frozen on purpose and is not a defect.
+
+For the pack's own name, the GitHub repository outranks the site in general web search. A `site:skills.suedeai.ai` count could not be measured with the tools available; use Search Console.
+
+## Draft replacement line for the awesome lists
+
+`[suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 74 open-source Agent Skills for Claude Code and Codex: AI SEO, code review with an A-F ship grade, CI gates, AI evals, design systems, conversion copy, iOS and Android app shipping, and creator rights. MIT.`
+
+## Next actions
+
+Agent-side, no external mutation: keep the count stamps on the site current; keep this file current when a listing changes.
+
+Owner-side, in order of reach per minute of effort: the Anthropic marketplace form, a Show HN, the three awesome-list PRs (two stale descriptions, one new entry on hesreallyhim), then an npm publish of the MCP followed by `mcp-publisher` for the registry, which unlocks PulseMCP without a second submission.

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1228,27 +1228,29 @@ cp -R /tmp/suede-creator-skills/skills/suede-workflow-skills .claude/skills/</co
         <div class="shell">
           <h2 id="notes-headline">Field notes.</h2>
           <p class="section-sub">The design decisions behind the pack, written up in full: what a skill costs, how routing avoids collisions, and where memory belongs.</p>
-          <a id="hero-shiplog" data-status="released" href="./#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 324 commits &middot; 14 weeks &middot; read the full ship log -&gt;. Read the full changelog on the homepage.">
+          <a id="hero-shiplog" data-status="released" href="./#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 357 commits &middot; 16 weeks &middot; read the full ship log -&gt;. Read the full changelog on the homepage.">
             <span class="hero-spark" aria-hidden="true">
-              <span style="height:8%"></span>
-              <span style="height:0%"></span>
+              <span style="height:4%"></span>
+              <span style="height:6%"></span>
               <span style="height:2%"></span>
-              <span style="height:3%"></span>
+              <span style="height:2%"></span>
               <span style="height:100%"></span>
-              <span style="height:39%"></span>
-              <span style="height:48%"></span>
-              <span style="height:39%"></span>
-              <span style="height:52%"></span>
-              <span style="height:29%"></span>
-              <span style="height:41%"></span>
+              <span style="height:77%"></span>
+              <span style="height:58%"></span>
+              <span style="height:35%"></span>
+              <span style="height:46%"></span>
+              <span style="height:77%"></span>
+              <span style="height:56%"></span>
               <span style="height:50%"></span>
-              <span style="height:39%"></span>
-              <span style="height:41%"></span>
+              <span style="height:65%"></span>
+              <span style="height:58%"></span>
+              <span style="height:52%"></span>
+              <span style="height:54%"></span>
             </span>
             <span class="hero-shiplog-text">
               <span class="hero-shiplog-top">Released Aug 26 <b>&middot; ae08836</b></span>
               <span class="hero-shiplog-title">Both design skills get a vetted component source</span>
-              <span class="hero-shiplog-more">324 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+              <span class="hero-shiplog-more">357 commits &middot; 16 weeks &middot; read the full ship log -&gt;</span>
             </span>
           </a>
           <div class="notes">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4045,8 +4045,8 @@
 <div id="proof-tape" aria-label="Pack proof at a glance">
   <div class="tape-inner">
     <ul class="tape-track">
-      <li><b>71</b> skills, open source</li>
-      <li><b>324</b> commits in 14 weeks</li>
+      <li><b>74</b> skills, open source</li>
+      <li><b>357</b> commits in 16 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -4054,8 +4054,8 @@
       <li><b>14</b>-chapter builder&rsquo;s book, free</li>
     </ul>
     <ul class="tape-track" aria-hidden="true">
-      <li><b>71</b> skills, open source</li>
-      <li><b>324</b> commits in 14 weeks</li>
+      <li><b>74</b> skills, open source</li>
+      <li><b>357</b> commits in 16 weeks</li>
       <li><b>$448.31</b> argued back from Amazon</li>
       <li><b>0</b> uploads by default</li>
       <li><b>2</b> runtimes: Claude Code + Codex</li>
@@ -4092,27 +4092,29 @@
           <a id="hero-cta-secondary" href="#scorecard">See where we lose</a>
         </div>
 
-        <a id="hero-shiplog" class="hero-anim" data-status="released" href="#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 324 commits &middot; 14 weeks &middot; read the full ship log -&gt;. Jump to the full changelog.">
+        <a id="hero-shiplog" class="hero-anim" data-status="released" href="#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 357 commits &middot; 16 weeks &middot; read the full ship log -&gt;. Jump to the full changelog.">
           <span class="hero-spark" aria-hidden="true">
-            <span style="height:8%"></span>
-            <span style="height:0%"></span>
+            <span style="height:4%"></span>
+            <span style="height:6%"></span>
             <span style="height:2%"></span>
-            <span style="height:3%"></span>
+            <span style="height:2%"></span>
             <span style="height:100%"></span>
-            <span style="height:39%"></span>
-            <span style="height:48%"></span>
-            <span style="height:39%"></span>
-            <span style="height:52%"></span>
-            <span style="height:29%"></span>
-            <span style="height:41%"></span>
+            <span style="height:77%"></span>
+            <span style="height:58%"></span>
+            <span style="height:35%"></span>
+            <span style="height:46%"></span>
+            <span style="height:77%"></span>
+            <span style="height:56%"></span>
             <span style="height:50%"></span>
-            <span style="height:39%"></span>
-            <span style="height:41%"></span>
+            <span style="height:65%"></span>
+            <span style="height:58%"></span>
+            <span style="height:52%"></span>
+            <span style="height:54%"></span>
           </span>
           <span class="hero-shiplog-text">
             <span class="hero-shiplog-top">Released Aug 26 <b>&middot; ae08836</b></span>
             <span class="hero-shiplog-title">Both design skills get a vetted component source</span>
-            <span class="hero-shiplog-more">324 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+            <span class="hero-shiplog-more">357 commits &middot; 16 weeks &middot; read the full ship log -&gt;</span>
           </span>
         </a>
       </div>
@@ -4257,23 +4259,25 @@
 
       <p class="clog-fresh reveal reveal-d2">Version 0.16.0 released Aug 26, 2026 <span id="clog-fresh-rel" data-iso="2026-08-26"></span></p>
 
-      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last fourteen weeks, oldest to newest: 5, 0, 1, 2, 66, 26, 32, 26, 34, 19, 27, 33, 26, and 27 commits.">
-        <span style="height:8%"></span>
-        <span style="height:0%"></span>
+      <div class="clog-spark reveal reveal-d2" role="img" aria-label="Commit activity per week over the last sixteen weeks, oldest to newest: 2, 3, 1, 1, 48, 37, 28, 17, 22, 37, 27, 24, 31, 28, 25, and 26 commits.">
+        <span style="height:4%"></span>
+        <span style="height:6%"></span>
         <span style="height:2%"></span>
-        <span style="height:3%"></span>
+        <span style="height:2%"></span>
         <span style="height:100%"></span>
-        <span style="height:39%"></span>
-        <span style="height:48%"></span>
-        <span style="height:39%"></span>
-        <span style="height:52%"></span>
-        <span style="height:29%"></span>
-        <span style="height:41%"></span>
+        <span style="height:77%"></span>
+        <span style="height:58%"></span>
+        <span style="height:35%"></span>
+        <span style="height:46%"></span>
+        <span style="height:77%"></span>
+        <span style="height:56%"></span>
         <span style="height:50%"></span>
-        <span style="height:39%"></span>
-        <span style="height:41%"></span>
+        <span style="height:65%"></span>
+        <span style="height:58%"></span>
+        <span style="height:52%"></span>
+        <span style="height:54%"></span>
       </div>
-      <p class="clog-spark-caption reveal reveal-d2">324 commits &middot; 14 weeks &middot; newest on the right</p>
+      <p class="clog-spark-caption reveal reveal-d2">357 commits &middot; 16 weeks &middot; newest on the right</p>
 
       <div class="clog-filters reveal reveal-d2" role="group" aria-label="Filter changelog entries by type">
         <button class="clog-filter" type="button" data-filter="all" aria-pressed="true">All</button>

--- a/docs/skills/index.html
+++ b/docs/skills/index.html
@@ -567,27 +567,29 @@
     <h1>Every skill. One honest line each.</h1>
     <p class="lead">Every skill is a plain-Markdown <code>SKILL.md</code> file you can read before your agent runs it, every line of it on GitHub. <strong>Six specialities:</strong> ship (15), craft (9), get found (13), demand channels (8), revenue &amp; retention (15), and strategy &amp; rights (14). Each splits into sub-lanes, and every row links to its deep docs and its source folder on GitHub. Nothing to uninstall but a folder.</p>
 
-    <a id="hero-shiplog" data-status="released" href="#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 324 commits &middot; 14 weeks &middot; read the full ship log -&gt;. Jump to the changelog.">
+    <a id="hero-shiplog" data-status="released" href="#changelog" aria-label="Ship log. Released Aug 26 &middot; ae08836 Both design skills get a vetted component source 357 commits &middot; 16 weeks &middot; read the full ship log -&gt;. Jump to the changelog.">
       <span class="hero-spark" aria-hidden="true">
-        <span style="height:8%"></span>
-        <span style="height:0%"></span>
+        <span style="height:4%"></span>
+        <span style="height:6%"></span>
         <span style="height:2%"></span>
-        <span style="height:3%"></span>
+        <span style="height:2%"></span>
         <span style="height:100%"></span>
-        <span style="height:39%"></span>
-        <span style="height:48%"></span>
-        <span style="height:39%"></span>
-        <span style="height:52%"></span>
-        <span style="height:29%"></span>
-        <span style="height:41%"></span>
+        <span style="height:77%"></span>
+        <span style="height:58%"></span>
+        <span style="height:35%"></span>
+        <span style="height:46%"></span>
+        <span style="height:77%"></span>
+        <span style="height:56%"></span>
         <span style="height:50%"></span>
-        <span style="height:39%"></span>
-        <span style="height:41%"></span>
+        <span style="height:65%"></span>
+        <span style="height:58%"></span>
+        <span style="height:52%"></span>
+        <span style="height:54%"></span>
       </span>
       <span class="hero-shiplog-text">
         <span class="hero-shiplog-top">Released Aug 26 <b>&middot; ae08836</b></span>
         <span class="hero-shiplog-title">Both design skills get a vetted component source</span>
-        <span class="hero-shiplog-more">324 commits &middot; 14 weeks &middot; read the full ship log -&gt;</span>
+        <span class="hero-shiplog-more">357 commits &middot; 16 weeks &middot; read the full ship log -&gt;</span>
       </span>
     </a>
 

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -847,7 +847,7 @@ const publicSkillFiles = publicFiles.filter((file) => {
     rel.startsWith("scripts/") ||
     rel.startsWith("tests/") ||
     rel.startsWith(".github/") ||
-    ["README.md", "COPY.md", "PROMO.md", "PASSPORT.md", "package.json", "package-lock.json"].includes(rel);
+    ["README.md", "COPY.md", "PROMO.md", "PASSPORT.md", "DISTRIBUTION.md", "package.json", "package-lock.json"].includes(rel);
 });
 
 for (const file of publicSkillFiles) {
@@ -1146,6 +1146,9 @@ countChecks.push(
   // Python proof-tape suite, after validate had already passed. Owned here now.
   { file: "docs/index.html", label: "essays stamp: pack size", re: /how (\d+) skills stay cheap to carry/, expected: totalSkillCount },
   { file: "docs/skills/index.html", label: "essays stamp: pack size", re: /how (\d+) skills stay cheap to carry/, expected: totalSkillCount },
+  // The #proof-tape marquee repeats its whole track for a seamless loop, so the
+  // pack-size claim appears twice; both copies said 71 after the pack reached 74.
+  { file: "docs/index.html", label: "proof-tape: pack size", re: /<li><b>(\d+)<\/b> skills, open source<\/li>/, expected: totalSkillCount, every: true },
   { file: "book/02-anatomy-of-a-skill.md", label: "frontmatter survey skill count", re: /Across all (\d+) skills, the frontmatter carries/, expected: totalSkillCount },
   { file: "book/02-anatomy-of-a-skill.md", label: "name key count", re: /carries `name` (\d+) times/, expected: totalSkillCount },
   { file: "book/02-anatomy-of-a-skill.md", label: "description key count", re: /and `description`\s+(\d+) times/, expected: totalSkillCount },


### PR DESCRIPTION
## What

- `DISTRIBUTION.md`: where the pack is listed, where it is not, what is stale, how each directory takes submissions, and which steps need the owner's accounts. Research by four read-only web agents on 2026-09-05; nothing was submitted.
- Homepage proof tape said **71 skills** against 74 in both marquee copies. Fixed, and `validate-skill-pack.mjs` now guards that line (`every: true`).
- Ship-log stamp regenerated (`build-shiplog --check` was failing on main).
- `DISTRIBUTION.md` added to the validator's public-file leak scan.

## Verification

- Guard proven: with the tape reverted to 71 the validator reports two stale occurrences; at 74 it passes.
- `npm run validate` green on this branch, rebased onto main at 23d31e7.