### PR TITLE
Add the vendorable frontend-design-review copy

### DIFF
--- a/vendorable/README.md
+++ b/vendorable/README.md
@@ -10,6 +10,7 @@ or references to sibling skills they do not have.
 
 | Folder | Derived from | Notes |
 | --- | --- | --- |
+| `frontend-design-review` | `skills/suede-design` | Renamed. Brand-free description, sibling routing removed, `CARD.md` omitted. The copy submitted to ComposioHQ/awesome-claude-skills (PR #1803), whose validator now accepts README-only entries linking to an external repo, so this is the folder that link must resolve to |
 | `site-to-ios-app` | `skills/site-to-ios-app` | `CARD.md` omitted (release metadata, repo-relative links) |
 | `voice-preserving-line-edit` | `skills/suede-deslop` | Renamed. Leads on the voice-preserving and audit-mode differentiators |
 

--- a/vendorable/frontend-design-review/SKILL.md
+++ b/vendorable/frontend-design-review/SKILL.md
@@ -1,0 +1,490 @@
+---
+name: frontend-design-review
+description: Design, review, and visually QA web and app interfaces against explicit design laws so shipped screens look intentional instead of generic AI output.
+---
+
+# Frontend Design Review
+
+Most AI-generated interfaces fail the same way: they compile, they look plausible
+in code, and they render as the average of every landing page in the training
+data. Dark blue for a developer tool. Purple gradient for a music app. Three
+icon cards in a row. A tiny uppercase eyebrow above every section.
+
+This skill replaces taste-by-vibes with thresholds. It gives Claude a design
+contract to lock before writing CSS, numeric laws to satisfy while writing it, a
+list of banned defaults with the specific replacement for each, and a
+render-and-compare loop so nothing is called done from reading code. It works on
+product UI, dashboards, marketing pages, component systems, and app store
+assets.
+
+**Core principle:** strip the logo and the surface must still be unmistakably
+this product, and render the result before claiming it works.
+
+## When to Use This Skill
+
+- Building a new landing page, dashboard, app shell, or component family and you
+  want it to look designed rather than defaulted.
+- Reviewing an interface someone (or an agent) already built, and you need
+  specific findings with file names, not "looks good."
+- Auditing a design system for drift: inconsistent tokens, ad hoc spacing,
+  five shades of the same gray, components that disagree with each other.
+- Comparing a mock, Figma frame, screenshot, or reference URL against a built
+  implementation and reporting the gaps by severity.
+- Fixing a UI that feels generic and you cannot articulate why.
+- Preparing high-visibility surfaces: launch pages, app store screenshots,
+  investor demos, docs sites.
+
+Skip it for backend-only work, or a one-line copy change with no visual
+consequence.
+
+## What This Skill Does
+
+1. **Locks a design contract before implementation**: audience, surface job,
+   primary action, register (brand vs. product), spacing scale, color roles,
+   type roles, copy vocabulary, and acceptance checks. Ambiguity resolved up
+   front instead of relitigated in review.
+2. **Forces a committed aesthetic direction**: pick one of eight named tonal
+   directions (refined minimal, editorial, brutalist, retro-technical, organic,
+   maximalist, luxury refined, product-utilitarian) and execute it fully. The
+   failure mode is not "too bold" or "too plain," it is uncommitted.
+3. **Applies numeric design laws**: color strategy, dark-mode surface lightness
+   and contrast floors, fluid type scale with `clamp()`, line measure, layout
+   and z-index rules, component laws for forms, modals, tables, navigation, and
+   empty states, plus motion curves and durations. See
+   [references/design-laws.md](./references/design-laws.md).
+4. **Rejects AI-slop defaults with named replacements**: gradient text,
+   decorative glass panels, orb backgrounds, ghost cards, over-rounded corners,
+   numbered section scaffolding, hero-metric templates, fake statistics. Each
+   ban ships with a BEFORE and an AFTER and the narrow case where the exception
+   is earned. See [references/scoped-bans.md](./references/scoped-bans.md).
+5. **Renders and verifies**: captures desktop and mobile screenshots, compares
+   source visual target to implementation in the same pass, and writes a
+   `visual-qa-report.md` with findings ordered P0 to P3.
+6. **Scores design systems out of 100** across ten dimensions and names the two
+   weakest to fix first.
+7. **Ends with a ship gate**: `ship`, `ship-with-caveats`, or `hold`, with the
+   evidence that supports the verdict.
+
+## How to Use
+
+### Basic Usage
+
+```
+Review the design of the dashboard at http://localhost:3000/app and tell me
+what is wrong with it. Render it at desktop and mobile before answering.
+```
+
+Claude inspects the source, renders the page, checks it against the design laws
+and the banned-defaults list, and reports findings with file names and specific
+fixes.
+
+### Advanced Usage
+
+```
+Redesign our pricing page. Before writing code:
+1. Write the design contract (audience, page job, primary action, register).
+2. Name the aesthetic direction and the one memorable move, and explain why the
+   obvious choice for this category is the wrong one.
+3. Propose two approaches with tradeoffs and let me pick.
+Then build it, render at 1280x900 and 390x844, and finish with a ship gate.
+```
+
+```
+Compare ./designs/hero-mock.png against the implementation at
+http://localhost:5173 and save visual-qa-report.md with P0-P3 findings.
+```
+
+```
+Audit our design system in ./src/styles and score it out of 100 across color
+consistency, typography hierarchy, spacing rhythm, component consistency,
+responsive behavior, dark/light behavior, motion restraint, accessibility,
+information density, and polish. Fix the two lowest dimensions.
+```
+
+## Example
+
+**User**: "Our analytics dashboard looks like every other analytics dashboard.
+Fix it."
+
+**Output**:
+
+```
+DESIGN PREFLIGHT
+target=./apps/web  surface=/dashboard  register=product
+context=partial (no DESIGN.md)  render=pass (1280x900, 390x844)
+
+DIAGNOSIS
+The surface is the category average. Three findings explain most of it.
+
+P0  Color is decorative, not semantic. src/styles/tokens.css:14
+    Six blues, none of which encode meaning. Threshold breaches, healthy
+    ranges, and stale data all render in the same accent.
+    Fix: commit to Restrained strategy. Tinted neutrals plus one accent
+    under 10% of surface area, reserved for threshold breaches only.
+
+P1  Card-in-card nesting. src/components/MetricGrid.tsx:31
+    Each metric is a card inside a section card. Cards are for items that
+    are independently scannable or selectable, not section wrappers.
+    Fix: rows with a shared rule, one card level maximum.
+
+P1  Hero-metric template. src/components/Headline.tsx:8
+    "$2.4M" at 80px/weight-900 with a 12px label under it. Isolated big
+    numbers read as marketing, not instrumentation.
+    Fix: put the number back in the row it belongs to, with its delta and
+    its comparison window beside it.
+
+DIRECTION
+Aesthetic: product-utilitarian. Scene: an on-call engineer scanning for the
+one number that moved, at 2am, on a second monitor. That scene forbids hero
+type and rewards density plus one loud state color.
+
+Memorable move: a sparkline gutter down the left edge of every row, so the
+shape of the week is readable before any number is.
+
+SHIP GATE
+Surface: /dashboard
+Done signal: desktop + mobile render, contrast pass
+Evidence: dashboard-desktop.png, dashboard-mobile.png, contrast 7.1:1 body
+Blockers: none
+Accepted caveats: empty state still generic, tracked separately
+Next action: apply P0 token change, re-render
+Status: ship-with-caveats
+```
+
+**Inspired by:** the design workflow from the
+[Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills)
+collection by Jason Colapietro, generalized for any product.
+
+## Tips
+
+- Name the physical scene concretely enough that it forces the design answer.
+  "A studio engineer reviewing a rights dispute at 2am on a secondary monitor"
+  forces different choices than "a user looking at data." If the sentence does
+  not force the answer, add detail until it does.
+- Run the two-step slop check before committing to an aesthetic. First: could
+  someone guess the palette from the product category alone (observability to
+  dark blue, healthcare to white and teal)? Reject that. Second: could someone
+  guess it from category plus your anti-references? That is the subtler trap.
+  Go further.
+- Render before you claim. One-line CSS changes break mobile navigation.
+  Minimum coverage: 1280px wide desktop and 390px wide mobile.
+- `npx playwright screenshot <url> --viewport-size=1280,900 desktop.png`
+  captures the render. One-time setup: `npx playwright install chromium`.
+- Extract a design-system issue when a token, spacing pattern, color, or state
+  treatment repeats three or more times, or controls a high-visibility surface.
+- Never redraw, trace, recolor, or approximate a logo or brand mark. Use the
+  approved asset file. If it is unavailable, omit the mark and say so rather
+  than improvise one.
+- Fake metrics and fake testimonials ship if nobody stops them. Flag every
+  placeholder number with `[NEEDS REAL DATA]`.
+- Below 70/100 on the design-system score, the system is failing. Fix the two
+  lowest dimensions before styling new features on that surface.
+
+## Common Use Cases
+
+- Rescuing a page that feels generic and stating precisely why.
+- Pre-launch visual QA on marketing sites, docs sites, and product tours.
+- Mock-versus-implementation fidelity checks with a written report.
+- Design-system audits and drift cleanups before a redesign.
+- Dark-mode passes that are not just inverted light mode.
+- Component reviews for forms, tables, modals, navigation, and empty states.
+- App store screenshot preparation (1290x2796 for 6.7-inch, 1488x2266 for
+  iPad Pro 13-inch).
+- Accessibility sweeps: contrast ratios, focus order, touch targets, keyboard
+  paths, reduced-motion compliance.
+
+---
+
+## Reference: Working Method
+
+The sections below are the operating detail. Read them when doing the work, not
+when deciding whether the skill applies.
+
+### Operating Stance
+
+- Work from current source and a rendered screen. Do not design from memory when
+  a repo, live URL, screenshot, or local preview can be checked.
+- Prefer the existing framework, tokens, components, icon library, and routing
+  patterns. Add a new abstraction only when it removes real complexity or
+  matches an established local pattern.
+- Keep the product's actual differentiators in the copy. Do not flatten a
+  specific product into generic category language.
+- Never redraw, trace, approximate, typeset, recolor, or generate a replacement
+  for a brand mark. Use the approved file or omit it.
+
+Before design work, read the surface context:
+
+- `PRODUCT.md` if present: users, brand, tone, anti-references, principles.
+- `DESIGN.md` if present: color tokens, type scale, component inventory, spacing.
+- `AGENTS.md`, `CLAUDE.md`, `AI_HANDOFF.md`, or `README.md` for surface context.
+
+If those files are missing on a major surface, note the gap, proceed with what is
+available, and offer to create them afterward.
+
+State the preflight before starting:
+
+```text
+DESIGN PREFLIGHT
+target=<repo-or-folder>  surface=<route-or-url>  register=<brand|product>
+context=<pass|partial|none>  design_system=<loaded|not_found>
+render=<pass|pending|skipped:reason>
+```
+
+### Task Router
+
+Choose the smallest path that fits the request.
+
+- **Clear small fix**: inspect current UI, make the narrow edit, verify the
+  render, report what changed.
+- **Ambiguous or net-new design**: gather context, propose two or three
+  approaches with tradeoffs, recommend one, get approval before implementing.
+- **Large redesign**: write a compact shape brief first, covering audience, page
+  job, register, scene, color strategy, typography, layout, signature moment,
+  constraints, and QA plan.
+- **Visual system work**: scan current CSS, tokens, components, spacing,
+  shadows, breakpoints, icon usage, and repeated patterns before proposing
+  changes.
+- **Source-to-implementation QA**: compare the visual target and the rendered
+  build in the same pass, then save `visual-qa-report.md`.
+- **Long polish loop**: iterate through a visible checklist. If the same failure
+  repeats, freeze the loop, reduce scope to the failing unit, and rerun with
+  explicit acceptance criteria.
+
+### Design Contract
+
+Before a new surface, significant redesign, reusable component family, or
+design-system pass, lock these:
+
+- audience, surface job, primary action, and launch stage;
+- spacing scale, grid behavior, breakpoints, and stable dimensions;
+- color roles, semantic states, contrast requirements, and dark/light behavior;
+- typography roles, hierarchy limits, body measure, and truncation strategy;
+- copy vocabulary for buttons, empty states, loading, errors, and success;
+- asset sources, logo use, crop rules, screenshot states, and motion rules;
+- acceptance checks for desktop, mobile, accessibility, and rendered evidence.
+
+For a narrow one-element fix, document only the relevant items instead of
+forcing a full spec.
+
+### Context Checklist
+
+1. Identify the surface: repo or folder, route, live URL, deployment target,
+   branch, dirty files, and relevant local docs.
+2. Read repo-local agent and product docs when present.
+3. Decide the register:
+   - **Brand**: marketing, launch, campaign, public page, portfolio, editorial.
+   - **Product**: app shell, dashboard, tool, form, settings, admin, workflow.
+4. Name the physical scene: who uses this, where, under what light, with what
+   pressure, and what they need to do next.
+5. Inspect the current rendered UI at desktop and mobile breakpoints before
+   making claims about quality.
+
+### Design Laws
+
+The numeric rules (spacing, type scale, color, contrast, dark mode, density,
+motion, component behavior) are in
+[references/design-laws.md](./references/design-laws.md). Read that file whenever
+writing or reviewing actual styles. It is not needed to route a request or scope
+the work.
+
+### Scoped Bans And Exceptions
+
+What is banned, the scope each ban applies to, and the narrow allowed exceptions
+are in [references/scoped-bans.md](./references/scoped-bans.md). Read it when a
+design choice looks like it needs an exception, or when reviewing whether one was
+legitimately taken.
+
+### Aesthetic Direction
+
+Commit to a direction before writing code, and name it explicitly.
+
+Tonal spectrum, pick one and execute it with precision:
+
+- **Refined minimal**: restraint, negative space, weight as the only accent, no
+  ornamentation.
+- **Editorial**: strong typographic hierarchy, asymmetry, text as structure,
+  headline-first layout.
+- **Brutalist**: raw grids, exposed structure, high contrast, deliberate
+  anti-polish.
+- **Retro-technical**: monospace, terminal palette, scan-line texture, system-UI
+  references.
+- **Organic**: rounded forms, warm neutrals, tactile texture, soft shadow.
+- **Maximalist**: density as delight, layered elements, multiple active
+  typefaces, controlled chaos.
+- **Luxury refined**: generous space, serif hierarchy, muted palette,
+  detail-obsessed craft.
+- **Product-utilitarian**: information density, data-first, compact controls, no
+  decorative chrome.
+
+Bold maximalism and refined minimalism both work. The failure mode is neither: a
+design with no committed direction reads as generic.
+
+**Unforgettable factor**: every major surface should have one move that earns
+memory, and it should be subject-native, something that only makes sense for this
+product. A chain-of-title timeline for a rights platform. A live request waterfall
+for an API tool. A shift-coverage ribbon for a scheduling app. Name it before
+implementation.
+
+**AI slop check**: run both reflex tests before committing.
+
+1. Could someone guess the theme and palette from the product category alone?
+   That is the first-order training-data reflex. Reject it.
+2. Could someone guess the aesthetic family from category plus anti-references?
+   That is the second-order trap. Go further.
+
+**Theme sentence**: name the physical scene concretely enough that it forces the
+design answer. Dark versus light is never a default. Not dark because tools look
+cool dark, not light to play it safe.
+
+**Background and atmosphere**: gradient meshes, noise textures, geometric
+patterns, layered transparencies, dramatic shadows, grain overlays, and
+decorative borders are legitimate tools when they serve the aesthetic. Do not
+substitute generic gradient blobs, bokeh orbs, or CSS-only approximations for
+real art direction.
+
+### Copy Rules
+
+- Write like a product operator, not a brochure.
+- Every label names an action, not a category. "Create Invoice" not "Invoice
+  Creation." "Verify Domain" not "Domain Verification." The actor is the user;
+  the object is specific.
+- Cut filler, vague promises, and restated headings.
+- Use the same action name across button, toast, empty state, and confirmation.
+- Errors must say what happened and how to fix it.
+- Empty states point to the next specific action, not a generic "get started."
+
+### Design System Quality Of Life
+
+For any major surface, reusable app shell, or important component family,
+produce these at the smallest useful fidelity:
+
+- **Token map**: color roles, type scale, spacing, radii, shadows, motion,
+  z-layers, and semantic state names, stored in `DESIGN.md` or
+  `design-tokens.json`.
+- **State matrix**: default, hover, focus, active, disabled, loading, empty,
+  success, warning, error, and permission-denied for every component that
+  touches data.
+- **Copy vocabulary**: action labels, toast language, error messages, and
+  empty-state prompts that stay consistent across the product.
+- **Screenshot contract**: named states with seeded demo data so marketing, app
+  store, QA, and docs reproduce the same visuals.
+- **Accessibility pass**: contrast ratios, focus order, touch targets, keyboard
+  paths, and reduced-motion compliance.
+- **Migration notes**: what old styles still exist, what not to touch, and how
+  new work adopts the system without rewriting unrelated screens.
+
+Extract a design-system issue when a token, component, spacing pattern, color,
+type treatment, or state pattern repeats at least three times or controls a
+high-visibility surface. Classify drift root cause as token missing, token
+ignored, component gap, content pressure, platform convention, or legacy debt.
+
+For broad audits, score:
+
+```text
+Color consistency: /10
+Typography hierarchy: /10
+Spacing rhythm: /10
+Component consistency: /10
+Responsive behavior: /10
+Dark/light behavior: /10
+Motion restraint: /10
+Accessibility: /10
+Information density: /10
+Polish: /10
+Total: /100
+```
+
+Below 70/100 the system is failing: fix the two lowest dimensions before styling
+new features on that surface. Any dimension at 4/10 or lower is a P1 finding.
+
+### Implementation Workflow
+
+1. **Scan**: inspect current files, styles, rendered UI, and route behavior.
+2. **Shape**: when needed, write a compact plan with color, type, layout,
+   motion, asset, copy, and verification decisions.
+3. **Build**: edit narrowly inside the local architecture. Keep unrelated
+   refactors out.
+4. **Render**: run the local server or existing preview. Capture desktop and
+   mobile screenshots:
+   `npx playwright screenshot <url> --viewport-size=1280,900 desktop.png` and
+   `--viewport-size=390,844 mobile.png`, or the environment's built-in preview
+   or screenshot tool. For app store submissions: 1290x2796 (6.7-inch),
+   1488x2266 (iPad Pro 13-inch).
+5. **Review**: check typography, spacing, colors, asset fidelity, copy,
+   accessibility, responsive behavior, and loading, empty, error, hover, focus,
+   and active states.
+6. **Verify**: run the relevant lint, typecheck, test, build, or focused
+   command. Run `git diff --check` when files changed. Verify live URLs before
+   claiming public behavior.
+7. **Handoff**: record target, files changed, commands, verification, caveats,
+   and the next step.
+
+### Red Flags, Stop
+
+If any of these thoughts appear, stop and run the check being skipped:
+
+- "The code reads right, so it will render right." Render it. Screenshots beat
+  code inspection.
+- "This change is too small for visual QA." One-line CSS changes break mobile
+  navigation. Check desktop and mobile.
+- "Music tool, so dark purple." That is the first-order reflex the Color law
+  exists to reject. Substitute your own category and its obvious palette.
+- "A placeholder metric is fine for now." Fake numbers ship unless they carry a
+  `[NEEDS REAL DATA]` flag.
+- "I remember what the reference looks like." Compare source and implementation
+  in the same pass, never from memory.
+- "I will write the tokens down later." Unlogged tokens are how drift starts.
+  Note the gap now.
+
+### Visual QA Report
+
+When comparing a source visual target against an implementation, save
+`visual-qa-report.md` with:
+
+- source visual truth path or URL;
+- implementation path, URL, or screenshot;
+- viewport and state;
+- theme, auth state, content or data state, and interaction state;
+- full-view comparison evidence;
+- focused region comparison evidence, or why it was not needed;
+- findings ordered by P0/P1/P2/P3 severity;
+- patches made after the previous pass;
+- `final result: passed` or `final result: blocked`.
+
+Compare source and implementation in the same visual pass, not from memory.
+Check typography, spacing and layout, colors and tokens, image and asset
+fidelity, logos and icons, copy and content, loading/empty/error/hover/focus/
+active states, responsiveness, accessibility, and motion where relevant.
+
+Use `blocked` when a required artifact is missing for the comparison, or when
+actionable P0/P1/P2 issues remain. Use `passed` only when no actionable P0/P1/P2
+findings remain.
+
+### Ship Gate
+
+For launch pages, app shells, public marketing surfaces, app store assets, or
+high-visibility dashboard work, end with:
+
+```text
+Surface:
+Done signal:
+Evidence:
+Blockers:
+Accepted caveats:
+Next action:
+Status: ship | ship-with-caveats | hold
+```
+
+Use `hold` when a core path is broken, claims are false, screenshots do not match
+the implementation, accessibility blocks a primary action, or the live route
+cannot be verified. Use `ship-with-caveats` only when the caveat is explicit,
+non-critical, and acceptable for the launch stage.
+
+Do not call work done because the code changed. Call it done only when the done
+signal has been checked or the remaining gap is named.
+
+### Output Style
+
+Findings lead, rationale follows. Name the file and the line. For builds, state
+what changed and show the render evidence. Do not narrate internal process step
+names in user-visible output.

--- a/vendorable/frontend-design-review/references/design-laws.md
+++ b/vendorable/frontend-design-review/references/design-laws.md
@@ -1,0 +1,256 @@
+# Design Laws
+
+The numeric rules an interface has to satisfy: spacing, type scale, color,
+contrast, density, motion, and state. Every law here is a threshold, not a
+preference.
+
+## Subject First
+
+Strip the logo from the surface. If what remains could belong to a generic SaaS,
+a crypto exchange, or a music streaming app, the design has failed. Every
+surface should answer one question specifically: "what does this user do here?"
+
+## One Memorable Move
+
+Give each major surface one signature element that earns attention, and make it
+native to the subject. A chain-of-title timeline for a rights platform. A live
+request waterfall for an API tool. A shift-coverage ribbon for a scheduling app.
+A provenance receipt for a supply-chain product. Keep the surrounding UI
+disciplined so the signature move carries.
+
+## Color
+
+- Pick a strategy from the Color Strategy Axis below before picking any values.
+- Color must earn its position by encoding meaning: ownership, status, action
+  type, risk level, state change, tier, or sequence. Decorative color is waste.
+- First-order reflex to reject: "creator tool, so dark purple gradient."
+  Second-order trap: avoided purple and landed on muted-teal-on-dark anyway. Go
+  further until the palette is specific to this surface's physical scene.
+
+### Color Strategy Axis
+
+Before picking values, commit to a strategy:
+
+- **Restrained**: tinted neutrals plus one accent at 10% or less of surface
+  area. Default for product dashboards, admin, tools, and focus-heavy workflows.
+- **Committed**: one saturated color carries 30-60% of the surface. Default for
+  brand pages and identity-driven screens. The "one accent at 10% or less" rule
+  does NOT apply here.
+- **Full palette**: three or four named color roles, each used deliberately. Use
+  for data visualization, campaign pages, and multi-feature products.
+- **Drenched**: the surface IS the color. Use for campaign heroes, launch
+  moments, and brand statements.
+
+Pick a strategy before picking values. Avoid defaulting to Restrained for
+everything. Committed and Full palette designs require it to feel intentional.
+
+For CSS color values, prefer OKLCH. Reduce chroma as lightness approaches 0 or
+100 to avoid garish extremes. Tint every neutral toward the brand hue (chroma
+0.005-0.01 is enough). Never use pure `#000` or `#fff`.
+
+## Dark Mode
+
+Dark mode is not an inversion. These are the specific rules.
+
+**Surfaces:** dark surfaces use OKLCH lightness 10-18, not 0. Background layers
+stack from dark to slightly lighter: base (L=12), elevated (L=16), overlay
+(L=20), modal (L=24). Never use pure black as a surface.
+
+**Shadows:** shadows disappear on dark surfaces. Replace elevation cues with
+border-based layering: 1px border at `oklch(1 0 0 / 0.08)` on elevated surfaces,
+`oklch(1 0 0 / 0.12)` on modals. Drop shadows only appear in dark mode when the
+element is physically lifted (a draggable card, a tooltip, a floating toolbar).
+
+**Contrast minimums:** body text on a dark background, minimum 7:1 (WCAG AAA).
+Secondary text 4.5:1. Disabled text 3:1. Do not use near-black text on dark
+surfaces. Use light text with opacity adjustments: `oklch(1 0 0 / 0.45)` for
+secondary, `oklch(1 0 0 / 0.25)` for disabled.
+
+**Chroma:** in dark mode, reduce saturated color chroma by 15-25%.
+`oklch(0.65 0.22 260)` in light becomes `oklch(0.72 0.17 260)` in dark. Fully
+saturated accents on dark backgrounds read as neon. Pull back.
+
+**Semantic tokens:** define light and dark values for every semantic token at
+design time: `--color-surface-base`, `--color-surface-elevated`,
+`--color-border-subtle`, `--color-text-primary`, `--color-text-secondary`,
+`--color-text-disabled`. Never hardcode hex in component CSS.
+
+## Typography
+
+- Pair typefaces deliberately. Display, body, and utility text should have
+  distinct jobs.
+- Use scale and weight for hierarchy. Keep at least a 1.25 ratio between major
+  type steps.
+- Keep body copy around 65-75 characters per line.
+- Keep letter spacing at 0 by default. Do not use negative letter spacing.
+- Match type size to context. Dashboards, cards, and toolbars need compact
+  hierarchy, not hero-scale text.
+
+Typography anti-patterns to avoid without explicit justification:
+
+- Overused system fonts as the display face: Inter, Roboto, Arial, SF Pro.
+- Symmetric type pairing: display and body from the same family.
+- Uniform weight across headline, subhead, and body.
+- Letter spacing on body copy.
+- Negative letter spacing on small text (under 16px).
+
+Pair typefaces deliberately: one font earns the display role (personality, brand
+signal), one earns the body role (readability, neutrality). They should
+contrast. A geometric display pairs with a humanist body; a serif display pairs
+with a sans body.
+
+## Fluid Type Scale
+
+Use `clamp()` for all responsive type. The pattern is `clamp(min, preferred,
+max)` where preferred is a viewport-relative value.
+
+Reference scale, adjusted to match the surface's type role:
+
+```css
+--text-xs:   clamp(0.75rem,  0.70rem + 0.25vw,  0.875rem);
+--text-sm:   clamp(0.875rem, 0.82rem + 0.28vw,  1rem);
+--text-base: clamp(1rem,     0.94rem + 0.30vw,  1.125rem);
+--text-lg:   clamp(1.125rem, 1.0rem  + 0.62vw,  1.375rem);
+--text-xl:   clamp(1.375rem, 1.1rem  + 1.40vw,  2rem);
+--text-2xl:  clamp(1.75rem,  1.3rem  + 2.20vw,  3rem);
+--text-3xl:  clamp(2.25rem,  1.6rem  + 3.25vw,  4.5rem);
+```
+
+Min is the floor at roughly a 375px viewport. Max is the ceiling at roughly
+1440px. The preferred `vw` value controls how aggressively type grows.
+
+Never use fixed `px` font sizes for display, heading, or subheading roles. Fixed
+sizes are acceptable only for UI chrome (badges, labels, captions) that must not
+resize with the viewport.
+
+Line height scales inversely with size: large display text (2xl and up) uses
+line height 1.05-1.1, body text 1.5-1.6, subheadings 1.2-1.35.
+
+## Layout
+
+- Make structure explain the product. Use bands, rails, timelines, consoles,
+  grids, tabs, and split panes because the content needs them.
+
+Spatial composition. Intentional layouts use asymmetry, overlap, diagonal flow,
+and the tension between density and negative space. All are legitimate tools:
+
+- Asymmetry: column grids that do not divide evenly, deliberate visual weight on
+  one side.
+- Overlap: elements that break their containing rows to create depth.
+- Diagonal flow: content that leads the eye along a non-horizontal axis.
+- Generous negative space OR controlled density, not an accidental middle
+  ground.
+
+Never use a card where a row would do. Use cards only for items that must be
+independently scannable, draggable, or selectable, not as a visual wrapper for
+sections, tabs, or form groups. One card inside another card means the
+information architecture is wrong. Fix the hierarchy, not the nesting.
+
+- Stable UI elements need stable dimensions. Boards, grids, icon buttons,
+  counters, tiles, canvases, and toolbars should not resize when labels, hover
+  states, loading text, or data change.
+- Build a semantic z-index scale: dropdown, sticky, modal-backdrop, modal,
+  toast, tooltip. Never arbitrary values like 999 or 9999.
+- On landing pages, the first viewport must show the brand, product, or offer
+  clearly and leave a hint of the next section visible on mobile and desktop.
+- Text must not overlap, clip, or fight its container at any viewport.
+
+## Controls
+
+- Use icon buttons for familiar commands when the icon exists in the local icon
+  set. Add tooltips for icons that are not obvious.
+- Use segmented controls for modes, toggles or checkboxes for binary settings,
+  sliders or inputs for numeric values, tabs for views, menus for option sets,
+  and text buttons for commands.
+- Keep touch targets usable and focus states visible.
+- A dropdown or popover rendered with `position: absolute` inside a parent with
+  `overflow: hidden` or `overflow: auto` gets clipped. Use the native
+  `<dialog>`/popover API, `position: fixed`, or a portal to escape the stacking
+  context.
+
+## Component Laws
+
+**Forms.** Every form field shows its label above the input, never as
+placeholder text. Placeholder is hint text only: it disappears on focus and must
+not carry required information. Error messages appear below the field they
+belong to, not as a toast. Required fields are marked; optional fields are not,
+since the default expectation is required. A submit button is always the primary
+action, and it is disabled only when the form is provably incomplete, never as
+the default initial state.
+
+BEFORE: `<input placeholder="Email address" />` with no visible label
+AFTER: `<label>Email address</label><input placeholder="e.g. you@company.com" />`
+
+**Modals.** A modal is for a destructive action, a focused sub-task that needs
+temporary full attention, or a preview that should not break navigation context.
+It is not the first answer to "the user needs more information." Use inline
+expansion, a side drawer, or a dedicated route when the content is browsable or
+the action is reversible. Every modal has one primary action and one escape
+(keyboard Escape plus backdrop click). Never stack modals.
+
+BEFORE: clicking "details" opens a modal with a scrollable list of 12 items
+AFTER: clicking "details" expands an inline panel or navigates to a detail route
+
+**Empty states.** An empty state is a conversion opportunity, not a placeholder.
+It must contain what would be here (one concrete example), why it is empty (the
+specific reason), and what to do next (a single, specific action). Never show
+just an illustration and "No results found." Name the specific thing that is
+missing.
+
+BEFORE: `[Icon] No items yet.` with a disabled button
+AFTER: `Add your first client to start tracking unpaid invoices. [Add a client]`
+
+**Data tables.** Column headers are left-aligned except numeric columns, which
+are right-aligned. Rows are 40-48px tall for data-dense tables, 56-64px when each
+row needs a secondary line. Alternating row fills are a last resort for wide
+tables with more than eight columns; prefer generous column padding and strong
+header contrast. Sort indicators are visible on hover for all sortable columns,
+not only the active one. Pagination controls live below the table, right-aligned,
+with the total count visible at all times.
+
+**Navigation.** Primary navigation shows the user's current location at all times
+with a visible active state that is not only color. Use weight, underline, or
+background shape so it survives grayscale. Depth beyond three levels means the
+information architecture needs restructuring, not another nav level. Mobile
+navigation collapses to a bottom tab bar (five items maximum) or a full-screen
+drawer. Never a hamburger that reveals a sidebar on a phone.
+
+## Assets
+
+- Use real product, media, logo, or generated bitmap imagery when the surface
+  needs a visual asset. Do not replace visible brand assets, product imagery, or
+  nonstandard icons with CSS shapes, emoji, placeholder divs, or improvised
+  inline drawings.
+- Use approved logo files from the current project or an operator-provided brand
+  folder. Never redraw, trace, approximate, typeset, recolor, or distort a brand
+  mark. If the approved file is unavailable, stop and request it, or omit the
+  mark rather than improvise one.
+- Do not reference private local asset paths in public docs, screenshots, or
+  generated output.
+- For 3D work, use Three.js and verify the canvas is non-blank, framed,
+  interactive or moving as intended, and responsive.
+
+## Motion
+
+Every animation must justify its CPU cost. If removing it makes the UI clearer,
+remove it. If keeping it makes an action legible (a row sliding out when deleted,
+a panel expanding from its trigger, a success state settling into place), keep
+it.
+
+Never animate width, height, top, left, or margin. Animate `transform` and
+`opacity` only.
+
+Exit curve: `ease-out-expo` (`cubic-bezier(0.16, 1, 0.3, 1)`), duration 220-280ms.
+The UI should feel like it arrives, not drifts.
+
+Entrance sequencing for lists, cards, and panels: `translate3d(0, 12px, 0)` to
+`translate3d(0, 0, 0)` plus opacity 0 to 1, 240ms ease-out-expo, stagger 40ms per
+item, six items staggered maximum then clamp. Cap the total reveal sequence at
+480ms. Panels enter at 300ms, hero content at 180ms.
+
+Scroll-triggered reveals fire once, not on every scroll direction change. Use
+`IntersectionObserver` with `threshold: 0.15`.
+
+In React, use Motion (formerly Framer Motion). Always include a
+`prefers-reduced-motion` variant that removes translation and cuts duration to
+0ms.

--- a/vendorable/frontend-design-review/references/scoped-bans.md
+++ b/vendorable/frontend-design-review/references/scoped-bans.md
@@ -1,0 +1,121 @@
+# Scoped Bans And Exceptions
+
+What is banned, where the ban applies, and the narrow cases allowed to break it.
+Check this before arguing an exception.
+
+These are not blanket bans. Keep or recreate a pattern when source fidelity,
+platform convention, accessibility, a confirmed brand system, or a direct user
+request makes it the right choice. When making an exception, name why it is
+earned.
+
+Rewrite the element if any of these appear as a lazy default.
+
+## Scaffolding And Typography Devices
+
+**Tiny uppercase tracked eyebrow above every section.**
+BEFORE: a small all-caps kicker ("ABOUT", "PROCESS", "PRICING") sitting above
+every section heading, page after page.
+AFTER: vary the cadence, or drop the kicker and let the heading carry weight. One
+deliberate kicker as a named brand device is voice; one on every section is AI
+grammar.
+
+**Numbered section markers as default scaffolding (01 / 02 / 03).**
+BEFORE: `01 About`, `02 Process`, `03 Pricing` stamped above every section
+regardless of content.
+AFTER: reserve numbering for a real ordered sequence (an actual three-step flow,
+a timeline) where the order carries information. Elsewhere, drop it.
+
+**Identical icon-card grids as the main page structure.**
+BEFORE: a 3x2 grid of cards, each with an icon, a title, and a one-line
+description.
+AFTER: a task-driven layout where each row or section maps to a specific user
+action, not a product category.
+
+**Em dashes in UI or marketing copy.**
+BEFORE: "Ship faster. Own every decision."
+AFTER: use a period, a colon, or a comma. If the clause needs an em dash,
+restructure the sentence.
+
+## Surface And Color Treatments
+
+**Gradient text.**
+BEFORE: `-webkit-background-clip: text` rainbow or metallic effect on headlines.
+AFTER: a single high-contrast headline at full weight with an accent word in a
+solid color, or a single-hue gradient at low chroma (essentially a slight
+lightness shift).
+
+**Decorative glass panels (blur plus translucent background).**
+BEFORE: a `backdrop-filter: blur(20px)` card floating over a gradient background.
+AFTER: an opaque surface at the correct elevation token, with a 1px border for
+definition.
+
+**Colored side-stripe borders on cards, alerts, or list items.**
+BEFORE: a card with a 4px left border in `--color-warning` indicating status.
+AFTER: an icon plus label in the semantic color inside the card, or a
+top-of-card banner strip that spans the full width and carries text.
+
+**The ghost-card pattern (thin border plus soft wide shadow, stacked).**
+BEFORE: `border: 1px solid` combined with `box-shadow: 0 16px+ blur` on the same
+card or button as decoration.
+AFTER: pick one. A defined border at the brand color, or a shadow no wider than
+8px blur at the correct elevation token. Never both as ornament.
+
+**Over-rounded corners.**
+BEFORE: `border-radius: 32px` or higher on cards, sections, or inputs.
+AFTER: cap cards and inputs at a 12-16px radius. Full-pill radius is fine for
+tags and buttons only.
+
+**Repeating-linear-gradient stripe backgrounds.**
+BEFORE: diagonal stripe patterns in a section or body background via
+`repeating-linear-gradient`.
+AFTER: a real art-direction choice: a solid surface, a noise texture, or a
+concrete product artifact.
+
+**Decorative orbs, bokeh blobs, generic gradient backgrounds.**
+BEFORE: three radial gradients at 30% opacity behind the hero.
+AFTER: a concrete art-direction choice: a noise texture, a geometric system, a
+real product screenshot, an illustrated scene, or a typographic lock-up that IS
+the background.
+
+**Cream, sand, or beige as the default body background.**
+BEFORE: a near-white warm-tinted background (OKLCH lightness 0.84-0.97, chroma
+below 0.06, hue 40-100) used as the safe default for a "warm" or "editorial"
+brief, under a name like `--paper`, `--cream`, `--sand`, `--linen`, or
+`--ivory`.
+AFTER: pick a saturated brand color as the body, a true off-white at chroma 0
+(or tinted toward the brand's own hue, not toward warmth by default), or a
+darker tinted neutral that reads as this brand's own. Carry warmth through
+accent color, typography, and imagery instead. Same chroma-tinting discipline as
+the Color Strategy Axis, applied to the one background choice teams default on
+without thinking.
+
+## Content Integrity And Structure
+
+**The hero-metric template (big number, tiny label, support stats, gradient
+accent).**
+BEFORE: `$2.4M` at 80px weight-900 with "Revenue generated" in 12px below it.
+AFTER: a metric placed inside a real workflow context. The payout total shown
+inside the ledger column it belongs to, not isolated as a hero number.
+
+**Modal as the first answer to every interaction.**
+BEFORE: every "view details" opens a modal.
+AFTER: inline expansion, a side panel, or a dedicated route. Modals reserved for
+destructive confirmation or focused isolated actions.
+
+**Centered hero copy over a stock-feeling gradient with no real product
+artifact.**
+BEFORE: a three-word promise centered on a dark gradient, with no visual content
+below.
+AFTER: a hero containing a real product artifact (a partial registry UI, a live
+data panel, a receipt, an actual screen) with copy anchored to it.
+
+**Fake metrics, fake testimonials, fake partner claims.**
+No exception. Remove and replace with one of: a real statistic with a source
+note, a placeholder carrying a `[NEEDS REAL DATA]` flag, or a structural element
+that does not depend on a specific number.
+
+**Hand-drawn or sketchy SVG illustrations.**
+BEFORE: crude wavy-line doodles, `feTurbulence`/`feDisplacementMap` paper-grain
+filters, or a 5-30 path sketch standing in for a real subject.
+AFTER: ship a real asset (a photo, a product screenshot, a properly illustrated
+scene) or ship no illustration at all.


### PR DESCRIPTION
Composio's validator now allows README-only PRs whose bullets link to an external repo, which is why #1803 there fails with `disallowed file changed: frontend-design-review/SKILL.md`. This hosts the same neutralized copy of suede-design under `vendorable/` (plain ASCII verified, references included, CARD.md omitted) so the Composio bullet can link here. Ledger row added to `vendorable/README.md`. Validator green.