### PR TITLE
Blog: date the Android essay to the day its cross-links were added

### DIFF
--- a/docs/blog/android-recommend-next-action-and-workflows.html
+++ b/docs/blog/android-recommend-next-action-and-workflows.html
@@ -27,7 +27,7 @@
         "description": "Suede Creator Skills adds suede-recommend-next-action and android-app-factory, which brought the pack to 27 public skills at the time, and routes both through the existing end-to-end workflow umbrella.",
         "url": "https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html",
         "datePublished": "2026-07-19",
-        "dateModified": "2026-07-19",
+        "dateModified": "2026-08-07",
         "author": {"@type": "Person", "@id": "https://suedeai.ai/founder#person", "name": "Jason Colapietro"},
         "publisher": {"@type": "Organization", "name": "Suede Labs AI", "url": "https://suedeai.ai"},
         "about": ["Suede Creator Skills", "Claude Code skills", "Codex skills", "Android app development", "next action recommendation", "agent workflow"],

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -500,7 +500,7 @@
   </url>
   <url>
     <loc>https://skills.suedeai.ai/blog/android-recommend-next-action-and-workflows.html</loc>
-    <lastmod>2026-07-19</lastmod>
+    <lastmod>2026-08-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
record-audit.py: the essay declared 2026-07-19 while five lines of its own
text changed on 2026-08-07, when the three new essays were cross-linked
from it. The date moves; the sitemap follows the page.
