### PR TITLE
Clarify Graph Flo XR picker wording

### DIFF
--- a/skills/suede-graph-flo-xr/agents/openai.yaml
+++ b/skills/suede-graph-flo-xr/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Suede Graph Flo XR"
-  short_description: "Evidence-gated plan contract for one repo change"
+  short_description: "Evidence-gated plan contract for repo changes"
   default_prompt: "Use $suede-graph-flo-xr as the orchestration contract for [multi-file scope] in [repo]. In Codex, implement directly with the available agent tools, preserve the skill's safety and evidence gates, do not claim its bundled Claude Workflow ran, and never deploy or publish."
 policy:
   allow_implicit_invocation: true


### PR DESCRIPTION
The Graph Flo XR picker description now says "repo changes" instead of "one repo change" to remove the implication of a one-change limit. The workflow design, scope rules, and execution behavior are unchanged.

Validation: `npm run validate` and `git diff --check` passed.
