### PR TITLE
seo: title the skills homepage on the phrases it is searched for

### DIFF
--- a/COPY.md
+++ b/COPY.md
@@ -55,7 +55,7 @@ It is free under MIT for the original work, with no binaries and no telemetry.
 
 ### Page title
 
-Suede Creator Skills | 74 Open-Source Agent Skills
+Suede Creator Skills: Agent Skills for Claude Code and Codex
 
 ### Meta description
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Suede Creator Skills | 76 Open-Source Agent Skills</title>
+  <title>Suede Creator Skills: Agent Skills for Claude Code and Codex</title>
   <meta name="description" content="Install 76 free open-source Claude Code and Codex skills for outcome-bound orchestration, code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, MCP, and creator workflows.">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Suede Creator Skills | 76 Open-Source Agent Skills">
+  <meta property="og:title" content="Suede Creator Skills: Agent Skills for Claude Code and Codex">
   <meta property="og:description" content="Install 76 free open-source Claude Code and Codex skills for outcome-bound orchestration, code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, MCP, and creator workflows.">
   <meta property="og:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta property="og:image:width" content="1200">
@@ -19,7 +19,7 @@
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Suede Creator Skills | 76 Open-Source Agent Skills">
+  <meta name="twitter:title" content="Suede Creator Skills: Agent Skills for Claude Code and Codex">
   <meta name="twitter:description" content="Install 76 free open-source Claude Code and Codex skills for outcome-bound orchestration, code review, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, MCP, and creator workflows.">
   <meta name="twitter:image" content="https://skills.suedeai.ai/assets/og-image-v2.png">
   <meta name="twitter:image:alt" content="Suede Creator Skills: open-source agent skills for Claude Code and OpenAI Codex">

--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -1037,12 +1037,10 @@ const countChecks = [
   // shipped stale (29, 39, 67, 69, 70, and 71 all reached production that way).
   // The prose now describes the pack instead of counting it. What remains here
   // is the short list of surfaces where the number is the point: the homepage
-  // title a searcher reads, its structured-data twin, the hero stat, the README
-  // badge, and the two graphics that render the figure as art. Those stay
-  // guarded. Everywhere else, do not add a count back — describe the pack.
-  { file: "docs/index.html", label: "title tag", re: /<title>Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
-  { file: "docs/index.html", label: "og:title", re: /property="og:title" content="Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
-  { file: "docs/index.html", label: "twitter:title", re: /name="twitter:title" content="Suede Creator Skills \| (\d+) Open-Source Agent Skills/, expected: totalSkillCount },
+  // description a searcher reads, the structured-data item total, the hero
+  // stat, the README badge, and the two graphics that render the figure as art.
+  // Those stay guarded. Everywhere else, do not add a count back — describe the
+  // pack. The homepage title prints no number; it is pinned below the array.
   // The homepage description, repeated verbatim across the meta, og, and
   // twitter tags. `every` because the ad-hoc check this replaced read only
   // the first of the three, leaving the two social copies free to drift.
@@ -1062,6 +1060,30 @@ const countChecks = [
   { file: "docs/assets/readme/hero.svg", label: "hero graphic skill count", re: /letter-spacing="-12">(\d+)<\/text>/, expected: totalSkillCount },
   { file: "docs/assets/og-image-v2.svg", label: "social card headline number", re: /letter-spacing="-18">(\d+)<\/text>/, expected: totalSkillCount },
 ];
+
+// The homepage title, and its og and twitter twins. The pack size used to ride
+// in this title, which is why the three tags were count checks; the title now
+// leads with the phrases the page is searched for, so no number is printed
+// there and the three tags are pinned as one exact string instead. They must
+// stay byte-identical to each other, which is how the two social copies drifted
+// from the <title> before.
+const HOMEPAGE_TITLE = "Suede Creator Skills: Agent Skills for Claude Code and Codex";
+const homepageTitlePath = path.join(repoRoot, "docs", "index.html");
+if (!fs.existsSync(homepageTitlePath)) {
+  fail.push("docs/index.html is missing — the homepage title guard cannot run");
+} else {
+  const homepageTitleText = readText(homepageTitlePath);
+  const homepageTitleTags = [
+    ["title tag", `<title>${HOMEPAGE_TITLE}</title>`],
+    ["og:title", `property="og:title" content="${HOMEPAGE_TITLE}"`],
+    ["twitter:title", `name="twitter:title" content="${HOMEPAGE_TITLE}"`]
+  ];
+  for (const [label, needle] of homepageTitleTags) {
+    if (!homepageTitleText.includes(needle)) {
+      fail.push(`docs/index.html ${label} must read exactly "${HOMEPAGE_TITLE}"`);
+    }
+  }
+}
 
 // book/ is prose, so its counts are written inline rather than in a fixed
 // template. Enumerate the files at validation time and guard every numeric

--- a/tests/test_neutral_oss_positioning.py
+++ b/tests/test_neutral_oss_positioning.py
@@ -105,11 +105,16 @@ class NeutralOssPositioningTests(unittest.TestCase):
         # The pack size is no longer restated in prose. It survives only on the
         # surfaces where the number is the point, and those are what this test
         # pins: the README badge (URL value and alt text, because the rendered
-        # number lives in the URL) and the homepage title a searcher reads.
+        # number lives in the URL). The homepage title stopped printing the
+        # count when it was rewritten around the phrases the page is searched
+        # for, so it is pinned here as an exact string, not as a number.
         readme = read("README.md")
         self.assertIn(f"skills-{count}-c8a96e", readme)
         self.assertIn(f"![Skills: {count}]", readme)
-        self.assertIn(f"| {count} Open-Source Agent Skills", read("docs/index.html"))
+        self.assertIn(
+            "<title>Suede Creator Skills: Agent Skills for Claude Code and Codex</title>",
+            read("docs/index.html"),
+        )
         stale_counts = [f"{n} skills" for n in range(20, 40) if n != count]
         stale_counts += [f"{n}-skill" for n in range(20, 40) if n != count]
         # A focused subset plugin advertises how many skills *it* bundles, which


### PR DESCRIPTION
Keywords Everywhere (US, 2026-09-08): 'claude skills' 40,500/mo (competition 0.05), 'claude code skills' 12,100 (0.09, KD 30), 'agent skills' 8,100 (0.04), 'claude code plugins' 5,400 (0.03), 'codex skills' 4,400 (0.08). The homepage answers all five, its title named only 'agent skills', and Google had the pack count cached two releases stale. DataForSEO finds no ranking for the host on any of them.

New title, byte-identical in <title>, og:title and twitter:title (60 characters):

    Suede Creator Skills: Agent Skills for Claude Code and Codex

The count leaves the title, so the three count checks in scripts/validate-skill-pack.mjs that pinned the old shape become one exact-string guard that also keeps the two social copies equal to <title>; tests/test_neutral_oss_positioning.py asserts the literal; COPY.md's page-title record catches up from a stale 74. Descriptions, hero stat, JSON-LD numberOfItems, README badge and artwork counts are unchanged.

Selected and built by a Suede Graph Flo XR run (wf_6b867468-971, standard budget, 45 of 110 calls). Its sandboxed gate could not load js-yaml in the bare ship worktree, so the suite was run by hand with node_modules linked: npm run validate green (76 skills, routing 18 groups / 74 cases), test:python 48 OK, git diff --check clean. PROMO.md still carries an older homepage-title record outside this change's scope; left for a copy-bank sync.