### PR TITLE
Repair truncated skills JSON-LD and assert the founder

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -42,9 +42,12 @@
   "@graph": [
     {
       "@type": "Organization",
-      "@id": "https://suedeai.ai/#org",
+      "@id": "https://suedeai.ai/#organization",
       "name": "Suede Labs AI",
       "url": "https://suedeai.ai",
+      "founder": {
+        "@id": "https://suedeai.ai/founder#person"
+      },
       "logo": "https://skills.suedeai.ai/assets/suede-ai-logo-transparent.png",
       "sameAs": [
         "https://twitter.com/johnnysuede",
@@ -58,7 +61,7 @@
       "name": "Suede Creator Skills",
       "description": "Public, open-source pack of installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server: multi-agent orchestration, code review with A-F ship grades, CI ship-gates, AI evals, Instagram growth, design, copy, SEO, and a creator toolkit.",
       "publisher": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       },
       "inLanguage": "en-US"
     },
@@ -144,7 +147,7 @@
         ]
       },
       "publisher": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       },
       "keywords": [
         "Suedify",
@@ -193,7 +196,7 @@
         "@id": "https://suedeai.ai/founder#person"
       },
       "publisher": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       },
       "keywords": [
         "creator rights",
@@ -218,7 +221,7 @@
         "@id": "https://suedeai.ai/founder#person"
       },
       "publisher": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       },
       "keywords": [
         "music metadata",

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,15 +47,18 @@
       "url": "https://skills.suedeai.ai/",
       "description": "Public, open-source pack of installable Agent Skills for Claude Code and OpenAI Codex, plus an optional MCP server for discovery, audits, and QA. The pack carries preferences, linked context, quality gates, and reusable workflow rules across agents and computers.",
       "publisher": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       }
     },
     {
       "@type": "Organization",
-      "@id": "https://suedeai.ai/#org",
+      "@id": "https://suedeai.ai/#organization",
       "name": "Suede Labs AI",
       "alternateName": "Suede AI",
       "url": "https://suedeai.ai",
+      "founder": {
+        "@id": "https://suedeai.ai/founder#person"
+      },
       "sameAs": [
         "https://github.com/JasonColapietro",
         "https://twitter.com/johnnysuede"
@@ -89,7 +92,7 @@
         "Model Context Protocol"
       ],
       "author": {
-        "@id": "https://suedeai.ai/#org"
+        "@id": "https://suedeai.ai/#organization"
       },
       "creator": {
         "@id": "https://suedeai.ai/founder#person"
@@ -578,6 +581,8 @@
           "name": "Suede Play Release",
           "url": "https://skills.suedeai.ai/skills/suede-play-release.html"
         }
+      ]
+    }
   ]
 }
 </script>


### PR DESCRIPTION
## What was broken

`docs/index.html` shipped a single `application/ld+json` block whose brackets never closed. The 76-item ItemList ended at the last entry, then the file closed two levels and stopped — the `itemListElement` array, the `ItemList` node, the `@graph` array and the root object were all left open. `json.loads` fails at char 18033.

Because it was the only JSON-LD block on the page, every consumer that parses structured data discarded the entire graph: `WebSite`, `Organization`, `Person`, `SoftwareSourceCode` and the `sameAs` array with it. skills.suedeai.ai had no machine-readable entity of any kind.

## Also fixed

Both entity-bearing pages (`index.html`, `guide.html`) minted `https://suedeai.ai/#org` for the Organization node. suedeai.ai itself publishes that company as `https://suedeai.ai/#organization` — two `@id`s for one company on one domain, which is the entity split the shared canon exists to prevent. Repointed to the canonical node, and added the `founder` edge to the `Person` node both pages already carried (`https://suedeai.ai/founder#person`).

## Verification

- All 109 `ld+json` blocks under `docs/` parse; 0 invalid.
- The repaired graph yields `['WebSite','Organization','Person','SoftwareSourceCode','ItemList']` with 76 items, matching `numberOfItems`.
- `npm run validate` passes (76 skills, trigger routing, book site, book, skill cards).