### PR TITLE
Deny the bare personal Gmail, not only its Drive-path form

### DIFF
--- a/scripts/validate-skill-pack.mjs
+++ b/scripts/validate-skill-pack.mjs
@@ -823,6 +823,7 @@ const publicFiles = repoFiles.filter((file) => {
 const privatePathPatterns = [
   /\/Users\/(jason|jasoncolapietro)\//,
   /GoogleDrive-jasoncola1@gmail\.com/,
+  /jasoncola1@gmail\.com/,
   /johnnysuedes@gmail\.com/,
   /team_[A-Za-z0-9]{8,}/
 ];


### PR DESCRIPTION
`privatePathPatterns` carried `GoogleDrive-jasoncola1@gmail.com`, which only matches the address inside a Google Drive path. The address on its own passed — which is how `jasoncola1@gmail.com` reached `suede-sdk-python`'s `pyproject.toml` and, from there, the live PyPI listing. One pattern added; nothing removed.

Mutation-tested both directions: the validator reports `Private path/account leak pattern` and exits 1 with the address in a covered file, and exits 0 with it gone.

Sweep of the covered directories (`skills/`, `mcp/`, `docs/`, `scripts/`, `tests/`, `.github/`) for every deny-list string returns nothing — they were already clean, so this PR is the pattern alone.