### PR TITLE
Stop naming one machine's home directory in tracked files

### DIFF
--- a/book/STYLE.md
+++ b/book/STYLE.md
@@ -3,7 +3,7 @@
 You are writing one or two chapters of a book called **S-Tier: The Builder's Book
 Behind the Suede Skills**. It is a real book about how agent skills work and how a
 person becomes an exceptional builder using them. Repo root:
-`/Users/jasoncolapietro/code/suede-creator-skills`.
+`~/code/suede-creator-skills`.
 
 ## Audience
 


### PR DESCRIPTION
Tracked files carried absolute paths under a personal home directory. In a public repo that publishes the operator's username and folder layout, and the paths are unusable by anyone else. `suede-creator-skills/scripts/validate-skill-pack.mjs` already treats `/Users/jason*/` as private — this is that rule applied here.

One hit in `book/STYLE.md`. This repo owns the deny-list that flags this pattern; it should not be failing its own rule.

Files touched:
- book/STYLE.md